### PR TITLE
fix(TestBed): preserve unmocked standalone imports #8649

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -17,6 +17,7 @@ import coreReflectMeta from './core.reflect.meta';
 import coreReflectProvidedIn from './core.reflect.provided-in';
 import { NG_MOCKS, NG_MOCKS_ROOT_PROVIDERS, NG_MOCKS_TOUCHES } from './core.tokens';
 import { AnyType, dependencyKeys } from './core.types';
+import { funcExtractDeps } from './func.extract-deps';
 import { getSourceOfMock } from './func.get-source-of-mock';
 import funcGetType from './func.get-type';
 import { isMockNgDef } from './func.is-mock-ng-def';
@@ -262,6 +263,20 @@ const configureTestingModule =
     let finalModuleDef = hasMocks === 0b11 ? undefined : moduleDef;
     if (!finalModuleDef) {
       let builder = MockBuilder(NG_MOCKS_ROOT_PROVIDERS);
+
+      const realDependencies = new Set<AnyType<any>>();
+      for (const [source, , isMock] of mockBuilder) {
+        if (!isMock) {
+          funcExtractDeps(funcGetType(source), realDependencies, true);
+        }
+      }
+      for (const dependency of mapValues(realDependencies)) {
+        // Explicit TestBed entries are applied below and take precedence.
+        // Global resolutions keep their existing MockBuilder semantics.
+        if (!ngMocksUniverse.getResolution(dependency)) {
+          builder = builder.keep(dependency, { dependency: true });
+        }
+      }
 
       for (const [source, def, isMock] of mockBuilder) {
         const transform = def.prototype.__ngMocksConfig?.transform;

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -64,6 +64,7 @@ file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-9684/test.spec.ts|features=signalInputs
+file|tests/issue-8649/*.ts|features=standalone
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
 file|tests/issue-11324/test.spec.ts|versions=15+

--- a/tests/issue-8649/test.spec.ts
+++ b/tests/issue-8649/test.spec.ts
@@ -1,0 +1,147 @@
+import { Component, VERSION } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  isMockOf,
+  MockBuilder,
+  MockComponent,
+  MockRender,
+  ngMocks,
+} from 'ng-mocks';
+
+@Component({
+  selector: 'issue-8649-my-comp-2',
+  template: 'real MyComp2',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+})
+class MyComp2 {}
+
+@Component({
+  selector: 'issue-8649-my-comp-1',
+  template: '<issue-8649-my-comp-2></issue-8649-my-comp-2>',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    MyComp2,
+  ],
+})
+class MyComp1 {}
+
+@Component({
+  selector: 'issue-8649-target',
+  template: `
+    <issue-8649-my-comp-1></issue-8649-my-comp-1>
+    <issue-8649-my-comp-2></issue-8649-my-comp-2>
+  `,
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    MyComp1,
+    MyComp2,
+  ],
+})
+class TargetComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/8649
+// The failure needs a shared standalone import: TargetComponent and MyComp1
+// both import MyComp2. MockComponent(MyComp1) creates a mock of that nested
+// import before the mixed-TestBed bridge resolves TargetComponent's real graph,
+// so the cached mock leaks into TargetComponent's own MyComp2 import.
+// Real TestBed roots and their dependencies should stay real unless the user
+// explicitly mocks them, while MockBuilder's shallow behavior stays unchanged.
+describe('issue-8649', () => {
+  if (Number.parseInt(VERSION.major, 10) < 14) {
+    it('needs >=a14', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  it('keeps an unrequested shared import real with declarations', async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MockComponent(MyComp1)],
+      imports: [TargetComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TargetComponent);
+    fixture.detectChanges();
+
+    const myComp1 = ngMocks.findInstance(fixture, MyComp1);
+    const myComp2 = ngMocks.findInstance(fixture, MyComp2);
+
+    // The author explicitly requested a mock of MyComp1 only.
+    expect(isMockOf(myComp1, MyComp1)).toBe(true);
+
+    // MyComp2 is also rendered directly by the real TargetComponent, so the
+    // author's untouched TestBed import graph should keep it real.
+    expect(isMockOf(myComp2, MyComp2)).toBe(false);
+    expect(ngMocks.formatText(fixture)).toContain('real MyComp2');
+  });
+
+  it('keeps an unrequested shared import real with imports', async () => {
+    await TestBed.configureTestingModule({
+      imports: [TargetComponent, MockComponent(MyComp1)],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TargetComponent);
+    fixture.detectChanges();
+
+    const myComp1 = ngMocks.findInstance(fixture, MyComp1);
+    const myComp2 = ngMocks.findInstance(fixture, MyComp2);
+
+    // Moving a standalone mock to imports must not widen the requested scope.
+    expect(isMockOf(myComp1, MyComp1)).toBe(true);
+    expect(isMockOf(myComp2, MyComp2)).toBe(false);
+    expect(ngMocks.formatText(fixture)).toContain('real MyComp2');
+  });
+
+  it('mocks the shared import when explicitly requested', async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TargetComponent,
+        MockComponent(MyComp1),
+        MockComponent(MyComp2),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TargetComponent);
+    fixture.detectChanges();
+
+    const myComp1 = ngMocks.findInstance(fixture, MyComp1);
+    const myComp2 = ngMocks.findInstance(fixture, MyComp2);
+
+    // Explicit mocks take precedence over the real root's dependency graph.
+    expect(isMockOf(myComp1, MyComp1)).toBe(true);
+    expect(isMockOf(myComp2, MyComp2)).toBe(true);
+  });
+
+  describe('with a global resolution', () => {
+    beforeAll(() => ngMocks.globalMock(MyComp2));
+    afterAll(() => ngMocks.globalWipe(MyComp2));
+
+    it('mocks the shared import when globally requested', async () => {
+      await TestBed.configureTestingModule({
+        imports: [TargetComponent, MockComponent(MyComp1)],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(TargetComponent);
+      fixture.detectChanges();
+
+      const myComp2 = ngMocks.findInstance(fixture, MyComp2);
+
+      // Global resolutions also take precedence over inferred real imports.
+      expect(isMockOf(myComp2, MyComp2)).toBe(true);
+    });
+  });
+
+  it('still mocks standalone imports with MockBuilder shallow rendering', async () => {
+    await MockBuilder(TargetComponent);
+
+    const fixture = MockRender(TargetComponent);
+    const myComp1 = ngMocks.findInstance(fixture, MyComp1);
+    const myComp2 = ngMocks.findInstance(fixture, MyComp2);
+
+    // MockBuilder(TargetComponent) explicitly requests shallow rendering.
+    expect(isMockOf(myComp1, MyComp1)).toBe(true);
+    expect(isMockOf(myComp2, MyComp2)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

When a real standalone component and an explicitly mocked standalone child share an import, MockComponent can resolve a mock for that shared dependency before the mixed TestBed bridge rebuilds the module. The cached mock then replaces the dependency in the real target component even though the caller did not request it.

## What

- Preserve the recursive dependency graph of real TestBed declarations and imports while rebuilding mixed real and mock configurations.
- Keep explicit TestBed mocks and global ng-mocks resolutions higher priority than inferred real dependencies.
- Add cross-version regression coverage for declarations and imports usage, explicit and global mocking, and MockBuilder shallow rendering.

## Impact

Mixed TestBed configurations now mock only the standalone components requested by the caller. Shared imports of real roots remain real by default, while explicit mocks, global resolutions, and MockBuilder shallow behavior remain unchanged.

Fixes #8649