### PR TITLE
#6143 test: add standalone forwardRef regression

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -57,5 +57,6 @@ file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
+file|tests/issue-6143/*.ts|versions=15+
 file|tests/**
 file|examples/**

--- a/tests/issue-6143/test.spec.ts
+++ b/tests/issue-6143/test.spec.ts
@@ -1,0 +1,55 @@
+import { CommonModule } from '@angular/common';
+import { Component, forwardRef } from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+// Regression coverage for #6143:
+// - this standalone child imports its standalone parent via forwardRef
+// - the parent imports the child directly
+//
+// The same setup fails with a recursive stack overflow on v14.7.1 for the
+// Angular 15 line reported in the issue, but current main should keep rendering
+// both sides of the standalone graph correctly.
+@Component({
+  selector: 'issue-6143-child',
+  template: 'ChildComponent',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    CommonModule,
+    forwardRef(() => ParentComponent),
+  ],
+})
+class ChildComponent {}
+
+@Component({
+  selector: 'issue-6143-parent',
+  template: 'ParentComponent',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    CommonModule,
+    ChildComponent,
+  ],
+})
+class ParentComponent {}
+
+describe('issue-6143', () => {
+  describe('ChildComponent', () => {
+    beforeEach(() => MockBuilder(ChildComponent));
+
+    it('renders without recursive parsing failures', () => {
+      const fixture = MockRender(ChildComponent);
+
+      expect(ngMocks.formatText(fixture)).toEqual('ChildComponent');
+    });
+  });
+
+  describe('ParentComponent', () => {
+    beforeEach(() => MockBuilder(ParentComponent));
+
+    it('renders its own standalone graph', () => {
+      const fixture = MockRender(ParentComponent);
+
+      expect(ngMocks.formatText(fixture)).toEqual('ParentComponent');
+    });
+  });
+});


### PR DESCRIPTION
closes #6143

## Summary
- rebase the regression coverage branch onto current `upstream/main`
- keep the standalone `forwardRef(() => ParentComponent)` reproducer from #6143 focused on the reported Angular 15 path
- gate `tests/issue-6143/*.ts` to Angular 15+ in `test-spread.conf` so older spread targets skip the standalone repro instead of carrying a runtime no-op

## Historical verification
- the same component graph previously failed on the reporter's `v14.7.1` path with `RangeError: Maximum call stack size exceeded`
- the spec covers `MockBuilder(ChildComponent)` where the child imports `forwardRef(() => ParentComponent)`, plus the reciprocal parent render path used in the maintainer verification

## Validation
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 sh compose.sh root`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm ng-mocks npm run prettier:check`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/ --ignore-pattern tests-e2e/`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm ng-mocks npm run ts:check`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 sh test.sh coverage` - 1665 specs passed, 100% statements/branches/functions/lines
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm ng-mocks npm run build:dev`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm ng-mocks npm run s:files:a14` - confirmed `issue-6143` is skipped for Angular 14
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 sh compose.sh a15`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm a15 npm run test:jasmine -- --include src/test/tests/issue-6143/test.spec.ts`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm a15 npm run test:jest -- --runTestsByPath src/test/tests/issue-6143/test.spec.ts`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 sh compose.sh a22`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm a22 npm run test:jasmine -- --include src/test/tests/issue-6143/test.spec.ts`
- `COMPOSE_PROJECT_NAME=ngmocks_13453_rebase_1056 docker compose run --rm a22 npm run test:jest -- --runTestsByPath src/test/tests/issue-6143/test.spec.ts`

Note: full `npm run lint` without CI's ignore patterns still reports pre-existing `tests-e2e` `Array.prototype.find` violations; the CI-style lint command above passes.

Refs #6143
