### PR TITLE
#10919 feat(MockService): mock own object properties

### DIFF
--- a/docs/articles/api/MockProvider.md
+++ b/docs/articles/api/MockProvider.md
@@ -8,6 +8,8 @@ sidebar_label: MockProvider
 The function supports services and tokens.
 Also, it accepts a shape of its service, in order to provide own properties,
 and values for tokens, otherwise the token's value will be `undefined`.
+When a mocked service can be created without constructor arguments,
+own object properties are kept and their methods are mocked too.
 
 ```ts
 TestBed.configureTestingModule({
@@ -28,6 +30,26 @@ TestBed.configureTestingModule({
     MockProvider(TOKEN, 'value'),
   ],
 });
+```
+
+```ts
+class Service {
+  public readonly info = {
+    request: () => 'real',
+  };
+}
+
+ngMocks.autoSpy('jasmine');
+
+TestBed.configureTestingModule({
+  providers: [MockProvider(Service)],
+});
+
+const service = TestBed.inject(Service);
+
+service.info.request();
+
+expect(service.info.request).toHaveBeenCalledTimes(1);
 ```
 
 ## useValue

--- a/docs/articles/api/MockService.md
+++ b/docs/articles/api/MockService.md
@@ -31,6 +31,30 @@ const i2 = MockService(MyClass, {
 
 It is useful, when a class has dozens of methods, whereas we want to change behavior of a few of them.
 
+## Own properties
+
+`MockService` also preserves own object properties of classes which can be created without constructor arguments.
+This is useful for services that expose an object with methods as a public field.
+
+```ts
+class TargetService {
+  public readonly info = {
+    request: () => 'real',
+  };
+}
+
+ngMocks.autoSpy('jasmine');
+
+const service = MockService(TargetService);
+
+service.info.request();
+
+expect(service.info.request).toHaveBeenCalledTimes(1);
+```
+
+In this case, `info` stays available on the mock instance, and `info.request` becomes a mock method.
+If the constructor needs arguments, or if calling it without arguments throws, `MockService` falls back to mocking the prototype.
+
 ## Simple example
 
 Let's suppose that a service has a method which returns `HTMLInputElement`, but we would like to mock the service

--- a/libs/ng-mocks/src/lib/mock-service/mock-service.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/mock-service.spec.ts
@@ -70,6 +70,22 @@ class GetterSetterMethodHuetod {
   }
 }
 
+class OwnObjectPropertiesClass {
+  public readonly info = {
+    request: () => 'request',
+  };
+}
+
+class ThrowingClass {
+  public constructor() {
+    throw new Error('constructor side effect');
+  }
+
+  public echo(): string {
+    return 'echo';
+  }
+}
+
 describe('MockService', () => {
   it('should convert boolean, number, string, null and undefined to undefined', () => {
     expect(MockService(true)).toBeUndefined();
@@ -164,6 +180,28 @@ describe('MockService', () => {
     expect(
       ngMocks.stub<any>(mockService, 'childMethod').and.identity,
     ).toBe('ChildClass.childMethod');
+  });
+
+  it('should mock own object properties of classes without constructor parameters', () => {
+    const mockService = MockService(OwnObjectPropertiesClass);
+
+    expect(mockService.info).toEqual({
+      request: jasmine.any(Function),
+    });
+    expect(mockService.info.request()).toBeUndefined();
+    expect(
+      (mockService.info.request as jasmine.Spy).and.identity,
+    ).toBe('func:OwnObjectPropertiesClass.info.request');
+  });
+
+  it('falls back to a prototype-only mock when a zero-arg constructor throws', () => {
+    const mockService = MockService(ThrowingClass);
+
+    expect(mockService.echo).toEqual(jasmine.any(Function));
+    expect(mockService.echo()).toBeUndefined();
+    expect((mockService.echo as jasmine.Spy).and.identity).toBe(
+      'ThrowingClass.echo',
+    );
   });
 
   it('should mock an instance of a class as an object', () => {

--- a/libs/ng-mocks/src/lib/mock-service/mock-service.ts
+++ b/libs/ng-mocks/src/lib/mock-service/mock-service.ts
@@ -9,16 +9,31 @@ import helperMockService from './helper.mock-service';
 
 type MockServiceHandler = (cache: Map<any, any>, service: any, prefix?: string, overrides?: any) => any;
 
-const mockVariableMap: Array<[(def: any) => boolean, MockServiceHandler]> = [
-  [
-    checkIsClass,
-    (cache, service) => {
-      const value = helperMockService.createMockFromPrototype(service.prototype);
+const createMockFromClass = (
+  cache: Map<any, any>,
+  service: any,
+  prefix: string | undefined,
+  callback: MockServiceHandler,
+) => {
+  if (service.length === 0) {
+    try {
+      const value = callback(cache, new service(), prefix || funcGetName(service));
       cache.set(service, value);
 
       return value;
-    },
-  ],
+    } catch {
+      // Falling back to the prototype-only mock keeps unsafe constructors supported.
+    }
+  }
+
+  const value = helperMockService.createMockFromPrototype(service.prototype);
+  cache.set(service, value);
+
+  return value;
+};
+
+const mockVariableMap: Array<[(def: any) => boolean, MockServiceHandler]> = [
+  [checkIsClass, (cache, service, prefix, callback) => createMockFromClass(cache, service, prefix, callback)],
   [
     checkIsFunc,
     (cache, service, prefix) => {

--- a/tests/issue-10919/test.spec.ts
+++ b/tests/issue-10919/test.spec.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockProvider, ngMocks } from 'ng-mocks';
+
+@Injectable()
+class TargetService {
+  public readonly info = {
+    request: () => 'target',
+  };
+}
+
+const resetSpy = (spy: any): void => {
+  if (typeof jest === 'undefined') {
+    spy.calls.reset();
+  } else {
+    spy.mockClear();
+  }
+};
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/10919
+describe('issue-10919', () => {
+  const anyTestBed: any = TestBed;
+
+  beforeEach(() =>
+    ngMocks.autoSpy(typeof jest === 'undefined' ? 'jasmine' : 'jest'),
+  );
+
+  afterEach(() => ngMocks.autoSpy('reset'));
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+
+    // The reported case is a service with an own object property.
+    // The app calls `service.info.request()`, therefore the mock has to keep the
+    // object shape and replace `request` with a callable spy.
+    //
+    // Before this behavior, mocked provider setup relied on
+    // MockService(TargetService), which only mocked the prototype of the class.
+    // Because `info` is created as an own property, it was dropped from the
+    // mock and `service.info.request()` crashed with:
+    // "Cannot read properties of undefined (reading 'request')".
+    TestBed.configureTestingModule({
+      providers: [MockProvider(TargetService)],
+    });
+  });
+
+  it('keeps own object properties of a mocked service', () => {
+    const service = anyTestBed.get
+      ? anyTestBed.get(TargetService)
+      : anyTestBed.inject(TargetService);
+
+    // We want the nested object to stay available and its method to be turned
+    // into a callable spy, so a provider mock can safely call
+    // `service.info.request()` without extra setup.
+    expect(service.info).toBeDefined();
+    expect(typeof service.info.request).toEqual('function');
+    resetSpy(service.info.request);
+
+    service.info.request();
+
+    expect(service.info.request).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #10919

## Summary
- add MockService support for own object properties on classes that can be instantiated without constructor arguments
- preserve nested object methods for MockProvider usage, including auto-spy assertions
- document MockService and MockProvider behavior for own object properties

## Validation
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh compose.sh root
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh test.sh root
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh test.sh coverage
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review docker compose run --rm ng-mocks npm run lint
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh compose.sh a5es5
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh test.sh a5es5
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh compose.sh a14
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh test.sh a14
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh compose.sh a20
- COMPOSE_PROJECT_NAME=ngmocks_i10919_review sh test.sh a20

## Coverage
- libs/ng-mocks/src/lib/mock-service/mock-service.ts: LF/LH 40/40, BRF/BRH 29/29
