### PR TITLE
test(MockComponent): cover required signal inputs #8887

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -62,6 +62,7 @@ file|tests/issue-13089/test.spec.ts|features=signalForms
 file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
+file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
 file|tests/issue-11324/test.spec.ts|versions=15+

--- a/tests/issue-8887/test.spec.ts
+++ b/tests/issue-8887/test.spec.ts
@@ -1,0 +1,77 @@
+import {
+  Component,
+  input,
+  isSignal,
+  reflectComponentType,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockComponent, ngMocks } from 'ng-mocks';
+
+interface Task {
+  completed: boolean;
+  id: string;
+  name: string;
+}
+
+@Component({
+  selector: 'target-8887-list-item',
+  standalone: true,
+  template: '',
+})
+class ListItemComponent {
+  public readonly task = input.required<Task>();
+}
+
+@Component({
+  imports: [ListItemComponent],
+  standalone: true,
+  template: ` <target-8887-list-item [task]="task" /> `,
+})
+class ListComponent {
+  public readonly task: Task = {
+    completed: true,
+    id: '1',
+    name: 'Buy milk',
+  };
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/8887
+describe('issue-8887', () => {
+  if (
+    !reflectComponentType(ListItemComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'task',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [ListComponent],
+    })
+      .overrideComponent(ListComponent, {
+        add: {
+          imports: [MockComponent(ListItemComponent)],
+        },
+        remove: {
+          imports: [ListItemComponent],
+        },
+      })
+      .compileComponents(),
+  );
+
+  it('keeps required signal inputs callable on mocked components', () => {
+    const fixture = TestBed.createComponent(ListComponent);
+    fixture.detectChanges();
+
+    const mocked = ngMocks.find(ListItemComponent).componentInstance;
+
+    expect(isSignal(mocked.task)).toBe(true);
+    expect(mocked.task()).toEqual(fixture.componentInstance.task);
+  });
+});


### PR DESCRIPTION
Why:

- #8887 reports that `MockComponent` turns an `input.required()` field into a plain property when the mock replaces a standalone import through `TestBed.overrideComponent`.
- The behavior is addressed by #14490, but the existing coverage does not reproduce the required-input override path from the report.

What:

- Add a focused regression that replaces the standalone child with `MockComponent`.
- Assert that the bound required input remains a signal and is still callable on the mocked component instance.

Where:

- Add `tests/issue-8887/test.spec.ts`.
- Gate the spec to Angular targets with signal-input support in `test-spread.conf`.

Closes #8887