### PR TITLE
build: guard Dependabot major updates

### DIFF
--- a/.agents/skills/prepare-dependabot-prs/SKILL.md
+++ b/.agents/skills/prepare-dependabot-prs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-dependabot-prs
-description: Use when preparing GitHub Dependabot pull requests by listing open PRs, verifying they are authored by app/dependabot, enabling auto-merge, and approving them without merging manually.
+description: Use when preparing GitHub Dependabot pull requests by listing open PRs, verifying they are authored by app/dependabot, closing package.json major-version updates, and enabling auto-merge and approval for eligible updates without merging manually.
 ---
 
 # Prepare Dependabot PRs
@@ -13,8 +13,10 @@ Use a plain Markdown checklist so the workflow is easy to follow in AI Agent:
 
 ```md
 - [ ] Confirm GitHub auth and list open Dependabot PRs in the upstream repository
-- [ ] Enable auto-merge with squash for each PR
-- [ ] Approve each PR
+- [ ] Verify authors, changed files, and package.json version changes
+- [ ] Close every PR containing a package.json major-version change
+- [ ] Enable auto-merge with squash for each remaining eligible PR
+- [ ] Approve each remaining eligible PR
 - [ ] Summarize prepared PRs and any blockers
 ```
 
@@ -22,9 +24,12 @@ Use a plain Markdown checklist so the workflow is easy to follow in AI Agent:
 
 1. Confirm GitHub CLI access.
 2. List open PRs authored by `app/dependabot` in `help-me-mom/ng-mocks`.
-3. Verify each candidate's author and changed files, then enable auto-merge with squash.
-4. Approve each eligible PR.
-5. Report any PRs skipped because of missing permissions, unexpected changes, or policy blockers.
+3. Verify each candidate's author and changed files.
+4. Inspect every changed `package.json`. Compare the before and after versions in all dependency declarations. Treat the PR as a major-version update when any dependency's SemVer major number changes.
+5. Close each major-version update. Do not enable auto-merge or approve it.
+6. Enable auto-merge with squash for each remaining eligible PR.
+7. Approve each remaining eligible PR.
+8. Report prepared and closed PRs, plus any PRs skipped because of missing permissions, unexpected changes, ambiguous versions, or policy blockers.
 
 ## Commands
 
@@ -34,19 +39,24 @@ REPO=help-me-mom/ng-mocks
 gh auth status
 gh pr list --repo "$REPO" --author app/dependabot --state open --json number,title,url,headRefName
 gh pr view <pr-number> --repo "$REPO" --json author,files,title,url
+gh api --paginate "repos/$REPO/pulls/<pr-number>/files" --jq '.[] | select(.filename | endswith("package.json")) | {filename,patch}'
+gh pr close <pr-number> --repo "$REPO"
 gh pr merge <pr-number> --repo "$REPO" --auto --squash
 gh pr review <pr-number> --repo "$REPO" --approve
-gh pr view <pr-number> --repo "$REPO" --json autoMergeRequest,reviews
+gh pr view <pr-number> --repo "$REPO" --json state,autoMergeRequest,reviews
 ```
 
 ## Validation
 
-- Confirm each acted-on PR now shows auto-merge enabled.
-- Confirm each acted-on PR has an approval from the current reviewer.
+- Confirm every detected major-version update is closed.
+- Confirm each prepared PR shows auto-merge enabled.
+- Confirm each prepared PR has an approval from the current reviewer.
 
 ## Guardrails
 
 - Do not merge PRs manually; this skill only prepares them for CI-driven auto-merge.
 - Skip any PR that is not clearly a Dependabot dependency update.
+- Never enable auto-merge or approve a PR when any dependency changes SemVer major in a `package.json`.
+- If a changed version is ambiguous or a `package.json` patch is unavailable or truncated, do not assume eligibility; retrieve the base and head file contents or stop and report the blocker.
 - Always target `help-me-mom/ng-mocks`; do not default to the checkout's `origin` remote.
 - If branch protection, reviewer rules, or GitHub permissions block the workflow, stop and report the blocker.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /docs/
@@ -16,6 +20,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /tests-e2e/
@@ -24,6 +32,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a5es5/
@@ -32,6 +44,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a5es2015/
@@ -40,6 +56,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a6/
@@ -48,6 +68,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a7/
@@ -56,6 +80,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a8/
@@ -64,6 +92,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a9/
@@ -72,6 +104,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a10/
@@ -80,6 +116,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a11/
@@ -88,6 +128,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a12/
@@ -96,6 +140,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a13/
@@ -104,6 +152,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a14/
@@ -112,6 +164,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a15/
@@ -120,6 +176,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a16/
@@ -128,6 +188,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a17/
@@ -136,6 +200,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a18/
@@ -144,6 +212,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a19/
@@ -152,6 +224,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a20/
@@ -160,6 +236,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a21/
@@ -168,6 +248,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/a22/
@@ -176,6 +260,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/jasmine/
@@ -184,6 +272,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/jest/
@@ -192,6 +284,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/min/
@@ -200,6 +296,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: /e2e/nx/
@@ -208,6 +308,10 @@ updates:
       interval: 'daily'
     commit-message:
       prefix: 'chore(deps)'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'docker'
     directory: /


### PR DESCRIPTION
## Summary

- update the Dependabot preparation skill to detect and close `package.json` SemVer-major updates before approval or auto-merge
- configure all 26 npm update entries to ignore `version-update:semver-major`
- leave Docker update behavior unchanged

## Why

The previous workflow treated clear Dependabot dependency updates as eligible without checking whether a declared dependency crossed a major version. Grouped updates could therefore carry incompatible Angular tooling or npm upgrades into version-specific projects.

## Impact

Scheduled npm version updates will no longer propose SemVer-major upgrades. The preparation workflow remains a second guard: if a major update still reaches review through an edge case, it is closed instead of approved or queued for auto-merge.