### PR TITLE
fix(injector): keep useFactory root providers for kept injectables (#7938)

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -76,6 +76,7 @@ When adding a spread test:
 - Match nearby compatibility style, including `VERSION.major` guards and metadata casts such as `['standalone' as never]` when older TypeScript or Angular targets still parse the file.
 - If a file imports APIs unavailable in older Angular targets, gate it in `test-spread.conf` with `versions=` or `features=` instead of relying only on runtime guards.
 - Prefer one `describe('issue-<number>')` suite with assertions that prove the reported failure and the expected behavior.
+- Add an in-file `// @see https://github.com/help-me-mom/ng-mocks/issues/<issue-number>` link near the regression suite. For subtle regressions, add a short comment block that explains the reported failure, the root cause, and the fix so future readers do not need to reconstruct the issue from the PR.
 
 ## Validation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 ## Test Style
 
 - Never add helper functions in tests. Keep the relevant setup, action, and assertion flow inline in each spec, even when that means duplicating a short block, so regressions stay obvious across Angular spread targets.
+- Prefer static ES imports in source and tests. Do not use `require` or dynamic module access unless there is a concrete technical reason; if an Angular API is unavailable in older spread targets, gate that file in `test-spread.conf` with `versions=` or `features=` instead of bypassing TypeScript compatibility.
 
 ## Code Quality Commands
 

--- a/libs/ng-mocks/src/lib/mock-builder/promise/get-root-provider-keep-provider.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/get-root-provider-keep-provider.spec.ts
@@ -1,0 +1,58 @@
+import { InjectionToken } from '@angular/core';
+
+import getRootProviderKeepProvider from './get-root-provider-keep-provider';
+
+describe('get-root-provider-keep-provider', () => {
+  it('keeps factory provider dependencies', () => {
+    const dependency = new InjectionToken('dependency');
+    const useFactory = () => 'value';
+    const target = () => undefined;
+
+    (target as any).decorators = [
+      {
+        args: [
+          {
+            deps: [dependency],
+            useFactory,
+          },
+        ],
+        type: {
+          prototype: {
+            ngMetadataName: 'Injectable',
+          },
+        },
+      },
+    ];
+
+    expect(getRootProviderKeepProvider(target)).toEqual({
+      deps: [dependency],
+      provide: target,
+      useFactory,
+    });
+  });
+
+  it('keeps service factory providers', () => {
+    const factory = () => 'value';
+    const target = () => undefined;
+
+    (target as any).decorators = [
+      {
+        args: [
+          {
+            factory,
+          },
+        ],
+        type: {
+          prototype: {
+            ngMetadataName: 'Service',
+          },
+        },
+      },
+    ];
+
+    expect(getRootProviderKeepProvider(target)).toEqual({
+      provide: target,
+      useFactory: factory,
+    });
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-builder/promise/get-root-provider-keep-provider.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/get-root-provider-keep-provider.ts
@@ -1,0 +1,20 @@
+import collectDeclarations from '../../resolve/collect-declarations';
+
+export default (parameter: any): undefined | any => {
+  if (typeof parameter !== 'function') {
+    return undefined;
+  }
+
+  const declarations = collectDeclarations(parameter);
+  const injectable = declarations.Injectable ?? declarations.Service;
+  const useFactory = injectable?.useFactory ?? injectable?.factory;
+  if (useFactory) {
+    return {
+      ...(injectable.deps === undefined ? {} : { deps: injectable.deps }),
+      provide: parameter,
+      useFactory,
+    };
+  }
+
+  return undefined;
+};

--- a/libs/ng-mocks/src/lib/mock-builder/promise/init-keep-def.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/init-keep-def.ts
@@ -2,6 +2,8 @@ import { mapValues } from '../../common/core.helpers';
 import { funcExtractDeps } from '../../common/func.extract-deps';
 import ngMocksUniverse from '../../common/ng-mocks-universe';
 
+import getRootProviderKeepProvider from './get-root-provider-keep-provider';
+
 export default (keepDef: Set<any>, configDef: Map<any, any>): Set<any> => {
   const dependencies = new Set<any>();
   const builtDeclarations = ngMocksUniverse.builtDeclarations;
@@ -9,7 +11,7 @@ export default (keepDef: Set<any>, configDef: Map<any, any>): Set<any> => {
   const resolutions = ngMocksUniverse.config.get('ngMocksDepsResolution');
   for (const def of mapValues(keepDef)) {
     builtDeclarations.set(def, def);
-    builtProviders.set(def, def);
+    builtProviders.set(def, getRootProviderKeepProvider(def) ?? def);
     resolutions.set(def, 'keep');
 
     const config = configDef.get(def);

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -58,5 +58,6 @@ file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+
+file|tests/issue-7938/*.ts|versions=15+
 file|tests/**
 file|examples/**

--- a/tests/issue-7938/test.spec.ts
+++ b/tests/issue-7938/test.spec.ts
@@ -1,0 +1,45 @@
+import { Component, Inject } from '@angular/core';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+} from '@angular/forms';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target-7938',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    ReactiveFormsModule,
+  ],
+  template: '',
+})
+class TargetComponent {
+  public form = this.fb.group({
+    age: this.fb.control(21),
+    name: this.fb.control(''),
+  });
+
+  public constructor(
+    @Inject(NonNullableFormBuilder)
+    private readonly fb: NonNullableFormBuilder,
+  ) {}
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/7938
+// `NonNullableFormBuilder` is a root provider whose factory returns
+// `inject(FormBuilder).nonNullable`; it is not provided by ReactiveFormsModule
+// itself. The bug happened because `.keep(NonNullableFormBuilder)` stored the
+// class token directly, so the provider resolver could replace Angular's real
+// factory provider with a class/provider shape that did not expose `control`.
+// The fix preserves reflected factory metadata for explicitly kept root
+// providers, including Angular 22's `Service({ factory })` metadata form.
+describe('issue-7938', () => {
+  it('works when NonNullableFormBuilder is explicitly kept', async () => {
+    await MockBuilder(TargetComponent)
+      .keep(ReactiveFormsModule)
+      .keep(NonNullableFormBuilder);
+
+    expect(() => MockRender(TargetComponent)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #7938

## Why
- `NonNullableFormBuilder` is a root provider, not a provider from `ReactiveFormsModule` itself.
- Before this change, explicitly keeping `NonNullableFormBuilder` could still register the class token directly, so Angular instantiated an object without the real form-builder methods and `fb.control()` was missing.
- Angular 22 reflects this provider as `Service({ factory })`, so the keep path needs to preserve both older `Injectable({ useFactory })` and newer `Service({ factory })` metadata.

## Reproduction
- Baseline: `upstream/main` at `cff512599f93591774772fe3806798c74c05e76e` in `/Volumes/MGS/Projects/ng-mocks-repro-7938`.
- Added only `tests/issue-7938/test.spec.ts`.
- Command: `COMPOSE_PROJECT_NAME=ngmocks_repro7938 docker compose run --rm -e KARMA_SUITE='./tests/issue-7938/**/*.ts' ng-mocks npm run test`.
- Result: failed with `TypeError: this.fb.control is not a function`.

## What
- Added `tests/issue-7938/test.spec.ts` to cover `ReactiveFormsModule` kept together with explicit `.keep(NonNullableFormBuilder)`.
- Added an in-file issue link and explanation of the reported failure, root cause, and fix.
- Used static Angular Forms imports and gated the spread test with `test-spread.conf` `versions=15+` instead of dynamic `require` compatibility handling.
- Added `get-root-provider-keep-provider.ts` to preserve factory metadata, including `deps`, for kept root providers.
- Handled both `Injectable({ useFactory })` and Angular 22 `Service({ factory })` reflected metadata.
- Updated `init-keep-def.ts` to register such kept providers through the reconstructed factory provider.
- Added focused helper specs so the new helper remains fully covered.
- Updated the triage-issue skill to ask for in-file issue links and explanatory comment blocks for subtle regressions.
- Added repo-wide `AGENTS.md` guidance to prefer static ES imports and avoid `require`/dynamic module access unless there is a concrete technical reason.

## Where
- `tests/issue-7938/test.spec.ts`
- `test-spread.conf`
- `libs/ng-mocks/src/lib/mock-builder/promise/init-keep-def.ts`
- `libs/ng-mocks/src/lib/mock-builder/promise/get-root-provider-keep-provider.ts`
- `libs/ng-mocks/src/lib/mock-builder/promise/get-root-provider-keep-provider.spec.ts`
- `.agents/skills/triage-issue/SKILL.md`
- `AGENTS.md`

## Validation
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm -e KARMA_SUITE='./tests/issue-7938/**/*.ts' ng-mocks npm run test` - passed, 1/1.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npm run s:files:a14` plus search for `issue-7938` in `e2e/a14/src/test` - passed; file is not spread to a14.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 sh test.sh coverage` - passed, 1668/1668.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 sh test.sh a15` - passed, Jasmine 1323/1323 and Jest 403/403 suites.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 sh test.sh a22` - passed, Jasmine 1296/1296 and Jest 401/401 suites.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npm run prettier:repo` - passed.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npm run prettier:check` - passed.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npm run ts:check` - passed.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/ --ignore-pattern tests-e2e/` - passed.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npm run build` - passed.
- `npx commitlint -V --from=upstream/main` - passed.
- `COMPOSE_PROJECT_NAME=ngmocks_13468_7938 docker compose run --rm ng-mocks npx semantic-release -h` - passed.
