### PR TITLE
docs: fixing spelling in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,7 +326,7 @@
 
 ### Bug Fixes
 
-* **MockBuilder:** respect extention of classes with different decorators [#2646](https://github.com/help-me-mom/ng-mocks/issues/2646) ([d069a90](https://github.com/help-me-mom/ng-mocks/commit/d069a9047cc3188bea384632ffa1d3a0a62a09da))
+* **MockBuilder:** respect extension of classes with different decorators [#2646](https://github.com/help-me-mom/ng-mocks/issues/2646) ([d069a90](https://github.com/help-me-mom/ng-mocks/commit/d069a9047cc3188bea384632ffa1d3a0a62a09da))
 
 
 ### Features
@@ -694,7 +694,7 @@
 ### Bug Fixes
 
 * **core:** properly handling Sanitizer and DomSanitizer [#538](https://github.com/help-me-mom/ng-mocks/issues/538) ([fb51bb4](https://github.com/help-me-mom/ng-mocks/commit/fb51bb478593c22ed436c896980244d45fd796ed))
-* **mock-render:** detectChanges flag has to be provided to supress render ([8195eeb](https://github.com/help-me-mom/ng-mocks/commit/8195eeb7e4dbeeac71061a9ac94b1436f7cfdb0c))
+* **mock-render:** detectChanges flag has to be provided to suppress render ([8195eeb](https://github.com/help-me-mom/ng-mocks/commit/8195eeb7e4dbeeac71061a9ac94b1436f7cfdb0c))
 
 ## [11.11.1](https://github.com/help-me-mom/ng-mocks/compare/v11.11.0...v11.11.1) (2021-05-09)
 
@@ -1082,7 +1082,7 @@
 * mocking private service in component ([ab43a43](https://github.com/help-me-mom/ng-mocks/commit/ab43a438902dc01a75a16b82a6cbd2ef50b8c252)), closes [#198](https://github.com/help-me-mom/ng-mocks/issues/198)
 * more intelligent overrides ([b17ff7f](https://github.com/help-me-mom/ng-mocks/commit/b17ff7ffedbda0867e7c6d7cdd06ffb70ea19e2a))
 * more restricted stub signature ([fc179db](https://github.com/help-me-mom/ng-mocks/commit/fc179dbb5402aef4b915d20e8cb09bccf28bacdd))
-* performance degration caused by .exclude feature ([3bf29ad](https://github.com/help-me-mom/ng-mocks/commit/3bf29ad9199169a33be6ba94f44a2d52176122a3))
+* performance degradation caused by .exclude feature ([3bf29ad](https://github.com/help-me-mom/ng-mocks/commit/3bf29ad9199169a33be6ba94f44a2d52176122a3))
 * support of modules with providers in MockBuilder ([e0250e0](https://github.com/help-me-mom/ng-mocks/commit/e0250e04028e781a6ebb6c43f5d138b1660c8569)), closes [#197](https://github.com/help-me-mom/ng-mocks/issues/197)
 
 ## [10.2.0](https://github.com/help-me-mom/ng-mocks/compare/v10.1.3...v10.2.0) (2020-10-03)
@@ -1265,7 +1265,7 @@
 * correct mocking of xxxChild(ren) decorators ([de7b8c3](https://github.com/help-me-mom/ng-mocks/commit/de7b8c3)), closes [#109](https://github.com/help-me-mom/ng-mocks/issues/109)
 * improved helpers and documentation ([9ef24a0](https://github.com/help-me-mom/ng-mocks/commit/9ef24a0))
 * more friendly return type of mock-render ([f4a3b79](https://github.com/help-me-mom/ng-mocks/commit/f4a3b79))
-* remove usage of uknown ([26dfdb8](https://github.com/help-me-mom/ng-mocks/commit/26dfdb8))
+* remove usage of unknown ([26dfdb8](https://github.com/help-me-mom/ng-mocks/commit/26dfdb8))
 
 
 ### Features
@@ -1570,7 +1570,7 @@
 ### Bug Fixes
 
 * integrate mock-pipe ([d747517](https://github.com/help-me-mom/ng-mocks/commit/d747517))
-* mock_direcive integration ([7f02f7b](https://github.com/help-me-mom/ng-mocks/commit/7f02f7b))
+* mock_directive integration ([7f02f7b](https://github.com/help-me-mom/ng-mocks/commit/7f02f7b))
 
 
 ### Features

--- a/docs/articles/api/MockInstance.md
+++ b/docs/articles/api/MockInstance.md
@@ -136,7 +136,7 @@ describe('suite', () => {
     beforeEach(MockInstance.remember);
     afterEach(MockInstance.restore);
 
-    // Existins only during this sub suite.
+    // Exists only during this sub suite.
     // After the sub suite, the parent
     // customization will be present.
     beforeEach(() => MockInstance(SomeService, 'login$', throwError('wrong')));
@@ -202,7 +202,7 @@ MockInstance.scope();
 beforeAll(() => MockInstance(TOKEN, () => true));
 
 // ItsModule provides TOKEN which is used in TargetComponent.
-beforEach(() => MockBuilder(TargetComponent, ItsModule));
+beforeEach(() => MockBuilder(TargetComponent, ItsModule));
 
 it('test 1', () => {
   // token is true

--- a/docs/articles/api/MockRender.md
+++ b/docs/articles/api/MockRender.md
@@ -67,7 +67,7 @@ const fixture = MockRender(Component, params);
 
 // fixture.componentInstance.i2 = 2;
 // The value is take via a proxy from point,
-// because params don't have i2, and Componet has.
+// because params don't have i2, and Component has.
 
 params.i1 = 6;
 // Now fixture.componentInstance.i1 = 6.

--- a/docs/articles/api/ngMocks/formatHtml.md
+++ b/docs/articles/api/ngMocks/formatHtml.md
@@ -73,7 +73,7 @@ const block2 = ngMocks.reveal(div, ['block2']);
 
 ngMocks.formatHtml(div, true);
 // returns
-// <div> headaer 1 body 2 footer </div>
+// <div> header 1 body 2 footer </div>
 
 ngMocks.formatHtml(block1);
 // returns

--- a/docs/articles/api/ngMocks/stubMember.md
+++ b/docs/articles/api/ngMocks/stubMember.md
@@ -12,10 +12,10 @@ ngMocks.stubMember(service, method, customCallback);
 // overriding the property's value
 ngMocks.stubMember(service, property, customValue);
 
-// overrding the getter, does not touch the existing setter
+// overriding the getter, does not touch the existing setter
 ngMocks.stubMember(service, property, customGetter, 'get');
 
-// overrding the setter, does not touch the existing getter
+// overriding the setter, does not touch the existing getter
 ngMocks.stubMember(service, property, customSetter, 'set');
 ```
 

--- a/docs/articles/extra/mock-form-controls.md
+++ b/docs/articles/extra/mock-form-controls.md
@@ -80,7 +80,7 @@ export class MyControl implements ControlValueAccessor {
 ## Caution about ngModel
 
 It's important to call `fixture.whenStable()` in addition to `fixture.detectChanges()`
-if `FormsModule` is kept in a test to let `ngModel` udpate its values correctly.
+if `FormsModule` is kept in a test to let `ngModel` update its values correctly.
 
 Because `fixture.whenStable()` returns a promise, the whole test should be `async`.
 

--- a/docs/articles/extra/quick-start.md
+++ b/docs/articles/extra/quick-start.md
@@ -273,7 +273,7 @@ the code would look like:
 ```ts
 beforeEach(() => {
   return MockBuilder(AppBaseComponent, AppBaseModule)
-    // TranslatePipe is declarared / imported in AppBaseModule
+    // TranslatePipe is declared / imported in AppBaseModule
     .mock(TranslatePipe, v => `translated:${v}`)
     // SearchService is provided / imported in AppBaseModule
     .mock(SearchService, {

--- a/docs/articles/guides/directive-attribute.md
+++ b/docs/articles/guides/directive-attribute.md
@@ -96,7 +96,7 @@ describe('TestAttributeDirective', () => {
       'style="background-color: yellow;"',
     );
 
-    // Now let's simulate the mouse mouse leave event.
+    // Now let's simulate the mouse leave event.
     fixture.point.triggerEventHandler('mouseleave', null);
 
     // And assert that the background color is gone now.

--- a/docs/articles/guides/host-directive.md
+++ b/docs/articles/guides/host-directive.md
@@ -50,7 +50,7 @@ beforeEach(() => MockBuilder(HostDirective, TargetComponent));
 
 Profit!
 
-To access the directive in a test, [`ngMocks.findInstnace`](../api/ngMocks/findInstance.md) can be used.
+To access the directive in a test, [`ngMocks.findInstance`](../api/ngMocks/findInstance.md) can be used.
 
 ```ts
 it('keeps host directives', () => {

--- a/examples/TestAttributeDirective/test.spec.ts
+++ b/examples/TestAttributeDirective/test.spec.ts
@@ -58,7 +58,7 @@ describe('TestAttributeDirective', () => {
       'style="background-color: yellow;"',
     );
 
-    // Now let's simulate the mouse mouse leave event.
+    // Now let's simulate the mouse leave event.
     fixture.point.triggerEventHandler('mouseleave', null);
 
     // And assert that the background color is gone now.

--- a/examples/TestRoutingGuard/can-deactivate.spec.ts
+++ b/examples/TestRoutingGuard/can-deactivate.spec.ts
@@ -92,7 +92,7 @@ class DashboardComponent {
 class TargetModule {}
 
 describe('TestRoutingGuard:canDeactivate', () => {
-  // Because we want to test a canDeactive guard, it means that we want to
+  // Because we want to test a canDeactivate guard, it means that we want to
   // test its integration with RouterModule.
   // Therefore, RouterModule and the guard should be kept,
   // and the rest of the module which defines the route can be mocked.

--- a/tests/issue-522/test.spec.ts
+++ b/tests/issue-522/test.spec.ts
@@ -30,7 +30,7 @@ describe('issue-522', () => {
     }).compileComponents(),
   );
 
-  // with out params the template has inputs and therefore change detection works
+  // without params the template has inputs and therefore change detection works
   describe('without params', () => {
     beforeEach(() => {
       fixture = MockRender(ErrorCountDisplayComponent);


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling)

The misspellings have been reported at https://github.com/jsoref/ng-mocks/actions/runs/14120574763#summary-39559936503

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/ng-mocks/actions/runs/14120574891#summary-39559936665