### PR TITLE
[codex] migrate CircleCI Docker executors to gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,79 +12,79 @@ executors:
   core:
     docker:
       - image: satantime/puppeteer-node:24.16.0
-    resource_class: medium
+    resource_class: medium.gen2
   a5:
     docker:
       - image: satantime/puppeteer-node:8.17.0
-    resource_class: medium
+    resource_class: medium.gen2
   a6:
     docker:
       - image: satantime/puppeteer-node:8.17.0
-    resource_class: medium
+    resource_class: medium.gen2
   a7:
     docker:
       - image: satantime/puppeteer-node:8.17.0
-    resource_class: medium
+    resource_class: medium.gen2
   a8:
     docker:
       - image: satantime/puppeteer-node:10.24.1
-    resource_class: medium
+    resource_class: medium.gen2
   a9:
     docker:
       - image: satantime/puppeteer-node:12.22.12
-    resource_class: medium
+    resource_class: medium.gen2
   a10:
     docker:
       - image: satantime/puppeteer-node:12.22.12
-    resource_class: medium
+    resource_class: medium.gen2
   a11:
     docker:
       - image: satantime/puppeteer-node:12.22.12
-    resource_class: medium
+    resource_class: medium.gen2
   a12:
     docker:
       - image: satantime/puppeteer-node:12.22.12
-    resource_class: medium
+    resource_class: medium.gen2
   a13:
     docker:
       - image: satantime/puppeteer-node:12.22.12
-    resource_class: medium
+    resource_class: medium.gen2
   a14:
     docker:
       - image: satantime/puppeteer-node:16.20.2
-    resource_class: medium
+    resource_class: medium.gen2
   a15:
     docker:
       - image: satantime/puppeteer-node:16.20.2
-    resource_class: medium
+    resource_class: medium.gen2
   a16:
     docker:
       - image: satantime/puppeteer-node:18.20.8
-    resource_class: medium
+    resource_class: medium.gen2
   a17:
     docker:
       - image: satantime/puppeteer-node:20.20.2
-    resource_class: medium
+    resource_class: medium.gen2
   a18:
     docker:
       - image: satantime/puppeteer-node:20.20.2
-    resource_class: medium
+    resource_class: medium.gen2
   a19:
     docker:
       - image: satantime/puppeteer-node:22.22.3
-    resource_class: medium
+    resource_class: medium.gen2
   a20:
     docker:
       - image: satantime/puppeteer-node:22.22.3
-    resource_class: medium
+    resource_class: medium.gen2
   a21:
     docker:
       - image: satantime/puppeteer-node:24.16.0
-    resource_class: medium
+    resource_class: medium.gen2
   a22:
     docker:
       - image: satantime/puppeteer-node:24.16.0
-    resource_class: medium
+    resource_class: medium.gen2
 
 commands:
   install:


### PR DESCRIPTION
## What changed

Migrates every CircleCI Docker executor in `.circleci/config.yml` from `resource_class: medium` to `resource_class: medium.gen2`.

The Windows orb job is unchanged because it does not use the Docker executor resource classes.

## Why

This lets the whole CircleCI Docker CI matrix run on CircleCI's gen2 Docker compute so the project can benchmark the real runtime and credit impact.

CircleCI currently prices `medium.gen2` higher per minute than `medium`, so this PR should be evaluated using the actual CI run duration and consumed credits before merging.

## Validation

- `git diff --check`
- Ruby YAML parse of `.circleci/config.yml`
- Confirmed no remaining `resource_class: medium` entries in `.circleci/config.yml`

CircleCI CLI validation was not run because the `circleci` CLI is not installed locally.