### PR TITLE
fix(MockRender): respect implicit OnPush strategy #14157

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -288,6 +288,8 @@ export default defineConfig([
   {
     files: ['**/*.spec.ts'],
     rules: {
+      // Test fixtures may intentionally exercise eager change detection.
+      '@angular-eslint/prefer-on-push-component-change-detection': 'off',
       'max-lines': 'off',
       'max-lines-per-function': 'off',
       'no-useless-assignment': 'off',

--- a/examples/MockComponent/test.spec.ts
+++ b/examples/MockComponent/test.spec.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   ContentChild,
   EventEmitter,
@@ -30,6 +31,7 @@ class ChildComponent {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target-mock-component',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: `

--- a/examples/MockDirective-Attribute/test.spec.ts
+++ b/examples/MockDirective-Attribute/test.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   EventEmitter,
@@ -22,6 +23,7 @@ class DependencyDirective {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: `

--- a/examples/MockObservable/test.spec.ts
+++ b/examples/MockObservable/test.spec.ts
@@ -1,5 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, Injectable, NgModule } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injectable,
+  NgModule,
+} from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 
 import {
@@ -21,6 +26,7 @@ class TargetService {
 }
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: '{{ list | json }}',

--- a/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
+++ b/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  DebugElement,
-  Directive,
-  InjectionToken,
-  VERSION,
-} from '@angular/core';
+import { ChangeDetectorRef, DebugElement, Directive, InjectionToken, VERSION } from '@angular/core';
 import { getTestBed, ModuleTeardownOptions, TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import coreDefineProperty from '../common/core.define-property';
@@ -108,19 +101,11 @@ const handleFixtureError = (e: any) => {
 // patch new versions and leave older Angular behavior untouched.
 const shouldPatchPointDetectChanges = (major = VERSION.major): boolean => Number.parseInt(major, 10) >= 22;
 
-// Respect explicit OnPush declarations; forcing their point CDR would hide the
-// very change-detection behavior a test might be asserting.
-// Covered by the Angular 22 e2e suite; root coverage runs on Angular 21.
+// Angular 22 reports both implicit OnPush and explicit Eager as Eager in
+// decorator annotations. The compiled definition contains the effective
+// strategy that MockRender must preserve.
 /* istanbul ignore next */
-const isExplicitlyOnPush = (fixture: any): boolean => {
-  const annotation = fixture.point?.componentInstance?.constructor?.__annotations__?.[0];
-
-  return (
-    annotation &&
-    Object.prototype.hasOwnProperty.call(annotation, 'changeDetection') &&
-    annotation.changeDetection === ChangeDetectionStrategy.OnPush
-  );
-};
+const isOnPush = (fixture: any): boolean => fixture.point?.componentInstance?.constructor?.ɵcmp?.onPush === true;
 
 // Token and plain-text renders do not have a child component CDR. The lookup is
 // intentionally best-effort so MockRender keeps supporting every render shape.
@@ -130,7 +115,7 @@ const getFixturePointChangeDetectorRef = (fixture: any): undefined | ChangeDetec
   if (!shouldPatchPointDetectChanges() || !fixture.point || fixture.point === fixture.debugElement) {
     return undefined;
   }
-  if (isExplicitlyOnPush(fixture)) {
+  if (isOnPush(fixture)) {
     return undefined;
   }
   try {

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -58,6 +58,7 @@ file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
+file|tests/issue-14157/test.spec.ts|versions=22+
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
 file|tests/**

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -58,7 +58,6 @@ file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
-file|tests/issue-14157/test.spec.ts|versions=22+
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
 file|tests/**

--- a/tests/control-value-accessor-ng-model/test.spec.ts
+++ b/tests/control-value-accessor-ng-model/test.spec.ts
@@ -1,5 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, forwardRef, NgModule } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  NgModule,
+} from '@angular/core';
 import {
   NgModel,
   ControlValueAccessor,
@@ -15,6 +20,7 @@ import {
 } from 'ng-mocks';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target-cva-ng-model',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template:

--- a/tests/fake-async/test.spec.ts
+++ b/tests/fake-async/test.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectionStrategy,
   Component,
   Input,
   NgZone,
@@ -10,6 +11,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target-fake-async',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: '{{ counter }}',

--- a/tests/issue-1165/test.spec.ts
+++ b/tests/issue-1165/test.spec.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target-1165',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: '{{ value }}',

--- a/tests/issue-14157/test.spec.ts
+++ b/tests/issue-14157/test.spec.ts
@@ -2,49 +2,61 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
+  VERSION,
 } from '@angular/core';
 
 import { MockBuilder, MockRender } from 'ng-mocks';
 
 @Component({
-  selector: 'target-default-14157',
-  standalone: false,
+  selector: 'target-implicit-14157',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: '{{ items.length }}',
 })
-class DefaultOnPushComponent {
+class ImplicitStrategyComponent {
   @Input() public items: string[] = [];
 }
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.Eager,
-  selector: 'target-eager-14157',
-  standalone: false,
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'target-default-14157',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: '{{ items.length }}',
 })
-class EagerComponent {
+class ExplicitDefaultComponent {
   @Input() public items: string[] = [];
 }
 
 // @see https://github.com/help-me-mom/ng-mocks/issues/14157
-// Angular 22 uses OnPush when changeDetection is omitted. MockRender should
-// preserve that compiled strategy instead of forcing the rendered point.
+// Before Angular 22, an omitted strategy is Default. Angular 22 uses OnPush.
+// MockRender should preserve the compiled strategy instead of forcing the
+// rendered point.
 describe('issue-14157', () => {
-  describe('default OnPush', () => {
-    beforeEach(() => MockBuilder(DefaultOnPushComponent));
+  describe('implicit strategy', () => {
+    beforeEach(() => MockBuilder(ImplicitStrategyComponent));
 
-    it('does not update for an unchanged input reference', () => {
+    it('uses the framework default for an unchanged input reference', () => {
       const parameters: { items: string[] } = { items: [] };
-      const fixture = MockRender(DefaultOnPushComponent, parameters);
+      const fixture = MockRender(
+        ImplicitStrategyComponent,
+        parameters,
+      );
 
       fixture.componentInstance.items.push('demo');
       fixture.detectChanges();
 
-      expect(fixture.point.nativeElement.textContent).toEqual('0');
+      if (Number.parseInt(VERSION.major, 10) >= 22) {
+        expect(fixture.point.nativeElement.textContent).toEqual('0');
+      } else {
+        expect(fixture.point.nativeElement.textContent).toEqual('1');
+      }
     });
 
     it('updates for a new input reference', () => {
       const parameters: { items: string[] } = { items: [] };
-      const fixture = MockRender(DefaultOnPushComponent, parameters);
+      const fixture = MockRender(
+        ImplicitStrategyComponent,
+        parameters,
+      );
 
       fixture.componentInstance.items = ['demo'];
       fixture.detectChanges();
@@ -53,12 +65,15 @@ describe('issue-14157', () => {
     });
   });
 
-  describe('explicit Eager', () => {
-    beforeEach(() => MockBuilder(EagerComponent));
+  describe('explicit Default', () => {
+    beforeEach(() => MockBuilder(ExplicitDefaultComponent));
 
     it('updates for an unchanged input reference', () => {
       const parameters: { items: string[] } = { items: [] };
-      const fixture = MockRender(EagerComponent, parameters);
+      const fixture = MockRender(
+        ExplicitDefaultComponent,
+        parameters,
+      );
 
       fixture.componentInstance.items.push('demo');
       fixture.detectChanges();

--- a/tests/issue-14157/test.spec.ts
+++ b/tests/issue-14157/test.spec.ts
@@ -1,0 +1,69 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+} from '@angular/core';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target-default-14157',
+  standalone: false,
+  template: '{{ items.length }}',
+})
+class DefaultOnPushComponent {
+  @Input() public items: string[] = [];
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Eager,
+  selector: 'target-eager-14157',
+  standalone: false,
+  template: '{{ items.length }}',
+})
+class EagerComponent {
+  @Input() public items: string[] = [];
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14157
+// Angular 22 uses OnPush when changeDetection is omitted. MockRender should
+// preserve that compiled strategy instead of forcing the rendered point.
+describe('issue-14157', () => {
+  describe('default OnPush', () => {
+    beforeEach(() => MockBuilder(DefaultOnPushComponent));
+
+    it('does not update for an unchanged input reference', () => {
+      const parameters: { items: string[] } = { items: [] };
+      const fixture = MockRender(DefaultOnPushComponent, parameters);
+
+      fixture.componentInstance.items.push('demo');
+      fixture.detectChanges();
+
+      expect(fixture.point.nativeElement.textContent).toEqual('0');
+    });
+
+    it('updates for a new input reference', () => {
+      const parameters: { items: string[] } = { items: [] };
+      const fixture = MockRender(DefaultOnPushComponent, parameters);
+
+      fixture.componentInstance.items = ['demo'];
+      fixture.detectChanges();
+
+      expect(fixture.point.nativeElement.textContent).toEqual('1');
+    });
+  });
+
+  describe('explicit Eager', () => {
+    beforeEach(() => MockBuilder(EagerComponent));
+
+    it('updates for an unchanged input reference', () => {
+      const parameters: { items: string[] } = { items: [] };
+      const fixture = MockRender(EagerComponent, parameters);
+
+      fixture.componentInstance.items.push('demo');
+      fixture.detectChanges();
+
+      expect(fixture.point.nativeElement.textContent).toEqual('1');
+    });
+  });
+});

--- a/tests/issue-333/test.spec.ts
+++ b/tests/issue-333/test.spec.ts
@@ -1,10 +1,16 @@
 import { CommonModule } from '@angular/common';
-import { Component, NgModule, Type } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgModule,
+  Type,
+} from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { isMockOf, MockBuilder, MockRender, ngMocks } from 'ng-mocks';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'dynamic-overlay',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template:

--- a/tests/issue-488/faster.spec.ts
+++ b/tests/issue-488/faster.spec.ts
@@ -1,4 +1,9 @@
-import { Component, NgModule, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgModule,
+  OnInit,
+} from '@angular/core';
 
 import {
   MockBuilder,
@@ -8,6 +13,7 @@ import {
 } from 'ng-mocks';
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.Default,
   selector: 'target',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: '{{ value }}',


### PR DESCRIPTION
## Why

Angular 22 defaults components with an omitted `changeDetection` setting to OnPush. Angular's decorator annotations report these components the same way as explicit Eager components, so `MockRender` forced the rendered component's change detector and hid the effective OnPush behavior.

## What

- Read the effective strategy from the compiled component definition before forcing point change detection.
- Add cross-version regression coverage for the implicit framework default, new input references, and explicit Default behavior.
- Mark existing test fixtures that intentionally depend on eager updates as explicit Default components.
- Allow test fixtures to opt into eager change detection without violating the production lint policy.

## Impact

`MockRender` now preserves Angular 22's implicit OnPush semantics while retaining eager/default behavior on Angular 5–21 and for explicitly eager components.

Fixes #14157