### PR TITLE
test(MockComponent): cover required signal inputs #7976

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -62,6 +62,7 @@ file|tests/issue-13089/test.spec.ts|features=signalForms
 file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
+file|tests/issue-7976/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-9684/test.spec.ts|features=signalInputs
 file|tests/issue-6143/*.ts|versions=15+

--- a/tests/issue-7976/test.spec.ts
+++ b/tests/issue-7976/test.spec.ts
@@ -1,0 +1,65 @@
+import {
+  Component,
+  input,
+  isSignal,
+  NgModule,
+  reflectComponentType,
+} from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+interface User {
+  name: string;
+}
+
+@Component({
+  selector: 'target-7976-user-profile-card',
+  standalone: false,
+  template: '{{ user().name }}',
+})
+class UserProfileCardComponent {
+  public readonly user = input.required<User>();
+}
+
+@Component({
+  selector: 'target-7976',
+  standalone: false,
+  template: ` <target-7976-user-profile-card [user]="user" /> `,
+})
+class TargetComponent {
+  public readonly user: User = {
+    name: 'test',
+  };
+}
+
+@NgModule({
+  declarations: [TargetComponent, UserProfileCardComponent],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/7976
+describe('issue-7976', () => {
+  if (
+    !reflectComponentType(UserProfileCardComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'user',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+  it('binds required signal inputs on mocked components', () => {
+    const fixture = MockRender(TargetComponent);
+    const mocked = ngMocks.find(
+      UserProfileCardComponent,
+    ).componentInstance;
+
+    expect(isSignal(mocked.user)).toBe(true);
+    expect(mocked.user()).toBe(fixture.point.componentInstance.user);
+  });
+});


### PR DESCRIPTION
Why:

- #7976 reports that module templates could not bind required signal inputs on mocked components, causing NG0303 and NG0950 failures.

What:

- Add a focused regression for the `MockBuilder` and `MockRender` path.
- Verify that the mocked required input remains a signal and receives the bound value.

Where:

- `tests/issue-7976/test.spec.ts`
- `test-spread.conf`

Closes #7976