### PR TITLE
feat: standalone pipes and legacy external modules support in angular 19

### DIFF
--- a/libs/ng-mocks/src/lib/common/core.reflect.directive-resolve.ts
+++ b/libs/ng-mocks/src/lib/common/core.reflect.directive-resolve.ts
@@ -1,4 +1,4 @@
-import { Component, Directive, NgModule } from '@angular/core';
+import { Component, Directive, NgModule, Pipe } from '@angular/core';
 
 import collectDeclarations from '../resolve/collect-declarations';
 
@@ -8,6 +8,7 @@ export default (
   def: any,
 ): Directive &
   Partial<Component> &
+  Pipe &
   NgModule & {
     hostBindings?: Array<[string, any]>;
     hostListeners?: Array<[string, any, any]>;
@@ -21,6 +22,9 @@ export default (
     }
     if (declaration.Directive) {
       return declaration.Directive;
+    }
+    if (declaration.Pipe) {
+      return declaration.Pipe;
     }
 
     throw new Error('Cannot resolve declarations');

--- a/libs/ng-mocks/src/lib/common/decorate.mock.ts
+++ b/libs/ng-mocks/src/lib/common/decorate.mock.ts
@@ -18,4 +18,9 @@ export default (mock: AnyType<any>, source: AnyType<any>, configInput: ngMocksMo
       }
     : configInput;
   coreDefineProperty(mock.prototype, '__ngMocksConfig', config);
+  if ((mock as any)?.ɵmod?.declarations) {
+    (mock as any).ɵmod.declarations
+      .filter((x: any) => x?.decorators?.[0]?.args?.[0] && x?.decorators?.[0]?.args?.[0].standalone === undefined)
+      .map((x: any) => (x.decorators[0].args[0].standalone = false));
+  }
 };

--- a/libs/ng-mocks/src/lib/common/func.is-standalone.ts
+++ b/libs/ng-mocks/src/lib/common/func.is-standalone.ts
@@ -1,6 +1,3 @@
-import ngMocksUniverse from '../common/ng-mocks-universe';
-import collectDeclarations from '../resolve/collect-declarations';
-
 import { getNgType } from './func.get-ng-type';
 
 /**
@@ -11,6 +8,10 @@ export function isStandalone(declaration: any): boolean {
   if (!type || type === 'Injectable' || type === 'NgModule') {
     return false;
   }
-
-  return collectDeclarations(declaration)[type].standalone ?? ngMocksUniverse.global.get('flags').defaultStandalone;
+  // here we don't use the angular/core isStandalone for backward compatibility
+  // once backward compatibility allows that, following lines can be replaced:
+  // import { isStandalone as isStandaloneAngular } from '@angular/core';
+  // return isStandalone(declaration);
+  const def = declaration.ɵcmp || declaration.ɵdir || declaration.ɵpipe;
+  return def?.standalone;
 }

--- a/libs/ng-mocks/src/lib/mock-pipe/mock-pipe.ts
+++ b/libs/ng-mocks/src/lib/mock-pipe/mock-pipe.ts
@@ -9,6 +9,7 @@ import funcImportExists from '../common/func.import-exists';
 import { isMockNgDef } from '../common/func.is-mock-ng-def';
 import { Mock } from '../common/mock';
 import ngMocksUniverse from '../common/ng-mocks-universe';
+import decorateDeclaration from '../mock/decorate-declaration';
 import returnCachedMock from '../mock/return-cached-mock';
 import helperMockService from '../mock-service/helper.mock-service';
 
@@ -36,7 +37,9 @@ const getMockClass = (pipe: Type<any>, transformValue?: PipeTransform['transform
   const config = ngMocksUniverse.config.get(pipe);
   const transform = transformValue ?? config?.defValue?.transform;
   const mock = extendClass(Mock);
-  Pipe(coreReflectPipeResolve(pipe))(mock);
+  const meta = coreReflectPipeResolve(pipe);
+
+  Pipe(decorateDeclaration(pipe, mock, meta, {}) as Pipe)(mock);
   decorateMock(mock, pipe, {
     init: (instance: PipeTransform) => {
       if (transform) {

--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
@@ -30,7 +30,7 @@ const registerTemplateMiddleware = (template: AnyType<any>, meta: Directive): vo
     // nothing to do
   }
 
-  const standalone = (meta as any).__ngMocksStandalone === true;
+  const standalone = (meta as any).standalone === true;
   (isNgDef(template, 'c') ? Component : Directive)({
     ...meta,
     ...set,

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
@@ -459,6 +459,7 @@ const parse = (def: any): any => {
   parsePropMetadata(def, declaration);
   buildDeclaration(declaration.Directive, declaration);
   buildDeclaration(declaration.Component, declaration);
+  buildDeclaration(declaration.Pipe, declaration);
 
   coreDefineProperty(def, '__ngMocksDeclarations', {
     ...parentDeclarations,


### PR DESCRIPTION
this PR solves two things:

1. angular standalone components in external legacy modules ( https://github.com/help-me-mom/ng-mocks/issues/10752 )
2. standalone pipes 

I've tested the following code in my project without issues but I'm not confident on how to run and fix tests with karma and e2e

I hope this PR somehow contributes towards the definitive solution for supporting Angular 19🙏