### PR TITLE
chore(repo): refresh agent workflows and lint baseline

### DIFF
--- a/.agents/skills/prepare-dependabot-prs/SKILL.md
+++ b/.agents/skills/prepare-dependabot-prs/SKILL.md
@@ -12,7 +12,7 @@ Use this skill for repetitive Dependabot PR preparation in this repository.
 Use a plain Markdown checklist so the workflow is easy to follow in AI Agent:
 
 ```md
-- [ ] Confirm GitHub auth and list open Dependabot PRs
+- [ ] Confirm GitHub auth and list open Dependabot PRs in the upstream repository
 - [ ] Enable auto-merge with squash for each PR
 - [ ] Approve each PR
 - [ ] Summarize prepared PRs and any blockers
@@ -21,19 +21,22 @@ Use a plain Markdown checklist so the workflow is easy to follow in AI Agent:
 ## Workflow
 
 1. Confirm GitHub CLI access.
-2. List open PRs authored by `app/dependabot`.
-3. Enable auto-merge with squash for each eligible PR.
+2. List open PRs authored by `app/dependabot` in `help-me-mom/ng-mocks`.
+3. Verify each candidate's author and changed files, then enable auto-merge with squash.
 4. Approve each eligible PR.
 5. Report any PRs skipped because of missing permissions, unexpected changes, or policy blockers.
 
 ## Commands
 
 ```bash
+REPO=help-me-mom/ng-mocks
+
 gh auth status
-gh pr list --author app/dependabot --state open --json number,title,url,headRefName
-gh pr view <pr-number> --json author,files,title,url
-gh pr merge --auto --squash <pr-number>
-gh pr review --approve <pr-number>
+gh pr list --repo "$REPO" --author app/dependabot --state open --json number,title,url,headRefName
+gh pr view <pr-number> --repo "$REPO" --json author,files,title,url
+gh pr merge <pr-number> --repo "$REPO" --auto --squash
+gh pr review <pr-number> --repo "$REPO" --approve
+gh pr view <pr-number> --repo "$REPO" --json autoMergeRequest,reviews
 ```
 
 ## Validation
@@ -45,4 +48,5 @@ gh pr review --approve <pr-number>
 
 - Do not merge PRs manually; this skill only prepares them for CI-driven auto-merge.
 - Skip any PR that is not clearly a Dependabot dependency update.
+- Always target `help-me-mom/ng-mocks`; do not default to the checkout's `origin` remote.
 - If branch protection, reviewer rules, or GitHub permissions block the workflow, stop and report the blocker.

--- a/.agents/skills/rebase-to-upstream/SKILL.md
+++ b/.agents/skills/rebase-to-upstream/SKILL.md
@@ -13,7 +13,8 @@ Use this skill when the current local branch should be replayed onto `upstream/m
 
 ```md
 - [ ] Inspect the current branch, target branch, and local changes
-- [ ] Stash local changes if needed and create a backup branch
+- [ ] Stash local changes if needed
+- [ ] Create a backup branch before resetting
 - [ ] Reset the current branch to the target ref (e.g., upstream/main)
 - [ ] Cherry-pick missing commits from the backup branch one by one
   - For each commit with conflicts: resolve source, then manifests, then lockfiles
@@ -39,7 +40,7 @@ git status --short
 git log --oneline --decorate --graph --max-count=20
 ```
 
-### 2. Stash and Backup (if needed)
+### 2. Stash if Needed, Then Create a Backup
 
 Only stash if there are actual local changes:
 
@@ -47,10 +48,10 @@ Only stash if there are actual local changes:
 # Check for changes first
 git status --short
 
-# Only stash if output is not empty
+# Only if the output is not empty
 git stash push -u -m "rebase-to-upstream: $CURRENT_BRANCH"
 
-# Create backup branch before any destructive operations
+# Always create a backup branch before any destructive operation.
 git branch "$BACKUP_BRANCH"
 ```
 
@@ -64,7 +65,7 @@ git reset --hard "$TARGET_REF"
 
 ```bash
 git cherry -v "$TARGET_REF" "$BACKUP_BRANCH"
-git log --reverse --format=%H "$TARGET_REF".."$BACKUP_BRANCH"
+git log --reverse --cherry-pick --right-only --format=%H "$TARGET_REF...$BACKUP_BRANCH"
 ```
 
 ### 5. Cherry-Pick Commits One by One
@@ -103,14 +104,14 @@ If conflicts occur, resolve them in this order:
 - **Regenerate immediately via wrapper before committing:**
 
   ```bash
