### PR TITLE
fix(TestBed): support compiled platform modules #12725

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -14,7 +14,6 @@ import coreDefineProperty from './core.define-property';
 import { flatten, mapEntries, mapValues } from './core.helpers';
 import coreInjector from './core.injector';
 import coreReflectMeta from './core.reflect.meta';
-import coreReflectModuleResolve from './core.reflect.module-resolve';
 import coreReflectProvidedIn from './core.reflect.provided-in';
 import { NG_MOCKS, NG_MOCKS_ROOT_PROVIDERS, NG_MOCKS_TOUCHES } from './core.tokens';
 import { AnyType, dependencyKeys } from './core.types';
@@ -168,7 +167,10 @@ const applyPlatformOverrideDef = (def: any) => {
     return;
   }
 
-  const original = coreReflectModuleResolve(ngModule);
+  const original = coreReflectMeta(ngModule);
+  if (!original) {
+    return;
+  }
   const set = getOverrideDef(original);
   if (set) {
     (TestBed as any).ngMocksOverrides.set(ngModule, { set: original });

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -58,6 +58,7 @@ file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-13089/test.spec.ts|features=signalForms
+file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+

--- a/tests/issue-12725/test.spec.ts
+++ b/tests/issue-12725/test.spec.ts
@@ -1,0 +1,37 @@
+import {
+  Injectable,
+  ɵcompileNgModuleDefs as compileNgModuleDefs,
+} from '@angular/core';
+import { getTestBed, TestBed } from '@angular/core/testing';
+
+import { MockProvider } from 'ng-mocks';
+
+@Injectable()
+class TargetService {}
+
+class TestModule {}
+
+compileNgModuleDefs(TestModule as never, {
+  providers: [],
+});
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/12725
+describe('issue-12725', () => {
+  it('uses MockProvider with a compiled platform module', () => {
+    expect(() => {
+      const testBed = getTestBed() as unknown as {
+        ngModule: unknown;
+      };
+      const ngModule = testBed.ngModule;
+      testBed.ngModule = [ngModule, TestModule];
+
+      try {
+        TestBed.configureTestingModule({
+          providers: [MockProvider(TargetService)],
+        });
+      } finally {
+        testBed.ngModule = ngModule;
+      }
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

Angular's legacy Karma builder creates its internal `TestModule` by adding compiled module definitions to a class without decorator metadata. The ng-mocks global platform scan treated every TestBed platform module as an explicitly supplied module and used strict reflection, so it rejected that builder-owned class before `MockProvider` configuration could complete.

## What

- Use optional metadata reflection while scanning TestBed platform modules for global overrides.
- Skip compiled-only internal modules that cannot participate in ng-mocks overrides while retaining strict validation for explicit ng-mocks module inputs.
- Add an Angular 21+ regression covering `MockProvider` with a runtime-compiled `TestModule`.

## Impact

Angular 21 legacy Karma tests can configure mocked providers without the false missing-decorator error. Explicitly passing an undecorated declaration to ng-mocks continues to report the existing validation error.

Fixes #12725