### PR TITLE
test(MockBuilder): track HttpClient global replacement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@
 - Standalone, signals, and defer support must match the compatibility tables in `README.md` and `docs/articles/index.md`.
 - Do not claim support beyond those tables unless you update the tables and the implementation together.
 
+## Test Style
+
+- Never add helper functions in tests. Keep the relevant setup, action, and assertion flow inline in each spec, even when that means duplicating a short block, so regressions stay obvious across Angular spread targets.
+
 ## Code Quality Commands
 
 - Run root quality checks through the main service container:

--- a/libs/ng-mocks/src/lib/mock-builder/promise/init-universe.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/init-universe.ts
@@ -32,6 +32,9 @@ const addDependencies = (
 const shouldKeepReplacementDependency = (dependency: any): boolean => {
   const ngType = getNgType(dependency);
 
+  // Replacement modules mostly contribute providers / tokens. Angular metadata
+  // exposes them either as plain values (undefined type) or Injectables, and
+  // both forms need to stay real after the replacement is applied.
   return ngType === undefined || ngType === 'Injectable';
 };
 

--- a/tests/issue-6402/test.spec.ts
+++ b/tests/issue-6402/test.spec.ts
@@ -22,8 +22,10 @@ class TargetService {
 })
 class TargetModule {}
 
-// The issue was that MockBuilder didn't apply global rules to mocked declarations.
+// Issue #10347 reports the same HttpClientModule replacement path, so this
+// regression keeps both local and global replacement behavior covered.
 // @see https://github.com/help-me-mom/ng-mocks/issues/6402
+// @see https://github.com/help-me-mom/ng-mocks/issues/10347
 describe('issue-6402', () => {
   describe('MockBuilder:replace', () => {
     beforeEach(() =>
@@ -34,8 +36,13 @@ describe('issue-6402', () => {
     );
 
     it('sends /api/config request', () => {
+      // TargetModule is mocked via MockBuilder, so this request only works if
+      // the local HttpClientTestingModule replacement keeps its real providers.
       MockRender(TargetService);
+
       const service = ngMocks.get(TargetService);
+      // HttpTestingController exists only on the replacement module, which makes
+      // it a good canary for replacement behavior across all Angular apps.
       const controller = ngMocks.get(HttpTestingController);
 
       service.getConfig().subscribe();
@@ -58,8 +65,13 @@ describe('issue-6402', () => {
     afterAll(() => ngMocks.globalWipe(HttpClientModule));
 
     it('sends /api/config request', () => {
+      // TargetModule is mocked via MockBuilder, so this request only works if
+      // the global HttpClientTestingModule replacement keeps its real providers.
       MockRender(TargetService);
+
       const service = ngMocks.get(TargetService);
+      // HttpTestingController exists only on the replacement module, which makes
+      // it a good canary for replacement behavior across all Angular apps.
       const controller = ngMocks.get(HttpTestingController);
 
       service.getConfig().subscribe();


### PR DESCRIPTION
Closes #10347

## Why

Issue #10347 reports that `ngMocks.globalReplace(HttpClientModule, HttpClientTestingModule)` can leave `HttpClient` unavailable when a mocked module imports `HttpClientModule`.

The same replacement path is already represented by `tests/issue-6402/test.spec.ts`, so this PR makes that regression explicitly track #10347 too.

## What

- Keeps the HttpClient replacement regression inline in each spec, without adding shared test helper functions.
- Covers both local `.replace(...)` and `ngMocks.globalReplace(...)` behavior with `HttpTestingController` as the provider canary.
- Adds comments explaining why the replacement test proves the real testing providers are retained.
- Adds an implementation comment documenting why provider-like replacement dependencies stay real.
- Updates `AGENTS.md` with the repo rule to never add helper functions in tests.

## Validation

- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh compose.sh root`
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh test.sh root` - passed, 1655 specs
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh test.sh coverage` - passed, 1655 specs; `init-universe.ts` LCOV `LF:69/LH:69`, `BRF:26/BRH:26`
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 docker compose run --rm ng-mocks npm run prettier:repo` - passed, unchanged after helper removal
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 docker compose run --rm ng-mocks npm run prettier:check` - passed after `AGENTS.md` update
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 docker compose run --rm ng-mocks npm run ts:check` - passed
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/ --ignore-pattern tests-e2e/` - passed
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh compose.sh a5 && COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh test.sh a5` - passed
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh compose.sh a9 && COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh test.sh a9` - passed
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh compose.sh a14 && COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh test.sh a14` - passed
- `COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh compose.sh a22 && COMPOSE_PROJECT_NAME=ngmocks_issue10347_20260525 sh test.sh a22` - passed

## Note

Raw root lint currently reports unrelated existing `tests-e2e` `Array.prototype.find` lint errors. The CircleCI-equivalent root lint command above passes.