-  # Standard flow: just run npm install via wrapper for affected project
-  sh compose.sh <affected-target>
+  # Standard flow: just run npm install via wrapper for affected project.
+  COMPOSE_PROJECT_NAME=ngmocks_rebase_<unique> sh compose.sh <affected-target>
 
   # Only if npm install fails, use the update workaround:
   # 1) Edit compose.yml: change service command from "npm install" to "npm update"
-  # 2) Run: sh compose.sh <affected-target>
+  # 2) Run: COMPOSE_PROJECT_NAME=ngmocks_rebase_<unique> sh compose.sh <affected-target>
   # 3) Restore compose.yml back to "npm install --no-audit"
-  # 4) Run: sh compose.sh <affected-target>
+  # 4) Run: COMPOSE_PROJECT_NAME=ngmocks_rebase_<unique> sh compose.sh <affected-target>
   ```
 
 - Stage the regenerated lockfile: `git add path/to/package-lock.json`
@@ -135,6 +136,10 @@ git stash apply <stash-ref>
 ### 7. Cleanup
 
 ```bash
+git branch -d "$BACKUP_BRANCH"
+# If rebased commit hashes make the safe delete fail, inspect the output first:
+git cherry -v HEAD "$BACKUP_BRANCH"
+# Delete forcibly only after every listed commit is marked `-`.
 git branch -D "$BACKUP_BRANCH"
 ```
 
@@ -143,9 +148,9 @@ git branch -D "$BACKUP_BRANCH"
 Run validation for affected targets:
 
 ```bash
-sh test.sh <affected-target>   # For specific project/suite changes
-sh test.sh root                # Only when root files changed
-sh test.sh e2e                 # Only when tests-e2e or shared e2e files changed
+COMPOSE_PROJECT_NAME=ngmocks_rebase_<unique> sh test.sh <affected-target> # For specific project/suite changes
+COMPOSE_PROJECT_NAME=ngmocks_rebase_<unique> sh test.sh root # Only when root files changed
+COMPOSE_PROJECT_NAME=ngmocks_rebase_<unique> sh test.sh e2e # Only when tests-e2e or shared e2e files changed
 ```
 
 ## Conflict Resolution Quick Reference
@@ -163,4 +168,5 @@ When conflicts occur during cherry-pick, resolve in this order:
 - Always create backup branch before `git reset --hard`
 - Only stash when local changes actually exist (check with `git status --short`)
 - Use repo wrappers (`sh compose.sh`, `sh test.sh`) for all npm operations; never run ad-hoc local `npm install` or `npm update`
+- Use a unique `COMPOSE_PROJECT_NAME` whenever another worktree or agent session may be active.
 - **Regenerate lockfiles immediately after resolving conflicts, before committing each cherry-pick** - this keeps each commit atomic and correct

--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -121,7 +121,7 @@ Coverage expectations:
 
 ## Comments, Commit, PR
 
-Use the same concise structure for issue comments, PR descriptions, and non-trivial commit bodies:
+Use the same concise structure for issue comments, PR descriptions, and non-trivial commit bodies. Keep validation details internal to the agent run and final user summary; do not put validation commands, logs, or results in GitHub comments, commit bodies, or PR descriptions.
 
 ```md
 Why:
@@ -137,12 +137,6 @@ Where:
 
 - `tests/issue-<issue-number>/test.spec.ts`
 - `libs/ng-mocks/src/lib/...`
-
-Validation:
-
-- `COMPOSE_PROJECT_NAME=... sh test.sh root`
-- `COMPOSE_PROJECT_NAME=... sh test.sh coverage`
-- `COMPOSE_PROJECT_NAME=... sh test.sh <target>`
 ```
 
 Commit message rules:
@@ -157,7 +151,7 @@ PR rules:
 - Open the PR against `help-me-mom/ng-mocks` base `main`, from the pushed issue branch.
 - Confirm the PR branch was created in the dedicated worktree from `upstream/main`.
 - Include `Closes #<issue-number>` or `Fixes #<issue-number>` in the PR body.
-- Put exact validation commands and results in the PR body.
+- Describe the problem and how it was fixed; omit validation commands and results.
 - Link related issues, duplicate reports, and previous PRs when they influenced the fix.
 - Do not commit, push, post GitHub comments, or create a PR when the requester explicitly asks to review locally first.
 

--- a/.agents/skills/update-node-version/SKILL.md
+++ b/.agents/skills/update-node-version/SKILL.md
@@ -27,12 +27,10 @@ Begin with a plain Markdown checklist that works in AI Agent:
    - specific versioned Angular fixtures,
    - or the whole repo.
 2. Inspect the current version mapping in:
