### PR TITLE
fix(MockComponent): preserve signal input behavior #13671

### DIFF
--- a/libs/ng-mocks/src/lib/common/core.types.ts
+++ b/libs/ng-mocks/src/lib/common/core.types.ts
@@ -44,7 +44,13 @@ export type AnyDeclaration<T> = AnyType<T> | InjectionToken<T> | string;
  *
  * @internal
  */
-export type DirectiveIoParsed = { name: string; alias?: string; required?: boolean };
+export type DirectiveIoParsed = {
+  name: string;
+  alias?: string;
+  required?: boolean;
+  isSignal?: boolean;
+  transform?: (value: any) => any;
+};
 
 /**
  * Possible Input / Output type.

--- a/libs/ng-mocks/src/lib/common/decorate.inputs.spec.ts
+++ b/libs/ng-mocks/src/lib/common/decorate.inputs.spec.ts
@@ -1,0 +1,26 @@
+import decorateInputs from './decorate.inputs';
+
+describe('decorateInputs', () => {
+  it('preserves signal input metadata for Angular JIT', () => {
+    class TargetComponent {}
+
+    decorateInputs(TargetComponent, [
+      {
+        alias: 'alias',
+        isSignal: true,
+        name: 'value',
+        transform: String,
+      },
+    ]);
+
+    expect((TargetComponent as any).__prop__metadata__.value).toEqual(
+      [
+        jasmine.objectContaining({
+          alias: 'alias',
+          isSignal: true,
+          transform: String,
+        }),
+      ],
+    );
+  });
+});

--- a/libs/ng-mocks/src/lib/common/decorate.inputs.ts
+++ b/libs/ng-mocks/src/lib/common/decorate.inputs.ts
@@ -13,11 +13,12 @@ export default (cls: AnyType<any>, inputs?: Array<DirectiveIo>, exclude?: string
   // istanbul ignore else
   if (inputs) {
     for (const input of inputs) {
-      const { name, alias, required } = funcDirectiveIoParse(input);
+      const { name, alias, required, isSignal, transform } = funcDirectiveIoParse(input);
       if (exclude && exclude.indexOf(name) !== -1) {
         continue;
       }
-      Input(funcDirectiveIoBuild({ name, alias, required }, true) as never)(cls.prototype, name);
+      // Angular's JIT facade consumes isSignal when it builds the mock definition.
+      Input(funcDirectiveIoBuild({ name, alias, required, isSignal, transform }, true) as never)(cls.prototype, name);
     }
   }
 };

--- a/libs/ng-mocks/src/lib/common/func.directive-io-build.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-build.ts
@@ -1,8 +1,17 @@
 import { DirectiveIo, DirectiveIoParsed } from './core.types';
 
-export default function ({ name, alias, required }: DirectiveIoParsed, skipName = false): DirectiveIo {
-  if (required) {
-    return { name, alias, required };
+export default function (
+  { name, alias, required, isSignal, transform }: DirectiveIoParsed,
+  skipName = false,
+): DirectiveIo {
+  if (required !== undefined || isSignal !== undefined || transform !== undefined) {
+    return {
+      ...(skipName ? {} : { name }),
+      ...(alias === undefined ? {} : { alias }),
+      ...(required === undefined ? {} : { required }),
+      ...(isSignal === undefined ? {} : { isSignal }),
+      ...(transform === undefined ? {} : { transform }),
+    } as DirectiveIo;
   }
   if (!alias || name === alias) {
     return skipName ? '' : name;

--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
@@ -37,4 +37,20 @@ describe('funcDirectiveIoParse', () => {
       required: true,
     });
   });
+
+  it('keeps signal input metadata', () => {
+    expect(
+      funcDirectiveIoParse({
+        alias: 'alias',
+        isSignal: true,
+        name: 'value',
+        transform: String,
+      }),
+    ).toEqual({
+      alias: 'alias',
+      isSignal: true,
+      name: 'value',
+      transform: String,
+    });
+  });
 });

--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.ts
@@ -1,15 +1,21 @@
 import { DirectiveIo, DirectiveIoParsed } from './core.types';
 
-const normalize = ({ name, alias, required }: DirectiveIoParsed): DirectiveIoParsed => {
+const normalize = ({ name, alias, required, isSignal, transform }: DirectiveIoParsed): DirectiveIoParsed => {
+  const metadata = {
+    ...(required === undefined ? {} : { required }),
+    ...(isSignal === undefined ? {} : { isSignal }),
+    ...(transform === undefined ? {} : { transform }),
+  };
+
   if (name === alias || !alias) {
-    return required === undefined ? { name } : { name, required };
+    return { name, ...metadata };
   }
 
   if (name + 'Change' === alias) {
-    return required === undefined ? { name: alias } : { name: alias, required };
+    return { name: alias, ...metadata };
   }
 
-  return required === undefined ? { name, alias } : { name, alias, required };
+  return { name, alias, ...metadata };
 };
 
 export default function (param: DirectiveIo): DirectiveIoParsed {

--- a/libs/ng-mocks/src/lib/common/mock.spec.ts
+++ b/libs/ng-mocks/src/lib/common/mock.spec.ts
@@ -2,10 +2,12 @@ import {
   Component,
   Directive,
   EventEmitter,
+  isSignal,
   NgModule,
   Pipe,
   PipeTransform,
 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import {
   ControlValueAccessor,
   NG_ASYNC_VALIDATORS,
@@ -386,6 +388,39 @@ describe('Mock prototype', () => {
 });
 
 describe('definitions', () => {
+  it('initializes signal inputs on mock instances', () => {
+    class TargetComponent {}
+
+    const testComponent = extendClass(Mock);
+    decorateMock(testComponent, TargetComponent, {
+      inputs: [
+        'regular',
+        {
+          isSignal: true,
+          name: 'value',
+          transform: String,
+        },
+        {
+          isSignal: true,
+          name: 'required',
+          required: true,
+        },
+        {
+          isSignal: true,
+          name: '__ngMocks',
+        },
+      ],
+    });
+
+    const instance: any = TestBed.runInInjectionContext(
+      () => new testComponent(),
+    );
+    expect(instance.regular).toBeUndefined();
+    expect(isSignal(instance.value)).toBe(true);
+    expect(isSignal(instance.required)).toBe(true);
+    expect(instance.__ngMocks).toBe(true);
+  });
+
   it('skips output properties from config', () => {
     class TargetComponent {}
 

--- a/libs/ng-mocks/src/lib/common/mock.ts
+++ b/libs/ng-mocks/src/lib/common/mock.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, Injector, Optional, PipeTransform, Self } from '@angular/core';
+import * as angularCore from '@angular/core';
 
 import { IMockBuilderConfig } from '../mock-builder/types';
 import mockHelperStub from '../mock-helper/mock-helper.stub';
@@ -130,6 +131,28 @@ const applyOutputs = (instance: MockConfig & Record<keyof any, any>) => {
   }
 };
 
+const applyInputs = (instance: MockConfig & Record<keyof any, any>) => {
+  const inputFactory = (angularCore as any).input;
+  // Older Angular versions do not expose the signal input factory.
+  /* istanbul ignore if */
+  if (typeof inputFactory !== 'function') {
+    return;
+  }
+
+  for (const input of instance.__ngMocksConfig.inputs || []) {
+    const { name, required, isSignal, transform } = funcDirectiveIoParse(input);
+    if (!isSignal || Object.getOwnPropertyDescriptor(instance, name)) {
+      continue;
+    }
+
+    const options = transform === undefined ? undefined : { transform };
+    instance[name] =
+      required && typeof inputFactory.required === 'function'
+        ? inputFactory.required(options)
+        : inputFactory(undefined, options);
+  }
+};
+
 const applyPrototype = (instance: Mock, prototype: AnyType<any>) => {
   for (const prop of [
     ...helperMockService.extractMethodsFromPrototype(prototype),
@@ -166,6 +189,7 @@ export type ngMocksMockConfig = {
   init?: (instance: any) => void;
   isControlValueAccessor?: boolean;
   isValidator?: boolean;
+  inputs?: Array<DirectiveIo>;
   outputs?: Array<DirectiveIo>;
   queryScanKeys?: string[];
   setControlValueAccessor?: boolean;
@@ -222,6 +246,7 @@ export class Mock {
     // istanbul ignore else
     if (funcIsMock(this)) {
       applyNgValueAccessor(this, ngControl, injector);
+      applyInputs(this);
       applyOutputs(this);
       applyPrototype(this, Object.getPrototypeOf(this));
       applyMethods(this, mockOf.prototype);

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.attributes.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.attributes.ts
@@ -1,4 +1,4 @@
-import { DirectiveIo } from '../common/core.types';
+import { DirectiveIo, DirectiveIoParsed } from '../common/core.types';
 import funcDirectiveIoParse from '../common/func.directive-io-parse';
 import { MockedDebugElement } from '../mock-render/types';
 
@@ -15,11 +15,12 @@ const parseArgs = (args: any[]): [MockedDebugElement | null | undefined, string,
   args.length === 3 ? args[2] : defaultNotFoundValue,
 ];
 
-const attrMatches = (attribute: DirectiveIo, selector: string): string | undefined => {
-  const { name, alias = '' } = funcDirectiveIoParse(attribute);
+const attrMatches = (attribute: DirectiveIo, selector: string): DirectiveIoParsed | undefined => {
+  const parsed = funcDirectiveIoParse(attribute);
+  const { name, alias = '' } = parsed;
 
   if ((!alias && name === selector) || (!!alias && alias === selector)) {
-    return name;
+    return parsed;
   }
 
   return undefined;
@@ -33,9 +34,11 @@ const detectAttribute = (el: MockedDebugElement | null | undefined, attr: 'input
     }
 
     for (const attrDef of meta[attr] || /* istanbul ignore next */ []) {
-      const prop = attrMatches(attrDef, sel);
-      if (prop) {
-        return mockHelperGet(el, token)[prop];
+      const parsed = attrMatches(attrDef, sel);
+      if (parsed) {
+        const value = mockHelperGet(el, token)[parsed.name];
+
+        return attr === 'inputs' && parsed.isSignal && typeof value === 'function' ? value() : value;
       }
     }
   }

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.spec.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Directive,
   EventEmitter,
+  input,
   Input,
   Output,
 } from '@angular/core';
@@ -21,6 +22,8 @@ import { ngMocks } from './mock-helper';
 })
 export class ExampleDirective {
   @Input() public exampleDirective = '';
+  @Input({ isSignal: true } as never)
+  public readonly signalInput = input('');
   @Output() public someOutput = new EventEmitter<boolean>();
   @Input('bah') public something = '';
 
@@ -280,6 +283,19 @@ describe('MockHelper:getDirective', () => {
     const node = ngMocks.find(fixture.debugElement, 'div');
     const input = ngMocks.input(node, 'exampleDirective');
     expect(input).toEqual('5');
+  });
+
+  it('input returns a signal input value', () => {
+    const fixture = MockRender(
+      '<div exampleDirective [signalInput]="value"></div>',
+      {
+        value: 'signal',
+      },
+    );
+
+    const node = ngMocks.find(fixture.debugElement, 'div');
+    const actual = ngMocks.input(node, 'signalInput');
+    expect(actual).toEqual('signal');
   });
 
   it('input returns default value', () => {

--- a/libs/ng-mocks/src/lib/mock/decorate-declaration.ts
+++ b/libs/ng-mocks/src/lib/mock/decorate-declaration.ts
@@ -26,6 +26,7 @@ const buildConfig = (
 ) => {
   return {
     config: ngMocksUniverse.config.get(source),
+    inputs: meta.inputs,
     outputs: meta.outputs,
     queryScanKeys: [],
     setControlValueAccessor: setControlValueAccessor,

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
@@ -336,7 +336,7 @@ describe('collect-declarations', () => {
           value: 'value',
         },
         inputs: {
-          value: ['value', 1, null],
+          value: ['value', 1, String],
         },
         outputs: {
           valueChange: 'value',
@@ -345,9 +345,40 @@ describe('collect-declarations', () => {
       },
     });
 
-    expect(actual.inputs).toEqual(['value']);
+    expect(actual.inputs).toEqual([
+      { name: 'value', isSignal: true, transform: String },
+    ]);
     expect(actual.outputs).toEqual(['valueChange']);
     expect(actual.standalone).toBe(true);
+    delete global.__ngMocksReflectComponentType;
+  });
+
+  it('enriches ng def inputs with reflected signal metadata', () => {
+    const global = funcGetGlobal();
+    global.__ngMocksReflectComponentType = () => ({
+      inputs: [
+        {
+          isSignal: true,
+          propName: 'value',
+          templateName: 'alias',
+        },
+      ],
+      outputs: [],
+    });
+    const actual = collectDeclarations({
+      ɵcmp: {
+        declaredInputs: {
+          alias: 'value',
+        },
+        inputs: {
+          alias: ['value', 0, null],
+        },
+      },
+    });
+
+    expect(actual.inputs).toEqual([
+      { name: 'value', alias: 'alias', isSignal: true },
+    ]);
     delete global.__ngMocksReflectComponentType;
   });
 

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
@@ -142,16 +142,32 @@ const addUniqueDirectiveIo = (
   name: string,
   alias: string | undefined,
   required: boolean | undefined,
+  isSignal?: boolean,
+  transform?: (value: any) => any,
 ): void => {
-  const normalizedDef = funcDirectiveIoBuild({ name, alias, required });
+  const normalizedDef = funcDirectiveIoBuild({ name, alias, required, isSignal, transform });
 
-  for (const def of declaration[key]) {
+  for (let index = 0; index < declaration[key].length; index += 1) {
+    const def = declaration[key][index];
     if (def === normalizedDef) {
       return;
     }
 
-    const { name: defName, alias: defAlias } = funcDirectiveIoParse(def);
+    const {
+      name: defName,
+      alias: defAlias,
+      required: defRequired,
+      isSignal: defIsSignal,
+      transform: defTransform,
+    } = funcDirectiveIoParse(def);
     if (defName === name && defAlias === alias) {
+      declaration[key][index] = funcDirectiveIoBuild({
+        name,
+        alias,
+        required: defRequired ?? required,
+        isSignal: defIsSignal ?? isSignal,
+        transform: defTransform ?? transform,
+      });
       return;
     }
   }
@@ -168,16 +184,20 @@ const parsePropMetadataParserFactoryProp =
       alias?: string;
       required?: boolean;
       bindingPropertyName?: string;
+      isSignal?: boolean;
+      transform?: (value: any) => any;
     },
     declaration: Declaration,
   ): void => {
-    const { alias, required } = funcDirectiveIoParse({
+    const { alias, required, isSignal, transform } = funcDirectiveIoParse({
       name,
       alias: decorator.alias ?? decorator.bindingPropertyName,
       required: decorator.required,
+      isSignal: decorator.isSignal || undefined,
+      transform: decorator.transform,
     });
 
-    addUniqueDirectiveIo(declaration, key, name, alias, required);
+    addUniqueDirectiveIo(declaration, key, name, alias, required, isSignal, transform);
   };
 const parsePropMetadataParserInput = parsePropMetadataParserFactoryProp('inputs');
 const parsePropMetadataParserOutput = parsePropMetadataParserFactoryProp('outputs');
@@ -305,6 +325,9 @@ const parsePropMetadata = (
   }
 };
 
+// Angular's compiled InputFlags.SignalBased value, introduced with signal inputs.
+const INPUT_FLAG_SIGNAL_BASED = 1;
+
 const parseNgDef = (
   def: {
     ɵcmp?: any;
@@ -329,6 +352,8 @@ const parseNgDef = (
   for (const alias of Object.keys(ngDef.inputs || {})) {
     const input = ngDef.inputs[alias];
     const minifiedName = Array.isArray(input) ? input[0] : input;
+    const flags = Array.isArray(input) && typeof input[1] === 'number' ? input[1] : 0;
+    const transform = Array.isArray(input) ? input[2] : undefined;
     const {
       name,
       alias: normalizedAlias,
@@ -339,7 +364,15 @@ const parseNgDef = (
       required: undefined,
     });
 
-    addUniqueDirectiveIo(declaration, 'inputs', name, normalizedAlias, required);
+    addUniqueDirectiveIo(
+      declaration,
+      'inputs',
+      name,
+      normalizedAlias,
+      required,
+      flags & INPUT_FLAG_SIGNAL_BASED ? true : undefined,
+      transform ?? undefined,
+    );
   }
 
   for (const alias of Object.keys(ngDef.outputs || {})) {
@@ -369,13 +402,15 @@ const parseReflectComponentType = (def: any, declaration: Declaration): void => 
   }
 
   for (const input of mirror.inputs) {
-    const { name, alias, required } = funcDirectiveIoParse({
+    const { name, alias, required, isSignal, transform } = funcDirectiveIoParse({
       name: input.propName,
       alias: input.templateName === input.propName ? undefined : input.templateName,
       required: undefined, // reflectComponentType doesn't provide required info for signal inputs
+      isSignal: input.isSignal || undefined,
+      transform: input.transform,
     });
 
-    addUniqueDirectiveIo(declaration, 'inputs', name, alias, required);
+    addUniqueDirectiveIo(declaration, 'inputs', name, alias, required, isSignal, transform);
   }
 
   for (const output of mirror.outputs) {

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -57,6 +57,7 @@ file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
+file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+

--- a/tests/issue-13671/test.spec.ts
+++ b/tests/issue-13671/test.spec.ts
@@ -1,0 +1,79 @@
+import {
+  Component,
+  input,
+  isSignal,
+  reflectComponentType,
+} from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'target-13671-kept',
+  standalone: true,
+  template: '{{ name() }}',
+})
+class KeptComponent {
+  public readonly name = input('kept-default');
+  public readonly label = input('kept-label', {
+    alias: 'displayLabel',
+  });
+}
+
+@Component({
+  selector: 'target-13671-mocked',
+  standalone: true,
+  template: '{{ name() }}',
+})
+class MockedComponent {
+  public readonly name = input('mocked-default');
+  public readonly label = input('mocked-label', {
+    alias: 'displayLabel',
+  });
+}
+
+@Component({
+  imports: [KeptComponent, MockedComponent],
+  standalone: true,
+  template: `
+    <target-13671-kept [name]="'kept-bound'" />
+    <target-13671-mocked
+      [name]="'mocked-bound'"
+      [displayLabel]="'mocked-alias'"
+    />
+  `,
+})
+class TargetComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/13671
+describe('issue-13671', () => {
+  if (
+    !reflectComponentType(MockedComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'name',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() =>
+    MockBuilder(TargetComponent)
+      .keep(KeptComponent)
+      .mock(MockedComponent),
+  );
+
+  it('keeps signal inputs callable on mocked components', () => {
+    MockRender(TargetComponent);
+
+    const kept = ngMocks.find(KeptComponent).componentInstance;
+    const mocked = ngMocks.find(MockedComponent).componentInstance;
+
+    expect(kept.name()).toEqual('kept-bound');
+    expect(typeof mocked.name).toEqual('function');
+    expect(isSignal(mocked.name)).toBe(true);
+    expect(mocked.name()).toEqual('mocked-bound');
+    expect(mocked.label()).toEqual('mocked-alias');
+  });
+});


### PR DESCRIPTION
## Why

Mocked components registered signal inputs as ordinary Angular inputs and did not initialize the corresponding `InputSignal` fields. Angular bindings therefore replaced those fields with their bound values, so calling an input such as `name()` failed at runtime.

## What

- Preserve signal, required, alias, and transform metadata while collecting and decorating mock inputs.
- Initialize mocked signal inputs with Angular's `input()` and `input.required()` factories.
- Keep `ngMocks.input(...)` value-oriented by unwrapping inputs identified as signals.
- Add cross-version regression coverage for callable signal inputs and aliased bindings.

## Impact

Signal inputs on mocked components now retain the same callable API as the real component while still receiving values through Angular bindings. Existing tests that inspect bindings through `ngMocks.input(...)` continue to receive the bound value.

Fixes #13671