### PR TITLE
Security: Potential Prototype Pollution via Object Spread in nxPreset

### DIFF
--- a/e2e/nx/jest.preset.js
+++ b/e2e/nx/jest.preset.js
@@ -1,3 +1,3 @@
 const nxPreset = require('@nx/jest/preset').default;
 
-module.exports = { ...nxPreset };
+module.exports = Object.assign(Object.create(null), nxPreset);


### PR DESCRIPTION
## Summary

Security: Potential Prototype Pollution via Object Spread in nxPreset

## Problem

**Severity**: `Low` | **File**: `e2e/nx/jest.preset.js:L3`

The jest.preset.js spreads properties from `@nx/jest/preset` using object spread syntax. While not directly exploitable in this context, object spread on untrusted objects can lead to prototype pollution if the source object has malicious properties. This is a low-risk pattern in this specific file but worth noting for defense in depth.

## Solution

Consider using `Object.create(null)` or explicitly checking for own properties when spreading objects from external modules. In this specific test configuration context, the risk is minimal.

## Changes

- `e2e/nx/jest.preset.js` (modified)