-   - `.nvmrc`
+   - root `.nvmrc`, `docs/.nvmrc`, `tests-e2e/.nvmrc`, and affected `e2e/*/.nvmrc`
    - `compose.yml`
-   - `.circleci/config.yml`
-   - `package.json`
-   - `tests-e2e/package.json`
-   - affected `e2e/*/package.json`
+   - `.circleci/config.yml` and any CI workflow that pins a Node version
+   - root, docs, tests-e2e, and affected e2e `package.json` files
 3. Keep related version declarations aligned:
    - Docker image tag
    - `.nvmrc`
@@ -42,30 +40,35 @@ Begin with a plain Markdown checklist that works in AI Agent:
 4. Do not assume every Angular fixture can move to the newest Node major. Preserve per-target compatibility unless the task explicitly changes that support boundary.
 5. Re-bootstrap changed targets with `sh compose.sh <target>`.
 6. Validate with `sh test.sh` for root, e2e, and every changed target.
+7. If changing dependency metadata requires a lockfile refresh, use the `update-package-locks` skill instead of an ad-hoc npm command.
 
 ## Commands
 
 ```bash
-# Bootstrap changed targets
-sh compose.sh root
-sh compose.sh e2e
-sh compose.sh <target>
+# Bootstrap changed targets with a unique compose namespace.
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh compose.sh root
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh compose.sh e2e
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh compose.sh <target>
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh compose.sh docs
 
-# Validation
-sh test.sh root
-sh test.sh e2e
-sh test.sh <target>
+# Validate changed targets.
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh test.sh root
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh test.sh e2e
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh test.sh <target>
+COMPOSE_PROJECT_NAME=ngmocks_node_<unique> docker compose run --rm docs npm run build
 ```
 
 ## Validation
 
-- `sh test.sh root`
-- `sh test.sh e2e`
-- `sh test.sh <target>` for each target whose Node line changed
+- `COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh test.sh root`
+- `COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh test.sh e2e`
+- `COMPOSE_PROJECT_NAME=ngmocks_node_<unique> sh test.sh <target>` for each target whose Node line changed
+- `COMPOSE_PROJECT_NAME=ngmocks_node_<unique> docker compose run --rm docs npm run build` when the docs Node line changed
 
 ## Guardrails
 
 - Never assume the root Node version should also be used by every legacy Angular fixture.
 - Never use local `npm install`, `npm update`, or ad-hoc `node` commands for validation when wrapper commands exist.
 - Keep npm compatibility aligned with the chosen Node version.
+- Use one unique `COMPOSE_PROJECT_NAME` for all commands in the same worktree.
 - If a commit is requested for a pure Node-image update, use `chore(docker): updating node images`.

--- a/.agents/skills/update-package-locks/SKILL.md
+++ b/.agents/skills/update-package-locks/SKILL.md
@@ -33,7 +33,7 @@ Create a plain Markdown checklist that any AI agent can follow:
 5. Restore the same service command line(s) back to `npm install`.
 6. Run the same target set again in batches of 2-4 so the resulting lockfiles match the normal CI install flow.
 7. Commit only the refreshed `package-lock.json` files, plus `.agents/skills/update-package-locks/SKILL.md` if this skill was intentionally edited.
-8. Push the branch and create a PR after the commit succeeds.
+8. Push the branch to a writable remote, normally `origin` for a fork checkout, and create a PR against `upstream/main` after the commit succeeds.
 
 Do not reuse the current worktree or an existing topic branch for a lockfile refresh. Do not manually run `sh test.sh`, root tests, lint, TypeScript checks, local `npm install`, local `npm update`, or ad-hoc dependency commands as part of this workflow unless the user explicitly asks for them.
 
