### PR TITLE
ci: fix puppeteer cache extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   lockindex:
     type: string
-    default: '1'
+    default: '2'
 
 orbs:
   windows: circleci/windows@5.1.1
@@ -132,6 +132,18 @@ commands:
           at: dist
       - restore_cache:
           key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
+      - run:
+          name: Fix Puppeteer browser cache
+          command: |
+            if [ -d "$HOME/.cache/puppeteer" ]; then
+              find "$HOME/.cache/puppeteer" -type f -name '*.zip' | while IFS= read -r zip; do
+                cache_dir="${zip%/*}"
+                browser_name="${cache_dir##*/}"
+                archive_name="${zip##*/}"
+                build_id="${archive_name%-${browser_name}-linux64.zip}"
+                unzip -qo "$zip" -d "$cache_dir/linux-${build_id}" && rm -f "$zip"
+              done
+            fi
       - run:
           name: Spreading Build
           command: npm run s:<< parameters.dir >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   lockindex:
     type: string
-    default: '2'
+    default: '3'
 
 orbs:
   windows: circleci/windows@5.1.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,18 @@ commands:
             fi
             md5sum -c package.md5
             rm package.md5
+      - run:
+          name: Fix Puppeteer browser cache
+          command: |
+            if [ -d "$HOME/.cache/puppeteer" ]; then
+              find "$HOME/.cache/puppeteer" -type f -name '*.zip' | while IFS= read -r zip; do
+                cache_dir="${zip%/*}"
+                browser_name="${cache_dir##*/}"
+                archive_name="${zip##*/}"
+                build_id="${archive_name%-${browser_name}-linux64.zip}"
+                unzip -qo "$zip" -d "$cache_dir/linux-${build_id}" && rm -f "$zip"
+              done
+            fi
       - save_cache:
           key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
           paths:
@@ -132,18 +144,6 @@ commands:
           at: dist
       - restore_cache:
           key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
-      - run:
-          name: Fix Puppeteer browser cache
-          command: |
-            if [ -d "$HOME/.cache/puppeteer" ]; then
-              find "$HOME/.cache/puppeteer" -type f -name '*.zip' | while IFS= read -r zip; do
-                cache_dir="${zip%/*}"
-                browser_name="${cache_dir##*/}"
-                archive_name="${zip##*/}"
-                build_id="${archive_name%-${browser_name}-linux64.zip}"
-                unzip -qo "$zip" -d "$cache_dir/linux-${build_id}" && rm -f "$zip"
-              done
-            fi
       - run:
           name: Spreading Build
           command: npm run s:<< parameters.dir >>


### PR DESCRIPTION
## Summary

- Bump the CircleCI cache version from `1` to `2` so e2e jobs rebuild their immutable caches.
- Repair Puppeteer browser caches during the install job by extracting leftover browser zip files and deleting each zip only after a successful extraction.

## Why

`node:24.16.0` can leave Puppeteer's downloaded Chrome archive partially extracted in `~/.cache/puppeteer`. The install job now repairs that cache before CircleCI saves it, so test jobs restore a cache with the expected Chrome binary already present.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml")'`\n- `git diff --check`\n- local shell extraction test against a temp fake Puppeteer cache\n- pre-commit hooks: lint-staged, `npm run lint`, `npm run ts:check`\n- pre-push hook: Karma root test suite, 1680 specs passing