### PR TITLE
test(MockComponent): link signal alias regression #9684

### DIFF
--- a/tests/issue-13671/test.spec.ts
+++ b/tests/issue-13671/test.spec.ts
@@ -44,6 +44,7 @@ class MockedComponent {
 })
 class TargetComponent {}
 
+// @see https://github.com/help-me-mom/ng-mocks/issues/9684
 // @see https://github.com/help-me-mom/ng-mocks/issues/13671
 describe('issue-13671', () => {
   if (


### PR DESCRIPTION
Why:

- #9684 reports the aliased signal-input failure covered by the implementation merged in #14490.
- The existing regression verifies the same behavior but only references #13671.

What:

- Link #9684 from the aliased signal-input regression so both reports remain traceable.
- Keep runtime behavior unchanged.

Where:

- `tests/issue-13671/test.spec.ts`

References #9684.