### PR TITLE
docs(provideRouter): add standalone routing guard example #7977

### DIFF
--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -28,6 +28,9 @@ The example below is applicable for all types of guards:
 - `canLoad` -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-load.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanLoad),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-load.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanLoad)
+- standalone applications (Angular 14+) -
+  [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone),
+  [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone)
 - class guards (legacy) -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/test.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Atest),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/test.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Atest)
@@ -118,6 +121,69 @@ expect(location.path()).toEqual('/login');
 
 Profit, [an example of a test for a functional guard](#live-example).
 
+## Functional Guards In Standalone Applications
+
+If your app uses `bootstrapApplication()` with `provideRouter(...)`, then you can provide the standalone router setup directly in the test.
+For example, a standalone app might configure the route like this:
+
+```ts
+bootstrapApplication(TargetComponent, {
+  providers: [
+    provideRouter([
+      {
+        component: LoginComponent,
+        path: 'login',
+      },
+      {
+        canActivate: [canActivateGuard],
+        component: DashboardComponent,
+        path: '**',
+      },
+    ]),
+  ],
+});
+```
+
+The test can pass the same standalone router providers to `MockBuilder` without introducing an extra `NgModule`.
+
+```ts
+beforeEach(() => {
+  return MockBuilder(TargetComponent)
+    .keep(NG_MOCKS_ROOT_PROVIDERS)
+    .provide(
+      provideRouter([
+        {
+          component: LoginComponent,
+          path: 'login',
+        },
+        {
+          canActivate: [canActivateGuard],
+          component: DashboardComponent,
+          path: '**',
+        },
+      ]),
+    )
+    .mock(LoginComponent)
+    .mock(DashboardComponent);
+});
+```
+
+Now render a standalone component with a router outlet, initialize navigation, and assert the redirected route:
+
+```ts
+const fixture = MockRender(TargetComponent);
+const router = ngMocks.get(Router);
+
+if (fixture.ngZone) {
+  fixture.ngZone.run(() => router.initialNavigation());
+  await fixture.whenStable();
+}
+
+expect(router.url).toEqual('/login');
+```
+
+The full runnable example is available in [the standalone routing guard example](#live-example).
+
 ## Class Guards (legacy)
 
 If your code has guards which a classes and angular services,
@@ -158,6 +224,8 @@ Profit.
 
 - [Try it on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
 - [Try it on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
+- [Try the standalone example on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone)
+- [Try the standalone example on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone)
 
 ```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-activate.spec.ts"
 import { Location } from '@angular/common';

--- a/examples/TestRoutingGuard/standalone.spec.ts
+++ b/examples/TestRoutingGuard/standalone.spec.ts
@@ -1,0 +1,106 @@
+import {
+  Component,
+  inject,
+  Injectable,
+  VERSION,
+} from '@angular/core';
+import {
+  CanActivateFn,
+  Router,
+  RouterOutlet,
+  provideRouter,
+} from '@angular/router';
+import { from } from 'rxjs';
+import { mapTo } from 'rxjs/operators';
+
+import {
+  MockBuilder,
+  MockRender,
+  NG_MOCKS_ROOT_PROVIDERS,
+  ngMocks,
+} from 'ng-mocks';
+
+// A simple service simulating login check.
+// It will be replaced with its mock copy.
+@Injectable({
+  providedIn: 'root',
+})
+class LoginService {
+  public isLoggedIn = false;
+}
+
+// A guard we want to test.
+const canActivateGuard: CanActivateFn = (route, state) => {
+  if (route && state && inject(LoginService).isLoggedIn) {
+    return true;
+  }
+
+  return from(inject(Router).navigate(['/login'])).pipe(mapTo(false));
+};
+
+// A simple component pretending a login form.
+// It will be replaced with a mock copy.
+@Component({
+  selector: 'login',
+  standalone: true,
+  template: 'login',
+})
+class LoginComponent {}
+
+// A simple component pretending a protected dashboard.
+// It will be replaced with a mock copy.
+@Component({
+  selector: 'dashboard',
+  standalone: true,
+  template: 'dashboard',
+})
+class DashboardComponent {}
+
+@Component({
+  imports: [RouterOutlet],
+  standalone: true,
+  template: '<router-outlet></router-outlet>',
+})
+class TargetComponent {}
+
+describe('TestRoutingGuard:standalone', () => {
+  if (Number.parseInt(VERSION.major, 10) < 14) {
+    it('needs a14', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => {
+    return MockBuilder(TargetComponent)
+      .keep(NG_MOCKS_ROOT_PROVIDERS)
+      .provide(
+        provideRouter([
+          {
+            component: LoginComponent,
+            path: 'login',
+          },
+          {
+            canActivate: [canActivateGuard],
+            component: DashboardComponent,
+            path: '**',
+          },
+        ]),
+      )
+      .mock(LoginComponent)
+      .mock(DashboardComponent);
+  });
+
+  it('redirects to login', async () => {
+    const fixture = MockRender(TargetComponent);
+    const router = ngMocks.get(Router);
+
+    if (fixture.ngZone) {
+      fixture.ngZone.run(() => router.initialNavigation());
+      await fixture.whenStable();
+    }
+
+    expect(router.url).toEqual('/login');
+  });
+});

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -47,6 +47,7 @@ feature|httpResource|versions=20+
 feature|signalForms|versions=21+
 
 file|examples/TestRoutingGuard/can-*.spec.ts|features=routerFns
+file|examples/TestRoutingGuard/standalone.spec.ts|features=standalone,routerFns
 file|examples/TestRoutingResolver/fn.spec.ts|features=routerFns
 file|tests/issue-4282/*.ts|versions=6+
 file|examples/TestRoutingGuard/test.spec.ts|versions=6+


### PR DESCRIPTION
Closes #7977

## Summary
- add a runnable standalone routing guard example using provideRouter
- link the routing guard guide to the standalone example and document the standalone test setup
- exclude the new example from pre-Angular-14 e2e targets where standalone APIs are unavailable

## Validation
- COMPOSE_PROJECT_NAME=ngmocks_7977 sh test.sh root
- COMPOSE_PROJECT_NAME=ngmocks_7977 sh test.sh coverage
- COMPOSE_PROJECT_NAME=ngmocks_7977 sh test.sh a5es5
- COMPOSE_PROJECT_NAME=ngmocks_7977 sh test.sh a14
- COMPOSE_PROJECT_NAME=ngmocks_7977 sh test.sh a20
- COMPOSE_PROJECT_NAME=ngmocks_7977 docker compose run --rm ng-mocks npm run prettier:check