### PR TITLE
docs: clarify dependency maintenance guidance

### DIFF
--- a/.agents/skills/update-package-locks/SKILL.md
+++ b/.agents/skills/update-package-locks/SKILL.md
@@ -5,7 +5,7 @@ description: Use when refreshing package-lock.json files in ng-mocks.
 
 # Update Package Locks
 
-Use this skill when the task is to refresh lockfiles without permanently changing the repo's normal install flow.
+Use this skill for a fresh lockfile refresh or to regenerate a lockfile while resolving an existing dependency PR conflict, without permanently changing the repo's normal install flow.
 
 This workflow is intentionally narrow. Follow the sequence exactly. Do not manually add tests, lint, local npm commands, rebases, or unrelated cleanup unless the user explicitly asks for them.
 
@@ -14,28 +14,32 @@ This workflow is intentionally narrow. Follow the sequence exactly. Do not manua
 Create a plain Markdown checklist that any AI agent can follow:
 
 ```md
-- [ ] Create a new branch and worktree from `upstream/main`
+- [ ] Identify whether this is a fresh refresh or an existing dependency PR conflict
+- [ ] Create an isolated worktree from `upstream/main` or the existing PR branch
+- [ ] For a PR conflict, merge `upstream/main` and keep the dependency PR's lockfile side as the regeneration base
 - [ ] Temporarily change the relevant `compose.yml` service command line(s) from `npm install` to `npm update`
 - [ ] Run the update wrapper pass with wrapper targets in batches of 2-4
 - [ ] Restore `compose.yml` back to `npm install`
 - [ ] Run the install wrapper pass with wrapper targets in batches of 2-4
-- [ ] Commit only the refreshed lockfiles, plus this skill if it was intentionally edited
-- [ ] Push the branch and create a PR after the commit succeeds
+- [ ] Commit the refreshed lockfiles with only the dependency or merge changes already in scope
+- [ ] Push a fresh branch and create a PR, or push the existing PR branch
 - [ ] Summarize the two wrapper passes and any npm warnings
 ```
 
 ## Workflow
 
-1. Fetch the current base and create a fresh branch in a fresh worktree from `upstream/main`.
+1. Work in an isolated worktree:
+   - For a fresh refresh, fetch the current base and create a new branch from `upstream/main`.
+   - For an existing dependency PR conflict, fetch that PR branch into an isolated worktree, merge `upstream/main` without rewriting history, and keep the dependency PR's lockfile side as the regeneration base.
 2. In that new worktree, inspect `compose.yml`.
 3. Temporarily change only the affected `compose.yml` service command line(s) from `npm install` to `npm update`.
 4. For a repo-wide refresh, derive the current wrapper targets from `compose.sh` and `compose.yml`, then run them in batches of 2-4 concurrent commands. If the user explicitly named one target, run only that target.
 5. Restore the same service command line(s) back to `npm install`.
 6. Run the same target set again in batches of 2-4 so the resulting lockfiles match the normal CI install flow.
-7. Commit only the refreshed `package-lock.json` files, plus `.agents/skills/update-package-locks/SKILL.md` if this skill was intentionally edited.
-8. Push the branch to a writable remote, normally `origin` for a fork checkout, and create a PR against `upstream/main` after the commit succeeds.
+7. Commit the refreshed `package-lock.json` files with only the dependency or merge changes already in scope, plus `.agents/skills/update-package-locks/SKILL.md` if this skill was intentionally edited.
+8. For a fresh refresh, push the branch to a writable remote and create a PR against `upstream/main`. For an existing dependency PR, push back to that PR branch.
 
-Do not reuse the current worktree or an existing topic branch for a lockfile refresh. Do not manually run `sh test.sh`, root tests, lint, TypeScript checks, local `npm install`, local `npm update`, or ad-hoc dependency commands as part of this workflow unless the user explicitly asks for them.
+Do not use the current active worktree. A fresh refresh needs a new branch; an existing dependency PR conflict stays on its PR branch in an isolated worktree. Do not manually run `sh test.sh`, root tests, lint, TypeScript checks, local `npm install`, local `npm update`, or ad-hoc dependency commands as part of this workflow unless the user explicitly asks for them.
 
 For a repo-wide refresh, the affected command lines are all service command entries in `compose.yml` that currently read `- install`. Change only those entries to `- update`, run the wrapper, then change those same entries back to `- install`. Do not edit `package.json`, shell scripts, or lockfiles by hand.
 
