### PR TITLE
fix: unable to bind ngIf in angular 17+

### DIFF
--- a/e2e/a12/jest.es2015ivy.js
+++ b/e2e/a12/jest.es2015ivy.js
@@ -1,6 +1,5 @@
 module.exports = {
   preset: 'jest-preset-angular',
-  workerIdleMemoryLimit: '1024MB',
   maxWorkers: 1,
   setupFilesAfterEnv: ['<rootDir>/src/setup-jest.ts'],
   testURL: 'http://localhost',

--- a/e2e/a12/jest.es5ivy.js
+++ b/e2e/a12/jest.es5ivy.js
@@ -1,6 +1,5 @@
 module.exports = {
   preset: 'jest-preset-angular',
-  workerIdleMemoryLimit: '1024MB',
   maxWorkers: 1,
   setupFilesAfterEnv: ['<rootDir>/src/setup-jest.ts'],
   testURL: 'http://localhost',

--- a/e2e/a12/package.json
+++ b/e2e/a12/package.json
@@ -17,7 +17,7 @@
     "test:jest": "npm run test:jest:es5:ivy && npm run test:jest:es2015:ivy",
     "test:jest:es5:ivy": "jest --config jest.es5ivy.js",
     "test:jest:es2015:ivy": "jest --config jest.es2015ivy.js",
-    "test:jest:debug": "jest -i --watch"
+    "test:jest:debug": "npm run test:jest:es2015:ivy -- -i --watch"
   },
   "dependencies": {
     "@angular/animations": "12.2.17",

--- a/e2e/a12/src/setup-jest.ts
+++ b/e2e/a12/src/setup-jest.ts
@@ -1,4 +1,4 @@
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 import { ngMocks } from 'ng-mocks';
 
 ngMocks.autoSpy('jest');

--- a/libs/ng-mocks/src/lib/mock-component/mock-component.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-component/mock-component.spec.ts
@@ -475,11 +475,30 @@ describe('MockComponent', () => {
         }),
       ],
 
+      __vcrIf_key_i1: [
+        jasmine.objectContaining({
+          selector: 'ngIf_key_i1',
+          isViewQuery: true,
+          static: false,
+          read: ViewContainerRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
+      __trIf_key_i1: [
+        jasmine.objectContaining({
+          selector: 'ngIf_key_i1',
+          isViewQuery: true,
+          static: false,
+          read: TemplateRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
       __mockView_key_i1: [
         jasmine.objectContaining({
           selector: 'key_i1',
           isViewQuery: true,
           static: false,
+          read: ViewContainerRef,
           ngMetadataName: 'ViewChild',
         }),
       ],
@@ -490,20 +509,58 @@ describe('MockComponent', () => {
           ngMetadataName: 'ContentChild',
         }),
       ],
+      __vcrIf_prop_o1: [
+        jasmine.objectContaining({
+          selector: 'ngIf_prop_o1',
+          isViewQuery: true,
+          static: false,
+          read: ViewContainerRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
+      __trIf_prop_o1: [
+        jasmine.objectContaining({
+          selector: 'ngIf_prop_o1',
+          isViewQuery: true,
+          static: false,
+          read: TemplateRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
       __mockView_prop_o1: [
         jasmine.objectContaining({
           selector: 'prop_o1',
           isViewQuery: true,
           static: false,
+          read: ViewContainerRef,
           ngMetadataName: 'ViewChild',
         }),
       ],
 
+      __vcrIf_key_i2: [
+        jasmine.objectContaining({
+          selector: 'ngIf_key_i2',
+          isViewQuery: true,
+          static: false,
+          read: ViewContainerRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
+      __trIf_key_i2: [
+        jasmine.objectContaining({
+          selector: 'ngIf_key_i2',
+          isViewQuery: true,
+          static: false,
+          read: TemplateRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
       __mockView_key_i2: [
         jasmine.objectContaining({
           selector: 'key_i2',
           isViewQuery: true,
           static: false,
+          read: ViewContainerRef,
           ngMetadataName: 'ViewChild',
         }),
       ],
@@ -514,11 +571,30 @@ describe('MockComponent', () => {
           ngMetadataName: 'ContentChildren',
         }),
       ],
+      __vcrIf_prop_o2: [
+        jasmine.objectContaining({
+          selector: 'ngIf_prop_o2',
+          isViewQuery: true,
+          static: false,
+          read: ViewContainerRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
+      __trIf_prop_o2: [
+        jasmine.objectContaining({
+          selector: 'ngIf_prop_o2',
+          isViewQuery: true,
+          static: false,
+          read: TemplateRef,
+          ngMetadataName: 'ViewChild',
+        }),
+      ],
       __mockView_prop_o2: [
         jasmine.objectContaining({
           selector: 'prop_o2',
           isViewQuery: true,
           static: false,
+          read: ViewContainerRef,
           ngMetadataName: 'ViewChild',
         }),
       ],

--- a/libs/ng-mocks/src/lib/mock-component/render/generate-template.ts
+++ b/libs/ng-mocks/src/lib/mock-component/render/generate-template.ts
@@ -8,7 +8,7 @@ const viewChildTemplate = (selector: string, key: string): string => {
   const condition = `ngMocksRender_${key}_${selector}`;
   return hasControlFlow
     ? `@if (${condition}) { ${content} }`
-    : `<ng-template [ngIf]="${condition}">${content}</ng-template>`;
+    : /* istanbul ignore next */ `<ng-template [ngIf]="${condition}">${content}</ng-template>`;
 };
 
 const isTemplateRefQuery = (query: Query): boolean => {

--- a/libs/ng-mocks/src/lib/mock-component/render/generate-template.ts
+++ b/libs/ng-mocks/src/lib/mock-component/render/generate-template.ts
@@ -1,9 +1,15 @@
-import { Query, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
+import { Query, TemplateRef, ViewChild, ViewContainerRef, VERSION } from '@angular/core';
 
+const hasControlFlow = Number.parseInt(VERSION.major, 10) >= 17;
 const viewChildArgs: any = { read: ViewContainerRef, static: false };
 
-const viewChildTemplate = (selector: string, key: string): string =>
-  `<div *ngIf="ngMocksRender_${key}_${selector}" data-${key}="${selector}"><ng-template #${key}_${selector}></ng-template></div>`;
+const viewChildTemplate = (selector: string, key: string): string => {
+  const content = `<div data-${key}="${selector}"><ng-template #${key}_${selector}></ng-template></div>`;
+  const condition = `ngMocksRender_${key}_${selector}`;
+  return hasControlFlow
+    ? `@if (${condition}) { ${content} }`
+    : `<ng-template [ngIf]="${condition}">${content}</ng-template>`;
+};
 
 const isTemplateRefQuery = (query: Query): boolean => {
   if (query.isViewQuery) {

--- a/tests/issue-8884/test.spec.ts
+++ b/tests/issue-8884/test.spec.ts
@@ -1,0 +1,66 @@
+import {
+  Component,
+  ContentChild,
+  NgModule,
+  TemplateRef,
+  VERSION,
+} from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/8884
+describe('issue-8884', () => {
+  ngMocks.throwOnConsole();
+
+  if (Number.parseInt(VERSION.major, 10) < 17) {
+    it('needs a17+', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  describe('when standalone component does not import NgIf', () => {
+    @Component({
+      selector: 'app-standalone',
+      standalone: true,
+      template: `<ng-template [ngTemplateOutlet]="content" />`,
+    })
+    class StandaloneComponent {
+      @ContentChild('content')
+      content?: TemplateRef<any>;
+    }
+
+    beforeEach(() => MockBuilder(null, StandaloneComponent));
+
+    it('should create', () => {
+      MockRender(`<app-standalone>Test content</app-standalone>`);
+
+      expect(ngMocks.findInstance(StandaloneComponent)).toBeTruthy();
+    });
+  });
+
+  describe('when NgIf is not avaiable to a component in a module', () => {
+    @Component({
+      selector: 'app-target',
+      template: `<ng-template [ngTemplateOutlet]="content" />`,
+    })
+    class TargetComponent {
+      @ContentChild('content')
+      content?: TemplateRef<any>;
+    }
+
+    @NgModule({
+      declarations: [TargetComponent],
+    })
+    class TargetModule {}
+
+    beforeEach(() => MockBuilder(null, TargetModule));
+
+    it('should create', () => {
+      MockRender(`<app-target>Test content</app-target>`);
+
+      expect(ngMocks.findInstance(TargetComponent)).toBeTruthy();
+    });
+  });
+});

--- a/tests/issue-8884/test.spec.ts
+++ b/tests/issue-8884/test.spec.ts
@@ -23,11 +23,11 @@ describe('issue-8884', () => {
   describe('when standalone component does not import NgIf', () => {
     @Component({
       selector: 'app-standalone',
-      standalone: true,
+      ['standalone' as never]: true,
       template: `<ng-template [ngTemplateOutlet]="content" />`,
     })
     class StandaloneComponent {
-      @ContentChild('content')
+      @ContentChild('content', {} as never)
       content?: TemplateRef<any>;
     }
 
@@ -46,7 +46,7 @@ describe('issue-8884', () => {
       template: `<ng-template [ngTemplateOutlet]="content" />`,
     })
     class TargetComponent {
-      @ContentChild('content')
+      @ContentChild('content', {} as never)
       content?: TemplateRef<any>;
     }
 


### PR DESCRIPTION
When component templates contain child templates, they are replaced with a mock template that contains a `*ngIf` this causes a failure when the component doesn't have NgIf imported.

Though this problem likely exists in some pre-angular 17 situations, it has been causing new failures to appear as people upgrade since 3rd party angular components are starting to use the new control flow syntax and no longer import `CommonModule` / `NgIf`.

Instead the mock template now uses `@if` syntax if angular is 17 or higher.

Fixes #8884