### PR TITLE
Use `reflectComponentType` as a Fallback to Detect Signals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "eslint-plugin-es-x": "8.7.0",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-json": "4.0.1",
-        "eslint-plugin-mdx": "3.6.0",
+        "eslint-plugin-mdx": "3.6.2",
         "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-prettier": "5.5.1",
         "eslint-plugin-unicorn": "56.0.1",
@@ -9545,9 +9545,9 @@
       }
     },
     "node_modules/eslint-mdx": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-mdx/-/eslint-mdx-3.6.0.tgz",
-      "integrity": "sha512-D1YKiLODSJmNK5+zOGqk5gU4lXEXCImUgT8uChDFgcwZYFYNUT71r+sOyLc0tYhTbuHg+tTOSkgSxJUhVon1Yg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-mdx/-/eslint-mdx-3.6.2.tgz",
+      "integrity": "sha512-5hczn5iSSEcwtNtVXFwCKIk6iLEDaZpwc3vjYDl/B779OzaAAK/ou16J2xVdO6ecOLEO1WZqp7MRCQ/WsKDUig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9738,13 +9738,13 @@
       }
     },
     "node_modules/eslint-plugin-mdx": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mdx/-/eslint-plugin-mdx-3.6.0.tgz",
-      "integrity": "sha512-q+OYdm/9QemwvxxMGmLFAJPx62l4V/38+Gk1wgRC8unnzF14sFgmCplrfuSQBUv5cndNd97xDuZO+83qM2n30A==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mdx/-/eslint-plugin-mdx-3.6.2.tgz",
+      "integrity": "sha512-RfMd5HYD/9+cqANhVWJbuBRg3huWUsAoGJNGmPsyiRD2X6BaG6bvt1omyk1ORlg81GK8ST7Ojt5fNAuwWhWU8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-mdx": "^3.6.0",
+        "eslint-mdx": "^3.6.2",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-mdx": "^3.0.0",
         "micromark-extension-mdxjs": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "eslint-plugin-es-x": "8.7.0",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-json": "4.0.1",
-    "eslint-plugin-mdx": "3.6.0",
+    "eslint-plugin-mdx": "3.6.2",
     "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-prettier": "5.5.1",
     "eslint-plugin-unicorn": "56.0.1",


### PR DESCRIPTION
This PR attempts to at least partially address https://github.com/help-me-mom/ng-mocks/issues/9698.

I saw [this comment](https://github.com/help-me-mom/ng-mocks/issues/7976#issuecomment-2067591950) and https://github.com/help-me-mom/ng-mocks/pull/8818, which leads me to believe this is the wrong solution; but, it does seem to fix the problem on a fresh Angular app (`ng generate app my-app` + `ng generate library my-lib`) and the larger Angular project that I care about - using NG 19, AOT, Webpack, and Karma.

---

For those that care, I built the package and published it [here](https://github.com/Watercycle/ng-mocks/releases/tag/v14.14.0). You can use it by updating your `package.json` with the following:
```json
"ng-mocks": "https://github.com/Watercycle/ng-mocks/releases/download/v14.14.0/ng-mocks-0.0.0.tgz"
```

and running `npm upgrade ng-mocks`.

This has been tricky to validate between _(seemingly)_ NG cache, NPM cache, and having to restart the test runner each time. That's mostly my inexperience with NPM packaging; but, it has led me down several false paths.