@@ -55,6 +59,12 @@ COMPOSE_PROJECT_NAME=ngmocks_<unique> sh compose.sh <target>
 # Start from upstream/main in a new worktree.
 git fetch upstream main
 git worktree add -b codex/<lockfile-branch> ../<lockfile-worktree> upstream/main
+
+# Resolve an existing dependency PR without rewriting its history.
+git fetch upstream main <pr-branch>
+git worktree add ../<pr-worktree> <pr-branch>
+git merge --no-edit upstream/main
+git checkout --ours path/to/package-lock.json # PR side when merging main into the PR branch
 
 # Repo-wide lockfile refresh.
 # Edit compose.yml to npm update, run current wrapper targets in batches of 2-4, then restore npm install and repeat the same batches.
@@ -84,8 +94,9 @@ git push -u origin codex/<lockfile-branch>
 
 ## Guardrails
 
-- Always start from a new branch and worktree based on current `upstream/main`.
+- Always use an isolated worktree: a new branch from current `upstream/main` for fresh work, or the existing PR branch for conflict resolution.
 - Never delete lockfiles.
+- Never hand-merge lockfile conflict blocks or rewrite dependency PR history.
 - Never leave `compose.yml` in an `npm update` state after finishing.
 - Never use local `npm install`, `npm update`, or ad-hoc `node` commands when the wrapper flow covers the task.
 - If multiple worktrees, agent sessions, or concurrent wrapper targets are active, set a unique `COMPOSE_PROJECT_NAME` for each wrapper command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@
 - Angular 12-22 are Ivy-only in the current repo setup.
 - Standalone, signals, and defer support must match the compatibility tables in `README.md` and `docs/articles/index.md`.
 - Do not claim support beyond those tables unless you update the tables and the implementation together.
+- When enabling new recommended lint rules, keep fixes that remain compatible with the supported Angular, Node.js, and ES targets. Disable rules that require newer framework APIs or runtime features, and leave a short reason beside the override.
 
 ## Test Style
 
@@ -69,13 +70,15 @@
   - `docker compose run --rm ng-mocks npm run ts:check`
 - If multiple worktrees are active, prefix direct `docker compose` commands with the same `COMPOSE_PROJECT_NAME` you use for wrappers so the checks stay inside that worktree's compose project.
 - Run Prettier before `git commit`.
+- For tooling migrations, use official packages and their exported presets. Remove direct subpackages only when the official umbrella package replaces them and the repository no longer imports them.
 
 ## Lockfiles and Dependency Refresh
 
 - Keep this section short on purpose. The step-by-step workflow belongs in the repo skill `.agents/skills/update-package-locks/SKILL.md`.
 - The runbook only needs the guardrail:
   - never delete `package-lock.json` files to regenerate them
-  - for lockfile conflicts, do not hand-merge the conflict block; reject the remote lockfile side for the affected project, then run the wrapper-based update flow and the normal wrapper-based install flow for that same target
+  - for lockfile conflicts, do not hand-merge the conflict block; keep the dependency PR's lockfile side as the regeneration base, then run the wrapper-based update and install passes for that target
+  - resolve an existing dependency PR in an isolated worktree on that PR branch and push the result back to the same PR without rewriting history
   - use the lockfile skill when a refresh is actually required
   - if multiple worktrees are active, use a unique `COMPOSE_PROJECT_NAME`
 


### PR DESCRIPTION
Updates the internal agent guidance based on the Angular ESLint 22 migration and subsequent dependency-PR conflict resolution.

- Records the Angular 5+/older-runtime compatibility boundary for new lint rules.
- Requires official tooling packages and exported presets while removing replaced direct dependencies.
- Distinguishes fresh lockfile refreshes from resolving an existing dependency PR in place without rewriting history.

This does not change runtime behavior or public documentation.