### PR TITLE
docs(ngxs): fixing typo in the library name #6356

### DIFF
--- a/docs/articles/guides/libraries/ngxs.md
+++ b/docs/articles/guides/libraries/ngxs.md
@@ -1,9 +1,9 @@
 ---
-title: How to test NGRS in Angular applications
-sidebar_label: NGRS
+title: How to test NGXS in Angular applications
+sidebar_label: NGXS
 ---
 
-If you need to avoid mocking of `NGRS` in your modules, you need to use [`.keep`](/api/MockBuilder.md#keep).
+If you need to avoid mocking of `NGXS` in your modules, you need to use [`.keep`](/api/MockBuilder.md#keep).
 
 ```ts
 beforeEach(() =>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -184,7 +184,7 @@ module.exports = {
         'guides/libraries/angular-material',
         'guides/libraries/primeng',
         'guides/libraries/ngrx',
-        'guides/libraries/ngrs',
+        'guides/libraries/ngxs',
       ],
     },
   ],


### PR DESCRIPTION
closes #6356