### PR TITLE
ci: align release and lint gates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
           command: npx commitlint -V --from=origin/main
       - run:
           name: Lint code style
-          command: npm run lint -- --ignore-pattern e2e/ --ignore-pattern tests-e2e/
+          command: npm run lint -- --ignore-pattern e2e/
       - run:
           name: Lint typescript
           command: npm run ts:check

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -9,10 +9,10 @@ plugins:
           scope: README
           release: patch
   - - '@semantic-release/exec'
-    - prepareCmd: |
-        sh compose.sh root
-        docker compose run --rm ng-mocks npm run lint
-        docker compose run --rm ng-mocks npm run ts:check
+    - prepareCmd: >-
+        sh compose.sh root &&
+        docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/ &&
+        docker compose run --rm ng-mocks npm run ts:check &&
         docker compose run --rm ng-mocks npm run build
   - '@semantic-release/release-notes-generator'
   - - '@semantic-release/changelog'

--- a/compose.yml
+++ b/compose.yml
@@ -77,6 +77,7 @@ services:
 
   a6:
     image: satantime/puppeteer-node:8.17.0
+    platform: linux/amd64
     working_dir: /app
     volumes:
       - ./e2e/a6:/app

--- a/tests-e2e/src/issue-305/test.spec.ts
+++ b/tests-e2e/src/issue-305/test.spec.ts
@@ -49,6 +49,7 @@ describe('issue-305', () => {
 
     // MatInput does not implement ControlValueAccessor
     const matInput = ngMocks.get(
+      // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
       ngMocks.find(['data-testid', 'inputControl']),
       MatInput,
     );
@@ -56,6 +57,7 @@ describe('issue-305', () => {
 
     // DefaultValueAccessor does implement ControlValueAccessor
     const valueAccessor = ngMocks.get(
+      // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
       ngMocks.find(['data-testid', 'inputControl']),
       DefaultValueAccessor,
     );

--- a/tests-e2e/src/issue-4693/test.spec.ts
+++ b/tests-e2e/src/issue-4693/test.spec.ts
@@ -25,6 +25,7 @@ describe('issue-4693', () => {
     it('loads lazy component', async () => {
       const fixture = MockRender(TargetComponent);
       await fixture.whenStable();
+      // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
       const el = ngMocks.find(ChildComponent);
       expect(ngMocks.formatText(el)).toEqual('child');
       expect(isMockOf(el.componentInstance, ChildComponent)).toEqual(
@@ -39,6 +40,7 @@ describe('issue-4693', () => {
     it('loads lazy component as a mock', async () => {
       const fixture = MockRender(TargetComponent);
       await fixture.whenStable();
+      // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
       const el = ngMocks.find(ChildComponent);
       expect(ngMocks.formatText(el)).toEqual('');
       expect(isMockOf(el.componentInstance, ChildComponent)).toEqual(

--- a/tests-e2e/src/mat-input/test.spec.ts
+++ b/tests-e2e/src/mat-input/test.spec.ts
@@ -39,7 +39,9 @@ describe('mat-input', () => {
     it('changes values', () => {
       const component =
         MockRender(TargetComponent).point.componentInstance;
+      // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
       const input1 = ngMocks.find(['name', 'form-control']);
+      // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
       const input2 = ngMocks.find(['name', 'ng-model']);
 
       ngMocks.change(input1, 'input1');

--- a/tests-e2e/src/mat-table/e2e.spec.ts
+++ b/tests-e2e/src/mat-table/e2e.spec.ts
@@ -54,6 +54,7 @@ describe('mat-table:e2e', () => {
   it('has access to child nodes', () => {
     MockRender(TargetComponent);
     // looking for the table and container
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const tableEl = ngMocks.find('[mat-table]');
     const containerEl = ngMocks.reveal(['matColumnDef', 'position']);
 

--- a/tests-e2e/src/ng-select/test.spec.ts
+++ b/tests-e2e/src/ng-select/test.spec.ts
@@ -65,6 +65,7 @@ describe('ng-select:props', () => {
       MockRender(TargetComponent).point.componentInstance;
 
     // Looking for a debug element of the ng-select.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const ngSelectEl = ngMocks.find('ng-select');
 
     // Asserting bound properties.
@@ -87,6 +88,7 @@ describe('ng-select:props', () => {
       MockRender(TargetComponent).point.componentInstance;
 
     // Looking for a debug element of the ng-select.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const ngSelectEl = ngMocks.find('ng-select');
 
     // Simulating an emit.
@@ -101,6 +103,7 @@ describe('ng-select:props', () => {
     MockRender(TargetComponent);
 
     // Looking for a debug element of the ng-select.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const ngSelectEl = ngMocks.find('ng-select');
 
     // Looking for the ng-label-tmp template
@@ -131,6 +134,7 @@ describe('ng-select:props', () => {
     MockRender(TargetComponent);
 
     // Looking for a debug element of the ng-select.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const ngSelectEl = ngMocks.find('ng-select');
 
     // Looking for the ng-optgroup-tmp template
@@ -167,6 +171,7 @@ describe('ng-select:props', () => {
     MockRender(TargetComponent);
 
     // Looking for a debug element of the ng-select.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const ngSelectEl = ngMocks.find('ng-select');
 
     // Looking for the ng-option-tmp template

--- a/tests-e2e/src/p-calendar/test.spec.ts
+++ b/tests-e2e/src/p-calendar/test.spec.ts
@@ -36,6 +36,7 @@ describe('p-datepicker:directives', () => {
       MockRender(TargetComponent).point.componentInstance;
 
     // Looking for a debug element of `p-datepicker`.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const calendarEl = ngMocks.find('p-datepicker');
 
     // Asserting bound properties.
@@ -49,6 +50,7 @@ describe('p-datepicker:directives', () => {
       MockRender(TargetComponent).point.componentInstance;
 
     // Looking for a debug element of `p-datepicker`.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const calendarEl = ngMocks.find('p-datepicker');
 
     // Simulating an emit.
@@ -64,6 +66,7 @@ describe('p-datepicker:directives', () => {
     MockRender(TargetComponent);
 
     // Looking for a debug element of `p-datepicker`.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const calendarEl = ngMocks.find('p-datepicker');
 
     // Looking for the template of 'header'.
@@ -85,6 +88,7 @@ describe('p-datepicker:directives', () => {
     MockRender(TargetComponent);
 
     // Looking for a debug element of `p-datepicker`.
+    // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
     const calendarEl = ngMocks.find('p-datepicker');
 
     // Looking for the template of 'footer'.


### PR DESCRIPTION
## What

- Align release `prepareCmd` with the CI lint target by excluding only the generated/versioned `e2e/` matrix.
- Chain release prepare commands with `&&` so a failed lint, typecheck, or build step cannot be masked by a later successful command.
- Set `platform: linux/amd64` for the `a6` compose service, matching the other Puppeteer/Chrome services.
- Annotate the existing `tests-e2e` `ngMocks.find` calls that `eslint-plugin-es-x` was mistaking for `Array.prototype.find`.

## Why

The release command previously ran multiple shell lines without fail-fast chaining, so eslint errors could be printed while the overall prepare step still succeeded. CircleCI also ignored `tests-e2e/`, which kept those files out of the main lint gate.

`tests-e2e` should be included in both CI and release lint because those files are part of the repo's maintained test surface. The versioned/generated `e2e/` matrix remains excluded from the shared lint command because it is maintained through the separate spread/matrix workflow.

## Validation

- `npx commitlint -V --from=HEAD~1 --to=HEAD`
- Parsed `.releaserc.yml` and ran the prepare command; before the `ngMocks.find` annotations, it exited `1` at `npm run lint -- --ignore-pattern e2e/` with the expected `tests-e2e` errors.
- `COMPOSE_PROJECT_NAME=ngmocks_eslint_exit_0527 docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/`
- Temporary `tests-e2e` real-file probe confirmed a real `Array.prototype.find` call is still rejected by eslint.
- `COMPOSE_PROJECT_NAME=ngmocks_eslint_exit_0527 docker compose run --rm ng-mocks npm run prettier:repo`
- `COMPOSE_PROJECT_NAME=ngmocks_eslint_exit_0527 sh test.sh root` - 1668 specs passed.
- `COMPOSE_PROJECT_NAME=ngmocks_eslint_exit_0527 sh compose.sh e2e`
- `COMPOSE_PROJECT_NAME=ngmocks_eslint_exit_0527 sh test.sh e2e` - 1075 specs passed.
- Verified every compose service has `platform: linux/amd64`.