### PR TITLE
feat: respect multiple args for creation of component #12293

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -305,8 +305,8 @@ const patchVcrInstance = (vcrInstance: ViewContainerRef) => {
 
 const createComponent =
   (original: TestBedStatic['createComponent'], instance: TestBedStatic): TestBedStatic['createComponent'] =>
-  component => {
-    const fixture = original.call(instance, component);
+  (...args) => {
+    const fixture = original.call(instance, ...args);
     try {
       const vcr = fixture.debugElement.injector.get(ViewContainerRef);
       patchVcrInstance(vcr);


### PR DESCRIPTION
This issue closes https://github.com/help-me-mom/ng-mocks/issues/12293 and allows for the usage of the TestBedStatic create component with Specator with bindings