### PR TITLE
fix(MockRender): preserve callable input values #13089

### DIFF
--- a/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
@@ -2,7 +2,8 @@ import { ChangeDetectionStrategy, Component, Directive } from '@angular/core';
 
 import coreConfig from '../common/core.config';
 import coreDefineProperty from '../common/core.define-property';
-import { Type } from '../common/core.types';
+import { DirectiveIo, Type } from '../common/core.types';
+import funcDirectiveIoParse from '../common/func.directive-io-parse';
 import ngMocksUniverse from '../common/ng-mocks-universe';
 import helperDefinePropertyDescriptor from '../mock-service/helper.define-property-descriptor';
 
@@ -98,6 +99,16 @@ const checkCache = (caches: Array<Type<any> & Record<'cacheKey', any[]>>, cacheK
   return undefined;
 };
 
+const getInputBindings = (inputs: DirectiveIo[]): string[] => {
+  const result: string[] = [];
+  for (const definition of inputs) {
+    const { name, alias } = funcDirectiveIoParse(definition);
+    result.push(alias || name);
+  }
+
+  return result;
+};
+
 export default (
   template: any,
   meta: Directive,
@@ -149,6 +160,7 @@ export default (
 
   ctor = generateWrapperComponent({ ...meta, bindings, options });
   coreDefineProperty(ctor, 'cacheKey', cacheKey);
+  coreDefineProperty(ctor, 'inputBindings', getInputBindings(inputs));
   coreDefineProperty(ctor, 'tpl', mockTemplate);
 
   if (meta.selector && options.providers) {

--- a/libs/ng-mocks/src/lib/mock-render/func.install-prop-reader.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.install-prop-reader.ts
@@ -2,9 +2,14 @@ import coreDefineProperty from '../common/core.define-property';
 import helperDefinePropertyDescriptor from '../mock-service/helper.define-property-descriptor';
 import helperMockService from '../mock-service/helper.mock-service';
 
-const createPropertyGet = (key: keyof any & string, reader: Record<keyof any, any>, source: Record<keyof any, any>) => {
+const createPropertyGet = (
+  key: keyof any & string,
+  reader: Record<keyof any, any>,
+  source: Record<keyof any, any>,
+  valueKeys: string[],
+) => {
   const handler = () => {
-    if (typeof source[key] === 'function') {
+    if (typeof source[key] === 'function' && valueKeys.indexOf(key) === -1) {
       if (reader[`__ngMocks_${key}__origin`] !== source[key]) {
         const clone = helperMockService.createClone(source[key], reader, source);
         coreDefineProperty(reader, `__ngMocks_${key}`, clone);
@@ -49,6 +54,7 @@ export default (
   source: Record<keyof any, any> | undefined,
   extra: string[],
   force = false,
+  valueKeys: string[] = [],
 ): void => {
   if (!source) {
     return;
@@ -61,7 +67,7 @@ export default (
       continue;
     }
     helperDefinePropertyDescriptor(reader, key, {
-      get: createPropertyGet(key, reader, source),
+      get: createPropertyGet(key, reader, source, valueKeys),
       set: createPropertySet(key, reader, source),
     });
     exists.push(key);

--- a/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
+++ b/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
@@ -200,7 +200,7 @@ const generateFactoryInstall =
   };
 
 const generateFactory = (
-  componentCtor: Type<any> & { tpl?: string },
+  componentCtor: Type<any> & { inputBindings: string[]; tpl?: string },
   bindings: undefined | null | string[],
   template: any,
   options: IMockRenderFactoryOptions,
@@ -223,7 +223,7 @@ const generateFactory = (
       };
     }
 
-    funcInstallPropReader(fixture.componentInstance, params ?? {}, bindings ?? []);
+    funcInstallPropReader(fixture.componentInstance, params ?? {}, bindings ?? [], false, componentCtor.inputBindings);
     coreDefineProperty(fixture, 'ngMocksStackId', ngMocksUniverse.global.get('bullet:stack:id'));
 
     if (detectChanges === undefined || detectChanges) {

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -57,6 +57,7 @@ file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
+file|tests/issue-13089/test.spec.ts|features=signalForms
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+

--- a/tests/issue-13089/callable.spec.ts
+++ b/tests/issue-13089/callable.spec.ts
@@ -1,0 +1,29 @@
+import { Component, Input } from '@angular/core';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target-13089-callable',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '',
+})
+class TargetComponent {
+  @Input('callableAlias')
+  public callable: (() => string) | undefined;
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/13089
+describe('issue-13089:callable', () => {
+  beforeEach(() => MockBuilder(TargetComponent));
+
+  it('passes callable inputs by identity', () => {
+    const callable = () => 'value';
+
+    const fixture = MockRender(TargetComponent, {
+      callableAlias: callable,
+    });
+
+    expect(fixture.componentInstance.callableAlias).toBe(callable);
+    expect(fixture.point.componentInstance.callable).toBe(callable);
+  });
+});

--- a/tests/issue-13089/test.spec.ts
+++ b/tests/issue-13089/test.spec.ts
@@ -1,0 +1,71 @@
+import {
+  Component,
+  input,
+  NgModule,
+  reflectComponentType,
+  signal,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FieldTree, form } from '@angular/forms/signals';
+
+import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
+
+interface Item {
+  name: string;
+}
+
+@Component({
+  selector: 'target-13089',
+  standalone: false,
+  template: `
+    @for (item of items(); track item) {
+      {{ item.name().value() }}
+    }
+  `,
+})
+class TargetComponent {
+  public readonly items = input.required<FieldTree<Item[]>>();
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/13089
+describe('issue-13089', () => {
+  if (
+    !reflectComponentType(TargetComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'items',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+  it('preserves callable input values', () => {
+    const factory = MockRenderFactory(TargetComponent, ['items']);
+    factory.configureTestBed();
+    const formState = signal({ items: [{ name: 'initial' }] });
+    const formModel = TestBed.runInInjectionContext(() =>
+      form(formState),
+    );
+
+    const fixture = factory({ items: formModel.items });
+
+    expect(fixture.point.componentInstance.items()).toBe(
+      formModel.items,
+    );
+    expect(ngMocks.formatText(fixture)).toContain('initial');
+
+    formState.set({ items: [{ name: 'updated' }] });
+    fixture.detectChanges();
+
+    expect(ngMocks.formatText(fixture)).toContain('updated');
+  });
+});


### PR DESCRIPTION
## Why

`MockRender` treated every callable parameter as a method and cloned it to preserve invocation context. Angular Signal Forms field trees are callable proxy values, so cloning them loses their proxy behavior and identity when passed through a component input.

## What

- Derive the wrapper's public input binding names from Angular metadata.
- Pass callable input values through unchanged while retaining method and output-handler rebinding.
- Add a cross-version callable-input regression and an Angular 21+ Signal Forms regression.

## Impact

`MockRender` now preserves function-valued inputs, including Signal Forms `FieldTree` proxies, without framework-specific special cases or changes to method binding behavior.

Fixes #13089