### PR TITLE
fix(helper): add possibility to set typed input

### DIFF
--- a/libs/ng-mocks/src/lib/mock-helper/func.set-input.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/func.set-input.spec.ts
@@ -1,0 +1,48 @@
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MockBuilder } from '../mock-builder/mock-builder';
+
+import { ngMocks } from './mock-helper';
+
+@Component({
+  selector: 'selector-name',
+  template: '{{ title() }} {{ description() }}',
+})
+export class SetInputMockComponent {
+  readonly title = input.required<string>();
+  readonly description = input('');
+}
+
+describe('SetInputMockComponent', () => {
+  let component: SetInputMockComponent;
+  let fixture: ComponentFixture<SetInputMockComponent>;
+
+  beforeEach(async () => {
+    await MockBuilder(SetInputMockComponent);
+
+    fixture = TestBed.createComponent(SetInputMockComponent);
+    component = fixture.componentInstance;
+    ngMocks.setInput(fixture, 'title', 'new title');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have required title', () => {
+    expect(component.title()).toEqual('new title');
+    expect(fixture.nativeElement.textContent).toContain('new title');
+  });
+
+  it('should change the value of the input signal', () => {
+    ngMocks.setInput(fixture, 'description', 'new description');
+    fixture.detectChanges();
+
+    expect(component.description()).toEqual('new description');
+    expect(fixture.nativeElement.textContent).toContain(
+      'new description',
+    );
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-helper/func.set-input.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/func.set-input.ts
@@ -1,0 +1,18 @@
+import { InputSignal, InputSignalWithTransform, ModelSignal } from '@angular/core';
+import { ComponentFixture } from '@angular/core/testing';
+
+type ExtractWithTransform<TValue> = TValue extends InputSignalWithTransform<any, infer R> ? R : never;
+type ExtractModelType<TValue> = TValue extends ModelSignal<infer R> ? R : ExtractWithTransform<TValue>;
+type ExtractInputType<TValue> = TValue extends InputSignal<infer R> ? R : ExtractModelType<TValue>;
+
+type ExtractComponentInputs<TComponent> = {
+  [K in keyof TComponent as ExtractInputType<TComponent[K]> extends never ? never : K]: ExtractInputType<TComponent[K]>;
+};
+
+export default <TComponent, TKey extends keyof ExtractComponentInputs<TComponent>>(
+  fixture: ComponentFixture<TComponent>,
+  inputProperty: TKey,
+  value: ExtractComponentInputs<TComponent>[TKey],
+): void => {
+  fixture.componentRef.setInput(inputProperty as string, value);
+};

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.object.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.object.ts
@@ -15,6 +15,7 @@ import mockHelperFindInstance from './find-instance/mock-helper.find-instance';
 import mockHelperFindInstances from './find-instance/mock-helper.find-instances';
 import mockHelperFormatHtml from './format/mock-helper.format-html';
 import mockHelperFormatText from './format/mock-helper.format-text';
+import mockHelperSetInput from './func.set-input';
 import mockHelperAutoSpy from './mock-helper.auto-spy';
 import mockHelperConsoleIgnore from './mock-helper.console-ignore';
 import mockHelperConsoleThrow from './mock-helper.console-throw';
@@ -94,6 +95,7 @@ export default {
   reset: mockHelperReset,
   reveal: mockHelperReveal,
   revealAll: mockHelperRevealAll,
+  setInput: mockHelperSetInput,
   stub: mockHelperStub,
   stubMember: mockHelperStubMember,
   throwOnConsole: mockHelperConsoleThrow,

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.ts
@@ -268,6 +268,19 @@ export const ngMocks: {
   input<T = any>(elSelector: DebugNodeSelector, input: string): T;
 
   /**
+   * To ensure a type-safe approach to the new input API, this function performs
+   * a check for input and model signals and wraps `fixture.componentRef.setInput`.
+   *
+   * Extracts all input properties that are of type `InputSignal` or `ModelSignal`
+   * from the component type and allows setting their values in a type-safe manner.
+   *
+   * @param fixture the component fixture
+   * @param inputProperty the input property name
+   * @param value the value to set for the property
+   */
+  setInput: typeof mockHelperObject.setInput;
+
+  /**
    * ngMocks.input allows to get an input value without knowing
    * which component / directive it belongs to, otherwise the notFoundValue.
    *


### PR DESCRIPTION
Add helper which extracts all input properties that are of type `InputSignal` or `ModelSignal` from the component type and allows setting their values in a type-safe manner.

Aligns as a extension to #8818, which allows setting the default inputs.
This might not work with older angular versions that do not support `InputSignal`s.
How would you handle this case @satanTime when something new is introduced? Should it be a breaking change?

depends on #8818 or whatever the solution for #11001 might be