### PR TITLE
fix: unable to find instance in case of ng17 control flow

### DIFF
--- a/libs/ng-mocks/src/lib/mock-helper/crawl/el-def-get-parent.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/crawl/el-def-get-parent.ts
@@ -24,6 +24,10 @@ const getScanViewRefRootNodes = (node: any, child: any): Array<[number, any]> =>
   const result: Array<[number, any]> = [];
   for (let vrIndex = 0; vrIndex < vcr.length; vrIndex += 1) {
     const vr = vcr.get(vrIndex);
+    if (!vr) {
+      continue;
+    }
+
     for (let rnIndex = 0; rnIndex < (vr as any).rootNodes.length; rnIndex += 1) {
       result.push([rnIndex, (vr as any).rootNodes[rnIndex]]);
     }

--- a/tests/issue-7216/test.spec.ts
+++ b/tests/issue-7216/test.spec.ts
@@ -1,0 +1,47 @@
+import { CommonModule } from '@angular/common';
+import { Component, NgModule, VERSION } from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/7216
+describe('issue-7216', () => {
+  if (Number.parseInt(VERSION.major, 10) < 17) {
+    it('needs a17+', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  @Component({
+    selector: 'target',
+    template: `
+      @if (hasChild) {
+        <child></child>
+      }
+    `,
+  })
+  class TargetComponent {
+    public readonly hasChild = true;
+  }
+
+  @Component({
+    selector: 'child',
+    template: '',
+  })
+  class ChildComponent {}
+
+  @NgModule({
+    imports: [CommonModule],
+    declarations: [TargetComponent, ChildComponent],
+  })
+  class TargetModule {}
+
+  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+  it('finds child-element', () => {
+    MockRender(TargetComponent);
+
+    expect(ngMocks.findInstance(ChildComponent)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
ViewContainerRef actually returns the wrong length in case of Angular 17 Control Flow. By checking that the returned value is not null we should be safe.

Solves #7216