### PR TITLE
fix(MockRender): preserve TestBed module options #11324

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -27,6 +27,7 @@ import {
   rememberMockDeclarations,
   resetInjectedDeclarations,
 } from './ng-mocks-injected-declarations';
+import { rememberTestModuleOptions, resetTestModuleOptions } from './ng-mocks-test-module-metadata';
 import ngMocksUniverse from './ng-mocks-universe';
 type NgMocksTestBed = TestBedStatic & {
   get?: (token: any, ...args: any[]) => any;
@@ -310,7 +311,10 @@ const configureTestingModule =
       applyPlatformOverrides(testBed, touches);
     }
 
-    return original.call(instance, finalModuleDef);
+    const result = original.call(instance, finalModuleDef);
+    rememberTestModuleOptions(finalModuleDef);
+
+    return result;
   };
 
 const resetTestingModule =
@@ -318,6 +322,7 @@ const resetTestingModule =
   () => {
     ngMocksUniverse.global.delete('builder:config');
     ngMocksUniverse.global.delete('builder:module');
+    resetTestModuleOptions();
     (TestBed as any).ngMocksSelectors = undefined;
     resetInjectedDeclarations();
     applyNgMocksOverrides(TestBed);

--- a/libs/ng-mocks/src/lib/common/ng-mocks-test-module-metadata.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-test-module-metadata.ts
@@ -2,29 +2,17 @@ import { TestModuleMetadata } from '@angular/core/testing';
 
 import ngMocksUniverse from './ng-mocks-universe';
 
-const testModuleOptionKeys: Array<keyof TestModuleMetadata> = [
-  'teardown',
-  'errorOnUnknownElements',
-  'errorOnUnknownProperties',
-  'rethrowApplicationErrors',
-  'deferBlockBehavior',
-  'inferTagName',
-  'animationsEnabled',
-];
-
 const testModuleOptionsKey = 'test-bed:module-options';
 
 export const getTestModuleOptions = (): Partial<TestModuleMetadata> =>
   ngMocksUniverse.global.get(testModuleOptionsKey) ?? {};
 
 export const rememberTestModuleOptions = (moduleDef: TestModuleMetadata): void => {
-  const options: Partial<TestModuleMetadata> = {};
-
-  for (const key of testModuleOptionKeys) {
-    if (Object.prototype.hasOwnProperty.call(moduleDef, key)) {
-      Object.assign(options, { [key]: moduleDef[key] });
-    }
-  }
+  const options: Partial<TestModuleMetadata> = { ...moduleDef };
+  delete options.declarations;
+  delete options.imports;
+  delete options.providers;
+  delete options.schemas;
 
   ngMocksUniverse.global.set(testModuleOptionsKey, options);
 };

--- a/libs/ng-mocks/src/lib/common/ng-mocks-test-module-metadata.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-test-module-metadata.ts
@@ -1,0 +1,34 @@
+import { TestModuleMetadata } from '@angular/core/testing';
+
+import ngMocksUniverse from './ng-mocks-universe';
+
+const testModuleOptionKeys: Array<keyof TestModuleMetadata> = [
+  'teardown',
+  'errorOnUnknownElements',
+  'errorOnUnknownProperties',
+  'rethrowApplicationErrors',
+  'deferBlockBehavior',
+  'inferTagName',
+  'animationsEnabled',
+];
+
+const testModuleOptionsKey = 'test-bed:module-options';
+
+export const getTestModuleOptions = (): Partial<TestModuleMetadata> =>
+  ngMocksUniverse.global.get(testModuleOptionsKey) ?? {};
+
+export const rememberTestModuleOptions = (moduleDef: TestModuleMetadata): void => {
+  const options: Partial<TestModuleMetadata> = {};
+
+  for (const key of testModuleOptionKeys) {
+    if (Object.prototype.hasOwnProperty.call(moduleDef, key)) {
+      Object.assign(options, { [key]: moduleDef[key] });
+    }
+  }
+
+  ngMocksUniverse.global.set(testModuleOptionsKey, options);
+};
+
+export const resetTestModuleOptions = (): void => {
+  ngMocksUniverse.global.delete(testModuleOptionsKey);
+};

--- a/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
+++ b/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, DebugElement, Directive, InjectionToken, VERSION } from '@angular/core';
-import { getTestBed, ModuleTeardownOptions, TestBed, TestModuleMetadata } from '@angular/core/testing';
+import { getTestBed, TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import coreDefineProperty from '../common/core.define-property';
 import { getInjection } from '../common/core.helpers';
@@ -8,6 +8,7 @@ import funcGetName from '../common/func.get-name';
 import funcImportExists from '../common/func.import-exists';
 import { isNgDef } from '../common/func.is-ng-def';
 import ngMocksStack from '../common/ng-mocks-stack';
+import { getTestModuleOptions } from '../common/ng-mocks-test-module-metadata';
 import ngMocksUniverse from '../common/ng-mocks-universe';
 import { ngMocks } from '../mock-helper/mock-helper';
 import helperDefinePropertyDescriptor from '../mock-service/helper.define-property-descriptor';
@@ -176,7 +177,6 @@ const generateFactoryInstall =
       };
       _declarations?: Array<AnyType<any>>;
       declarations?: Array<AnyType<any>>;