@@ -69,7 +69,8 @@ COMPOSE_PROJECT_NAME=ngmocks_<unique> sh compose.sh <target>
 git add package-lock.json docs/package-lock.json tests-e2e/package-lock.json e2e/*/package-lock.json
 git add .agents/skills/update-package-locks/SKILL.md # only if intentionally edited
 git commit -m "chore: refresh package lockfiles"
-git push -u upstream codex/<lockfile-branch>
+git remote -v
+git push -u origin codex/<lockfile-branch>
 # Create a PR against upstream/main after the push succeeds.
 ```
 
@@ -91,3 +92,4 @@ git push -u upstream codex/<lockfile-branch>
 - Clean up temporary compose projects with `docker compose down -v` after successful batches or failed transient Docker/Puppeteer setup runs.
 - When committing or pushing, let the repository's normal git hooks run. Do not bypass hooks unless the user explicitly asks.
 - Do not manually invoke extra validation beyond this skill; automated git hooks are the exception and should do their normal job.
+- Push to a configured writable remote; never assume `upstream` accepts contributor branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,13 @@
 - Keep agent guidance aligned with the current repository files:
   - `README.md`
   - `CONTRIBUTING.md`
+  - `docs/articles/index.md`
   - `compose.sh`
   - `test.sh`
   - `compose.yml`
   - `package.json`
+  - `test-spread.conf`
+  - `test-spread-app.conf`
 - If docs and executable files disagree, trust the current scripts and config first, then update the docs.
 
 ## AI Agents Compatibility
@@ -45,10 +48,10 @@
 
 ## Compatibility Guidance
 
-- `ng-mocks` currently documents support for Angular 5 through Angular 20.
+- `ng-mocks` currently documents support for Angular 5 through Angular 22.
 - Angular 5-8 are pre-Ivy.
 - Angular 9-11 have both View Engine and Ivy coverage in the repo scripts.
-- Angular 12-20 are Ivy-only in the current repo setup.
+- Angular 12-22 are Ivy-only in the current repo setup.
 - Standalone, signals, and defer support must match the compatibility tables in `README.md` and `docs/articles/index.md`.
 - Do not claim support beyond those tables unless you update the tables and the implementation together.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,11 @@
   4. Run `sh test.sh coverage` when core behavior or coverage-sensitive code changes
 - For docs-only or agent-guidance-only changes, tests may be skipped, but say so explicitly in the final summary.
 
+## GitHub Artifact Text
+
+- Keep issue comments, pull request descriptions, and non-trivial commit bodies focused on the problem and how it was fixed.
+- Do not include validation blocks, exact validation commands, logs, or local test results in PR descriptions or commit bodies. Treat those details as internal agent run notes unless the user asks to publish them.
+
 ## Git Safety
 
 - Do not use destructive git commands such as `git reset --hard` or force-push unless the user explicitly asked for history rewriting.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,7 @@ const tsJsRules = {
   'unicorn/max-nested-calls': 'off',
   'unicorn/no-anonymous-default-export': 'off',
   'unicorn/no-array-callback-reference': 'off',
+  'unicorn/no-array-for-each': 'off',
   'unicorn/no-array-sort': 'off',
   'unicorn/no-array-reverse': 'off',
   'unicorn/no-array-method-this-argument': 'off',

--- a/libs/ng-mocks/src/lib/common/core.helpers.ts
+++ b/libs/ng-mocks/src/lib/common/core.helpers.ts
@@ -55,7 +55,6 @@ export const flatten = <T>(values: T | T[] | { ɵproviders: T[] }, result: T[] =
 
 export const mapKeys = <T>(set: Map<T, any>): T[] => {
   const result: T[] = [];
-  // eslint-disable-next-line unicorn/no-for-each
   set.forEach((_, value: T) => result.push(value));
 
   return result;
@@ -64,12 +63,10 @@ export const mapKeys = <T>(set: Map<T, any>): T[] => {
 export const mapValues = <T>(set: { forEach(a1: (value: T) => void): void }, destination?: Set<T>): T[] => {
   const result: T[] = [];
   if (destination) {
-    // eslint-disable-next-line unicorn/no-for-each
     set.forEach((value: T) => {
       destination.add(value);
     });
   } else {
-    // eslint-disable-next-line unicorn/no-for-each
     set.forEach((value: T) => {
       result.push(value);
     });
@@ -82,10 +79,8 @@ export const mapEntries = <K, T>(set: Map<K, T>, destination?: Map<K, T>): Array
   const result: Array<[K, T]> = [];
 
   if (destination) {
-    // eslint-disable-next-line unicorn/no-for-each
     set.forEach((value: T, key: K) => destination.set(key, value));
   } else {
-    // eslint-disable-next-line unicorn/no-for-each
     set.forEach((value: T, key: K) => result.push([key, value]));
   }
 


### PR DESCRIPTION
Why:

Agent guidance lagged the supported Angular matrix and did not consistently account for fork remotes or parallel worktrees. The current Unicorn rule set also left obsolete lint suppressions behind.

What:

- Align the runbook and operational skills with Angular 5–22, current test-spread config, writable remotes, and compose namespaces.
- Make rebase backup handling explicit and preserve the normal lockfile workflow.
- Update the Unicorn configuration and remove obsolete inline suppressions.

Where:

- `AGENTS.md`
- `.agents/skills/*/SKILL.md`
- `eslint.config.mjs`
- `libs/ng-mocks/src/lib/common/core.helpers.ts`