### PR TITLE
fix(MockBuilder): support deep module re-exports #7490

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.extract-deps.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.extract-deps.spec.ts
@@ -1,0 +1,48 @@
+import { NgModule } from '@angular/core';
+
+import { funcExtractDeps } from './func.extract-deps';
+
+@NgModule({})
+class Issue7490Level4Module {}
+
+@NgModule({
+  imports: [Issue7490Level4Module],
+})
+class Issue7490Level3Module {}
+
+@NgModule({
+  imports: [Issue7490Level3Module],
+})
+class Issue7490Level2Module {}
+
+@NgModule({
+  imports: [Issue7490Level2Module],
+})
+class Issue7490Level1Module {}
+
+describe('funcExtractDeps', () => {
+  it('collects recursive dependencies to their full depth', () => {
+    const result = funcExtractDeps(
+      Issue7490Level1Module,
+      new Set(),
+      true,
+    );
+
+    expect(result.size).toBe(3);
+    expect(result.has(Issue7490Level2Module)).toBe(true);
+    expect(result.has(Issue7490Level3Module)).toBe(true);
+    expect(result.has(Issue7490Level4Module)).toBe(true);
+  });
+
+  it('traverses dependencies already present in the destination', () => {
+    const result = funcExtractDeps(
+      Issue7490Level1Module,
+      new Set([Issue7490Level2Module]),
+      true,
+    );
+
+    expect(result.size).toBe(3);
+    expect(result.has(Issue7490Level3Module)).toBe(true);
+    expect(result.has(Issue7490Level4Module)).toBe(true);
+  });
+});

--- a/libs/ng-mocks/src/lib/common/func.extract-deps.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.extract-deps.spec.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 
+import { AnyDeclaration } from './core.types';
 import { funcExtractDeps } from './func.extract-deps';
 
 @NgModule({})
@@ -44,5 +45,20 @@ describe('funcExtractDeps', () => {
     expect(result.size).toBe(3);
     expect(result.has(Issue7490Level3Module)).toBe(true);
     expect(result.has(Issue7490Level4Module)).toBe(true);
+  });
+
+  it('shares traversal state across dependency roots', () => {
+    const visited = new Set<AnyDeclaration<any>>();
+    const result = funcExtractDeps(
+      Issue7490Level1Module,
+      new Set(),
+      true,
+      visited,
+    );
+
+    funcExtractDeps(Issue7490Level1Module, result, true, visited);
+
+    expect(result.size).toBe(3);
+    expect(visited.size).toBe(4);
   });
 });