-      _instanceTeardownOptions?: ModuleTeardownOptions | undefined;
     } = getTestBed();
     // istanbul ignore next
     const existing = testBed._compiler?.declarations || testBed.declarations || testBed._declarations;
@@ -189,9 +189,9 @@ const generateFactoryInstall =
         }
         declarations.push(ctor);
         const moduleDef: TestModuleMetadata = {
+          ...getTestModuleOptions(),
           declarations,
         };
-        (moduleDef as any).teardown = testBed._instanceTeardownOptions;
         TestBed.configureTestingModule(moduleDef);
       } catch (error) {
         handleFixtureError(error);

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -63,5 +63,7 @@ file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
+file|tests/issue-11324/test.spec.ts|versions=15+
+file|tests/issue-11324/module-options.spec.ts|versions=20+
 file|tests/**
 file|examples/**

--- a/tests/issue-11324/module-options.spec.ts
+++ b/tests/issue-11324/module-options.spec.ts
@@ -1,18 +1,10 @@
-import { Component, VERSION } from '@angular/core';
+import { Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { MockRender } from 'ng-mocks';
 
 // @see https://github.com/help-me-mom/ng-mocks/issues/11324
 describe('issue-11324: test module options', () => {
-  if (Number.parseInt(VERSION.major, 10) < 20) {
-    it('needs a20+', () => {
-      expect(true).toBeTruthy();
-    });
-
-    return;
-  }
-
   @Component({
     selector: 'issue-11324-module-options',
     template: '',

--- a/tests/issue-11324/module-options.spec.ts
+++ b/tests/issue-11324/module-options.spec.ts
@@ -1,0 +1,46 @@
+import { Component, VERSION } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockRender } from 'ng-mocks';
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/11324
+describe('issue-11324: test module options', () => {
+  if (Number.parseInt(VERSION.major, 10) < 20) {
+    it('needs a20+', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  @Component({
+    selector: 'issue-11324-module-options',
+    template: '',
+    ['standalone' as never]: true,
+  })
+  class TargetComponent {}
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      ['imports' as never]: [TargetComponent],
+      ['inferTagName' as never]: true,
+    });
+  });
+
+  it('preserves public TestBed options while installing the render wrapper', () => {
+    const fixture = MockRender(TargetComponent);
+
+    expect(fixture.nativeElement.nodeName).toBe('MOCK-RENDER');
+  });
+
+  it('forgets public TestBed options after a reset', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      ['imports' as never]: [TargetComponent],
+    });
+
+    const fixture = MockRender(TargetComponent);
+
+    expect(fixture.nativeElement.nodeName).toBe('DIV');
+  });
+});

--- a/tests/issue-11324/test.spec.ts
+++ b/tests/issue-11324/test.spec.ts
@@ -61,10 +61,9 @@ describe('issue-11324', () => {
   }
 
   beforeEach(async () => {
-    const built = MockBuilder([FooComponent, BarComponent]).build();
-    (built as any).teardown = { destroyAfterEach: false };
     TestBed.configureTestingModule({
-      ...built,
+      ...MockBuilder([FooComponent, BarComponent]).build(),
+      teardown: { destroyAfterEach: false },
     });
     return await TestBed.compileComponents();
   });

--- a/tests/issue-11324/test.spec.ts
+++ b/tests/issue-11324/test.spec.ts
@@ -4,7 +4,6 @@ import {
   Component,
   Input,
   TemplateRef,
-  VERSION,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
@@ -14,14 +13,6 @@ import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
 
 // @see https://github.com/help-me-mom/ng-mocks/issues/11324
 describe('issue-11324', () => {
-  if (Number.parseInt(VERSION.major, 10) < 15) {
-    it('needs a15+', () => {
-      expect(true).toBeTruthy();
-    });
-
-    return;
-  }
-
   @Component({
     selector: 'app-baz',
     template: `Hello World!`,


### PR DESCRIPTION
## Why

`MockRender` installs a generated wrapper module after flushing `TestBed`. The existing issue fix reads Angular's private `_instanceTeardownOptions` field and restores only teardown, so it depends on framework internals and drops other public `TestModuleMetadata` options when the wrapper is configured.

## What

- Track the public, non-dependency `TestModuleMetadata` options after successful `TestBed` configuration.
- Reapply those options when installing a `MockRender` wrapper.
- Clear the tracked options on a real `TestBed` reset.
- Cover teardown preservation, public option preservation, and reset isolation with issue regressions.

## Impact

`MockRender` now respects the caller's public TestBed configuration without reading Angular's private teardown state. Existing defaults remain unchanged, and options cannot leak after a TestBed reset.

Fixes #11324