### PR TITLE
docs: updating use cases for ngMocks.get

### DIFF
--- a/docs/articles/api/ngMocks/get.md
+++ b/docs/articles/api/ngMocks/get.md
@@ -3,19 +3,39 @@ title: ngMocks.get
 description: Documentation about ngMocks.get from ng-mocks library
 ---
 
-Returns a declaration, service or token, which can be attribute or structural directives,
+Returns a component, directive, service or token, which can be attribute or structural directives,
 which belongs to the current element.
 
-- `ngMocks.get( debugElement, directive, notFoundValue? )`
+- `ngMocks.get( debugElement, Component, notFoundValue? )`
 
 ```ts
-const directive = ngMocks.get(fixture.debugElement, Directive);
+const component = ngMocks.get(fixture.debugElement, MyComponentType);
 ```
+
+- `ngMocks.get( debugElement, Directive, notFoundValue? )`
+
+```ts
+const directive = ngMocks.get(fixture.debugElement, MyDirectiveType);
+```
+
+- `ngMocks.get( Service )`
+
+```ts
+const service = ngMocks.get(MyServiceType);
+```
+
 
 or simply with selectors which are supported by [`ngMocks.find`](./find.md).
 
+- `ngMocks.get( cssSelector, Directive, notFoundValue? )`
 ```ts
-const directive = ngMocks.get('app-component', Directive);
+const directive = ngMocks.get('app-component', MyDirectiveType);
+```
+
+- `ngMocks.get( cssSelector, Component, notFoundValue? )`
+
+```ts
+const component = ngMocks.get('app-component', AppComponentType);
 ```
 
 ## Root providers


### PR DESCRIPTION
Currently `ngMocks.get` description could be understood to only concerns structural directives or services but it can also be used for components or common directives `declarations` word is too vague and can be more precise.

Consequently we may be tempted to use `ngMocks.findInstance` which mention components, directives and so on in the documentation. But in some cases we could have false positive tests (using `ngMocks.findInstance` rather than `ngMocks.get`), so documentation update is needed for `ngMocks.get`.

@satanTime let me know if the doc update looks great or if something else could be made event better.