### PR TITLE
chore(root): remove TypeScript 5 alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
         "ts-node": "10.9.2",
         "tsconfig-paths-webpack-plugin": "4.2.0",
         "typescript": "6.0.3",
-        "typescript5": "npm:typescript@5.9.3",
         "webpack": "5.107.2",
         "webpack-cli": "7.2.1",
         "zone.js": "0.16.2"
@@ -15896,21 +15895,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript5": {
-      "name": "typescript",
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -295,7 +295,6 @@
     "ts-node": "10.9.2",
     "tsconfig-paths-webpack-plugin": "4.2.0",
     "typescript": "6.0.3",
-    "typescript5": "npm:typescript@5.9.3",
     "webpack": "5.107.2",
     "webpack-cli": "7.2.1",
     "zone.js": "0.16.2"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,9 +30,9 @@ module.exports = [
             {
               loader: 'ts-loader',
               options: {
-                compiler: 'typescript5',
                 compilerOptions: {
                   downlevelIteration: true,
+                  ignoreDeprecations: '6.0',
                 },
                 configFile: path.resolve(__dirname, './libs/ng-mocks/tsconfig.json'),
                 transpileOnly: true,


### PR DESCRIPTION
## Summary

- remove the root `typescript5` npm alias
- let `ts-loader` use the root TypeScript 6 compiler
- silence TypeScript 6 deprecation diagnostics while preserving the legacy ES5 bundle

## Why

The second compiler existed only to avoid TypeScript 6 errors for deprecated ES5 build options. TypeScript 6 can still produce the bundle with `ignoreDeprecations: "6.0"`, so keeping a duplicate compiler dependency—and the odd automated updates it creates—is unnecessary.