### PR TITLE
fix: support signal model mock bindings #10942

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
@@ -1,0 +1,40 @@
+import funcDirectiveIoParse from './func.directive-io-parse';
+
+describe('funcDirectiveIoParse', () => {
+  it('keeps regular aliases', () => {
+    expect(funcDirectiveIoParse('prop:alias')).toEqual({
+      alias: 'alias',
+      name: 'prop',
+    });
+  });
+
+  it('normalizes signal model outputs from strings', () => {
+    expect(funcDirectiveIoParse('value:valueChange')).toEqual({
+      name: 'valueChange',
+    });
+  });
+
+  it('normalizes signal model outputs from objects', () => {
+    expect(
+      funcDirectiveIoParse({
+        alias: 'valueChange',
+        name: 'value',
+      }),
+    ).toEqual({
+      name: 'valueChange',
+    });
+  });
+
+  it('keeps required metadata for signal model outputs', () => {
+    expect(
+      funcDirectiveIoParse({
+        alias: 'valueChange',
+        name: 'value',
+        required: true,
+      }),
+    ).toEqual({
+      name: 'valueChange',
+      required: true,
+    });
+  });
+});

--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.ts
@@ -1,15 +1,22 @@
 import { DirectiveIo, DirectiveIoParsed } from './core.types';
 
+const normalize = ({ name, alias, required }: DirectiveIoParsed): DirectiveIoParsed => {
+  if (name === alias || !alias) {
+    return required === undefined ? { name } : { name, required };
+  }
+
+  if (name + 'Change' === alias) {
+    return required === undefined ? { name: alias } : { name: alias, required };
+  }
+
+  return required === undefined ? { name, alias } : { name, alias, required };
+};
+
 export default function (param: DirectiveIo): DirectiveIoParsed {
   if (typeof param === 'string') {
     const [name, alias] = param.split(':').map(v => v.trim());
-
-    if (name === alias || !alias) {
-      return { name };
-    }
-
-    return { name, alias };
+    return normalize({ name, alias });
   }
 
-  return param;
+  return normalize(param);
 }

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
@@ -1,5 +1,7 @@
 import { Component, EventEmitter, Output } from '@angular/core';
 