--- a/libs/ng-mocks/src/lib/common/func.extract-deps.ts
+++ b/libs/ng-mocks/src/lib/common/func.extract-deps.ts
@@ -11,30 +11,38 @@ export const funcExtractDeps = (
   result: Set<AnyDeclaration<any>>,
   recursive = false,
 ): Set<AnyDeclaration<any>> => {
-  const meta = collectDeclarations(def);
-  const type = getNgType(def);
-  // istanbul ignore if
-  if (!type || type === 'Injectable') {
-    return result;
-  }
+  const visited = new Set<AnyDeclaration<any>>();
+  const visit = (current: any): void => {
+    if (visited.has(current)) {
+      return;
+    }
+    visited.add(current);
 
-  const decorator = meta[type];
-  for (const field of coreConfig.dependencies) {
-    if (!decorator[field]) {
-      continue;
+    const meta = collectDeclarations(current);
+    const type = getNgType(current);
+    // istanbul ignore if
+    if (!type || type === 'Injectable') {
+      return;
     }
 
-    for (const item of flatten(decorator[field])) {
-      // istanbul ignore if: it is here for standalone things, however they don't support modules with providers.
-      const itemType = funcGetType(item);
-      if (!result.has(itemType)) {
+    const decorator = meta[type];
+    for (const field of coreConfig.dependencies) {
+      if (!decorator[field]) {
+        continue;
+      }
+
+      for (const item of flatten(decorator[field])) {
+        // istanbul ignore if: it is here for standalone things, however they don't support modules with providers.
+        const itemType = funcGetType(item);
         result.add(itemType);
         if (recursive) {
-          funcExtractDeps(itemType, result);
+          visit(itemType);
         }
       }
     }
-  }
+  };
+
+  visit(def);
 
   return result;
 };

--- a/libs/ng-mocks/src/lib/common/func.extract-deps.ts
+++ b/libs/ng-mocks/src/lib/common/func.extract-deps.ts
@@ -10,8 +10,8 @@ export const funcExtractDeps = (
   def: any,
   result: Set<AnyDeclaration<any>>,
   recursive = false,
+  visited = new Set<AnyDeclaration<any>>(),
 ): Set<AnyDeclaration<any>> => {
-  const visited = new Set<AnyDeclaration<any>>();
   const visit = (current: any): void => {
     if (visited.has(current)) {
       return;

--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -265,9 +265,10 @@ const configureTestingModule =
       let builder = MockBuilder(NG_MOCKS_ROOT_PROVIDERS);
 
       const realDependencies = new Set<AnyType<any>>();
+      const visitedDependencies = new Set<AnyType<any>>();
       for (const [source, , isMock] of mockBuilder) {
         if (!isMock) {
-          funcExtractDeps(funcGetType(source), realDependencies, true);
+          funcExtractDeps(funcGetType(source), realDependencies, true, visitedDependencies);
         }
       }
       for (const dependency of mapValues(realDependencies)) {

--- a/libs/ng-mocks/src/lib/mock-builder/promise/init-ng-modules.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/init-ng-modules.ts
@@ -62,7 +62,7 @@ const isExportedOnRoot = (
   configDef: Map<any, any>,
 ): undefined | Type<any> => {
   const cnfInstance = configInstance.get(def);
-  const cnfDef = configDef.get(def) || /* istanbul ignore next */ {};
+  const cnfDef = configDef.get(def);
 
   if (isNgDef(def, 'm') && cnfDef.onRoot) {
     return def;
@@ -116,14 +116,9 @@ export default ({ configDefault, keepDef, mockDef, replaceDef }: BuilderData, de
     if (!def || processed.indexOf(def) !== -1) {
       continue;
     }
-    const cnfDef = ngMocksUniverse.config.get(def) || /* istanbul ignore next */ { __set: true };
+    const cnfDef = ngMocksUniverse.config.get(def);
     processed.push(def);
     cnfDef.onRoot = cnfDef.onRoot || !cnfDef.dependency;
-    // istanbul ignore if
-    if (cnfDef.__set) {
-      cnfDef.__set = undefined;
-      ngMocksUniverse.config.set(def, cnfDef);
-    }
 
     if (isNgDef(def, 'm') && cnfDef.onRoot) {
       handleDef(meta, def, defProviders);

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -56,6 +56,7 @@ file|tests/mock-service/observable.spec.ts|versions=6+
 file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
+file|tests/issue-7490/*.ts|versions=17+
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-11001/test.spec.ts|features=signalInputs
 file|tests/issue-13089/test.spec.ts|features=signalForms

--- a/tests/issue-7490/test.spec.ts
+++ b/tests/issue-7490/test.spec.ts
@@ -1,0 +1,55 @@
+import { CommonModule } from '@angular/common';
+import { Component, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@NgModule({
+  imports: [CommonModule],
+  exports: [CommonModule],
+})
+class Issue7490Level4Module {}
+
+@NgModule({
+  imports: [Issue7490Level4Module],
+  exports: [Issue7490Level4Module],
+})
+class Issue7490Level3Module {}
+
+@NgModule({
+  imports: [Issue7490Level3Module],
+  exports: [Issue7490Level3Module],
+})
+class Issue7490Level2Module {}
+
+@NgModule({
+  imports: [Issue7490Level2Module],
+  exports: [Issue7490Level2Module],
+})
+class Issue7490Level1Module {}
+
+@Component({
+  selector: 'issue-7490-target',
+  template: '<ng-container *ngIf="true">target</ng-container>',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    CommonModule,
+    Issue7490Level1Module,
+  ],
+})
+class Issue7490TargetComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/7490
+// CommonModule is both a direct standalone import and a deep re-export.
+// MockBuilder must configure the complete dependency graph before it follows
+// export parents to select the TestBed root.
+describe('issue-7490', () => {
+  beforeEach(() => MockBuilder(Issue7490TargetComponent));
+
+  it('builds a standalone target with deep CommonModule re-exports', () => {
+    const fixture = TestBed.createComponent(Issue7490TargetComponent);
+    fixture.detectChanges();
+
+    expect(ngMocks.formatText(fixture)).toBe('target');
+  });
+});


### PR DESCRIPTION
## Why

`MockBuilder` creates definition configuration before resolving the module that exports each dependency onto the TestBed root. Recursive dependency extraction stopped after one nested traversal and also used the destination set as visited state, so a deep re-export chain could reach a definition that had never been configured and fail while reading `onRoot`.

The fallback configuration path masked that incomplete graph instead of preserving the configuration invariant.

## What

- Traverse recursive dependencies to their full depth with an independent visited set.
- Require export-root resolution to consume the complete prebuilt configuration graph, removing fallback and lazy configuration insertion.
- Add focused traversal coverage and an Angular 17+ standalone regression for a dependency shared through a deep module re-export chain.

## Impact

Standalone targets can now share imports with deeply re-exported NgModules without producing incomplete MockBuilder configuration. Recursive traversal remains cycle-safe, and export-root selection no longer relies on synthetic partial configuration objects.

Fixes #7490
