### PR TITLE
test(MockComponent): cover aliased signal inputs #9684

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -63,6 +63,7 @@ file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs
+file|tests/issue-9684/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
 file|tests/issue-11324/test.spec.ts|versions=15+

--- a/tests/issue-9684/test.spec.ts
+++ b/tests/issue-9684/test.spec.ts
@@ -1,0 +1,72 @@
+import {
+  Component,
+  input,
+  isSignal,
+  reflectComponentType,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockComponents, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'target-9684-fallheader-iconbar',
+  standalone: false,
+  template: '',
+})
+class FallheaderIconbarComponent {
+  public readonly hasLocalChangesInput = input(false, {
+    alias: 'hasLocalChanges',
+  });
+}
+
+@Component({
+  selector: 'target-9684-fallheader',
+  standalone: false,
+  template: `
+    <target-9684-fallheader-iconbar
+      [hasLocalChanges]="hasLocalChanges"
+    />
+  `,
+})
+class FallheaderComponent {
+  public readonly hasLocalChanges = true;
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/9684
+describe('issue-9684', () => {
+  if (
+    !reflectComponentType(FallheaderIconbarComponent)?.inputs.some(
+      inputMetadata =>
+        inputMetadata.propName === 'hasLocalChangesInput',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      declarations: [
+        FallheaderComponent,
+        ...MockComponents(FallheaderIconbarComponent),
+      ],
+    }).compileComponents(),
+  );
+
+  it('keeps aliased signal inputs on mocked components', () => {
+    const fixture = TestBed.createComponent(FallheaderComponent);
+    fixture.detectChanges();
+
+    const mocked = ngMocks.find(
+      FallheaderIconbarComponent,
+    ).componentInstance;
+
+    expect(isSignal(mocked.hasLocalChangesInput)).toBe(true);
+    expect(mocked.hasLocalChangesInput()).toBe(
+      fixture.componentInstance.hasLocalChanges,
+    );
+  });
+});


### PR DESCRIPTION
Why:

- #9684 reports that `MockComponents` loses the public alias of an input signal, causing Angular to reject the unchanged template binding.
- The behavior is fixed by #14490, but the existing coverage does not reproduce the `TestBed` declarations and `MockComponents` path from the report.

What:

- Add a focused regression that mocks the child through `MockComponents` and binds its signal input through the public alias.
- Assert that the mocked field remains a callable signal with the bound value.

Where:

- Add `tests/issue-9684/test.spec.ts`.
- Gate the spec to Angular targets with signal-input support in `test-spread.conf`.

Supersedes #14498.

Closes #9684