+import funcGetGlobal from '../common/func.get-global';
+
 import collectDeclarations from './collect-declarations';
 
 describe('collect-declarations', () => {
@@ -323,5 +325,61 @@ describe('collect-declarations', () => {
 
     const actual = collectDeclarations(TargetComponent);
     expect(actual.outputs).toEqual(['output']);
+  });
+
+  it('reads signal model bindings from ng defs', () => {
+    const global = funcGetGlobal();
+    global.__ngMocksReflectComponentType = false;
+    const actual = collectDeclarations({
+      ɵcmp: {
+        declaredInputs: {
+          value: 'value',
+        },
+        inputs: {
+          value: ['value', 1, null],
+        },
+        outputs: {
+          valueChange: 'value',
+        },
+        standalone: true,
+      },
+    });
+
+    expect(actual.inputs).toEqual(['value']);
+    expect(actual.outputs).toEqual(['valueChange']);
+    expect(actual.standalone).toBe(true);
+    delete global.__ngMocksReflectComponentType;
+  });
+
+  it('reads string-form ng def inputs without declaredInputs', () => {
+    const global = funcGetGlobal();
+    global.__ngMocksReflectComponentType = false;
+    const actual = collectDeclarations({
+      ɵcmp: {
+        inputs: {
+          alias: 'prop',
+        },
+      },
+    });
+
+    expect(actual.inputs).toEqual(['prop:alias']);
+    expect(actual.outputs).toEqual([]);
+    delete global.__ngMocksReflectComponentType;
+  });
+
+  it('reads ng def outputs without inputs', () => {
+    const global = funcGetGlobal();
+    global.__ngMocksReflectComponentType = false;
+    const actual = collectDeclarations({
+      ɵcmp: {
+        outputs: {
+          valueChange: 'value',
+        },
+      },
+    });
+
+    expect(actual.inputs).toEqual([]);
+    expect(actual.outputs).toEqual(['valueChange']);
+    delete global.__ngMocksReflectComponentType;
   });
 });

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
@@ -313,14 +313,47 @@ const parseNgDef = (
   },
   declaration: Declaration,
 ): void => {
-  if (declaration.standalone === undefined && def.ɵcmp?.standalone !== undefined) {
-    declaration.standalone = def.ɵcmp.standalone;
-  }
-  if (declaration.standalone === undefined && def.ɵdir?.standalone !== undefined) {
-    declaration.standalone = def.ɵdir.standalone;
+  const ngDef = def.ɵcmp ?? def.ɵdir;
+
+  if (declaration.standalone === undefined && ngDef?.standalone !== undefined) {
+    declaration.standalone = ngDef.standalone;
   }
   if (declaration.standalone === undefined && def.ɵpipe?.standalone !== undefined) {
     declaration.standalone = def.ɵpipe.standalone;
+  }
+
+  if (!ngDef) {
+    return;
+  }
+
+  for (const alias of Object.keys(ngDef.inputs || {})) {
+    const input = ngDef.inputs[alias];
+    const minifiedName = Array.isArray(input) ? input[0] : input;
+    const {
+      name,
+      alias: normalizedAlias,
+      required,
+    } = funcDirectiveIoParse({
+      name: ngDef.declaredInputs?.[alias] ?? minifiedName,
+      alias,
+      required: undefined,
+    });
+
+    addUniqueDirectiveIo(declaration, 'inputs', name, normalizedAlias, required);
+  }
+
+  for (const alias of Object.keys(ngDef.outputs || {})) {
+    const {
+      name,
+      alias: normalizedAlias,
+      required,
+    } = funcDirectiveIoParse({
+      name: ngDef.outputs[alias],
+      alias,
+      required: undefined,
+    });
+
+    addUniqueDirectiveIo(declaration, 'outputs', name, normalizedAlias, required);
   }
 };
 

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -56,5 +56,6 @@ file|tests/mock-service/observable.spec.ts|versions=6+
 file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
+file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/**
 file|examples/**

--- a/tests/issue-10942/test.spec.ts
+++ b/tests/issue-10942/test.spec.ts
@@ -1,0 +1,105 @@
+import { Component, VERSION } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockComponent, ngMocks } from 'ng-mocks';
+
+const ngCore = require('@angular/core');
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/10942
+describe('issue-10942', () => {
+  if (
+    Number.parseInt(VERSION.major, 10) < 17 ||
+    typeof (ngCore as any).model !== 'function'
+  ) {
+    it('needs signal model support', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  const model = (ngCore as any).model as (value: string) => any;
+  const signal = (ngCore as any).signal as (value: string) => any;
+
+  @Component({
+    selector: 'target-10942-signal',
+    template: '',
+    ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  })
+  class SignalComponent {
+    public value = model('');
+  }
+
+  @Component({
+    imports: [SignalComponent],
+    selector: 'target-10942',
+    template: `
+      <h1>{{ title() }}</h1>
+      <target-10942-signal [(value)]="title"></target-10942-signal>
+    `,
+    ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  } as never)
+  class TargetComponent {
+    public title = signal('test-default');
+  }
+
+  const hasCompiledModelMetadata = () => {
+    const reflectComponentType = (ngCore as any).reflectComponentType;
+    const mirror =
+      typeof reflectComponentType === 'function'
+        ? reflectComponentType(SignalComponent)
+        : undefined;
+    const signalCmp = (SignalComponent as any).ɵcmp;
+    const inputs =
+      signalCmp && signalCmp.inputs ? signalCmp.inputs : {};
+    const outputs =
+      signalCmp && signalCmp.outputs ? signalCmp.outputs : {};
+    const mirrorInputs =
+      mirror && mirror.inputs ? mirror.inputs.length : 0;
+    const mirrorOutputs =
+      mirror && mirror.outputs ? mirror.outputs.length : 0;
+
+    return (
+      Object.keys(inputs).length > 0 ||
+      Object.keys(outputs).length > 0 ||
+      mirrorInputs > 0 ||
+      mirrorOutputs > 0
+    );
+  };
+
+  if (!hasCompiledModelMetadata()) {
+    it('needs compiled signal model metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder(TargetComponent));
+
+  it('creates a mock with signal model bindings', () => {
+    const mockComponent = MockComponent(SignalComponent) as any;
+    const mockCmp = mockComponent.ɵcmp;
+    const inputs = mockCmp && mockCmp.inputs ? mockCmp.inputs : {};
+    const outputs = mockCmp && mockCmp.outputs ? mockCmp.outputs : {};
+
+    expect(inputs.value).toBeDefined();
+    expect(outputs.valueChange).toBeDefined();
+  });
+
+  it('provides the signal model change emitter after change detection', () => {
+    const fixture = TestBed.createComponent(TargetComponent);
+
+    fixture.detectChanges();
+    expect(() =>
+      ngMocks
+        .output('target-10942-signal', 'valueChange')
+        .emit('test-new'),
+    ).not.toThrow();
+    fixture.detectChanges();
+
+    expect(ngMocks.find('h1').nativeElement.innerHTML).toEqual(
+      'test-new',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- read signal-model inputs and outputs from Angular ng defs when building mock metadata
- normalize synthetic model outputs so mocks expose the expected `...Change` emitter
- add regression coverage for the parsing logic and the compiled Angular reproduction
- gate the signal-model spread test to Angular 17+ targets

Closes #10942

## Validation
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 sh compose.sh root`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 docker compose run --rm ng-mocks npm run prettier:repo`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 docker compose run --rm ng-mocks npm run prettier:check`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 docker compose run --rm ng-mocks npm run ts:check`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/ --ignore-pattern tests-e2e/`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 sh test.sh root`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525 sh test.sh coverage`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a8 sh compose.sh a8`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a8 sh test.sh a8`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a10 sh compose.sh a10`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a10 sh test.sh a10`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a14 sh compose.sh a14`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a14 sh test.sh a14`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a17 sh compose.sh a17`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a17 sh test.sh a17`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a22 sh compose.sh a22`
- `COMPOSE_PROJECT_NAME=ngmocks_10942_20260525_a22 sh test.sh a22`

## Notes
- A full unscoped `npm run lint` currently fails on pre-existing `tests-e2e` `Array.prototype.find` violations unrelated to this PR. The scoped lint command above matches the PR-relevant root lint scope used during investigation.
- The first `a14` bootstrap hit a transient Chromium download `ECONNRESET`; rerunning the wrapper completed successfully.