### PR TITLE
fix(MockRender): OnPush default for Angular >=22 #14157

### DIFF
--- a/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
+++ b/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
@@ -108,18 +108,25 @@ const handleFixtureError = (e: any) => {
 // patch new versions and leave older Angular behavior untouched.
 const shouldPatchPointDetectChanges = (): boolean => Number.parseInt(VERSION.major, 10) >= 22;
 
-// Respect explicit OnPush declarations; forcing their point CDR would hide the
+// Respect explicit OnPush declarations or no explicit ChangeDetectionStrategy with Angular >= 22; forcing their point CDR would hide the
 // very change-detection behavior a test might be asserting.
 // Covered by the Angular 22 e2e suite; root coverage runs on Angular 21.
 /* istanbul ignore next */
-const isExplicitlyOnPush = (fixture: any): boolean => {
+const isOnPush = (fixture: any): boolean => {
   const annotation = fixture.point?.componentInstance?.constructor?.__annotations__?.[0];
 
-  return (
-    annotation &&
-    Object.prototype.hasOwnProperty.call(annotation, 'changeDetection') &&
-    annotation.changeDetection === ChangeDetectionStrategy.OnPush
-  );
+  if (!annotation) {
+    return false;
+  }
+
+  const hasExplicitChangeDetection = Object.prototype.hasOwnProperty.call(annotation, 'changeDetection');
+
+  if (!hasExplicitChangeDetection) {
+    // If no ChangeDetectionStrategy is specified, OnPush is default starting with Angular 22
+    return Number.parseInt(VERSION.major, 10) >= 22;
+  }
+
+  return annotation.changeDetection === ChangeDetectionStrategy.OnPush;
 };
 
 // Token and plain-text renders do not have a child component CDR. The lookup is
@@ -130,7 +137,7 @@ const getFixturePointChangeDetectorRef = (fixture: any): undefined | ChangeDetec
   if (!shouldPatchPointDetectChanges() || !fixture.point || fixture.point === fixture.debugElement) {
     return undefined;
   }
-  if (isExplicitlyOnPush(fixture)) {
+  if (isOnPush(fixture)) {
     return undefined;
   }
   try {

--- a/tests/issue-14157/test.spec.ts
+++ b/tests/issue-14157/test.spec.ts
@@ -1,0 +1,52 @@
+import { Component, Input, VERSION } from '@angular/core';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target-14157',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class TargetComponent {
+  @Input() public items: string[] = [];
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14157
+// Angular 22 treats OnPush as the default when `changeDetection` is not set.
+// MockRender should not force the rendered point to run change detection as if
+// it were CheckAlways in that case.
+describe('issue-14157', () => {
+  if (Number.parseInt(VERSION.major, 10) < 22) {
+    it('needs a22+', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder(TargetComponent));
+
+  it('respects the default OnPush change detection', () => {
+    const parameters: { items: string[] } = {
+      items: [],
+    };
+    const fixture = MockRender(TargetComponent, parameters);
+
+    fixture.componentInstance.items.push('demo');
+    fixture.detectChanges();
+
+    expect(fixture.point.nativeElement.innerHTML).toEqual('0');
+  });
+
+  it('updates when the input reference changes', () => {
+    const parameters: { items: string[] } = {
+      items: [],
+    };
+    const fixture = MockRender(TargetComponent, parameters);
+
+    fixture.componentInstance.items = ['demo'];
+    fixture.detectChanges();
+
+    expect(fixture.point.nativeElement.innerHTML).toEqual('1');
+  });
+});


### PR DESCRIPTION
### Summary

- Adapt mock-render-factory.ts to use OnPush change detection codepath if no strategy is explicitly defined when running on Angular >= 22
- Add test to check behaviour for that case
- Fixes #14157 