### PR TITLE
chore(ci): avoid irrelevant tool warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ commands:
                 unzip -qo "$zip" -d "$cache_dir/linux-${build_id}" && rm -f "$zip"
               done
             fi
+            mkdir -p "$HOME/.cache/puppeteer"
       - save_cache:
           key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
           paths:
@@ -251,7 +252,7 @@ jobs:
             chmod +x codecov
       - run:
           name: Collecting https://codecov.io/gh/help-me-mom/ng-mocks
-          command: ./codecov upload-process -C "$CIRCLE_SHA1" -f test-reports/coverage/lcov.info --disable-search -Z
+          command: ./codecov upload-process -C "$CIRCLE_SHA1" -f test-reports/coverage/lcov.info --disable-search --plugin noop -Z
   E2E:
     executor: core
     steps:


### PR DESCRIPTION
Suppress Codecov probes for coverage tools this repository does not use, and ensure the Puppeteer cache path exists before CircleCI attempts to archive it. This keeps the pipeline warning output focused on actionable project issues.