### PR TITLE
test(TestBed): cover faster provider teardown #5437

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -59,6 +59,7 @@ file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-7490/*.ts|versions=17+
+file|tests/issue-5437/*.ts|versions=13+
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-11001/test.spec.ts|features=signalInputs
 file|tests/issue-13089/test.spec.ts|features=signalForms

--- a/tests/issue-5437/test.spec.ts
+++ b/tests/issue-5437/test.spec.ts
@@ -1,0 +1,58 @@
+import {
+  Component,
+  Injectable,
+  NgModule,
+  OnDestroy,
+} from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+let destroyCalls = 0;
+
+@Injectable({ providedIn: 'root' })
+class Issue5437Service implements OnDestroy {
+  public ngOnDestroy(): void {
+    destroyCalls += 1;
+  }
+}
+
+@Component({
+  selector: 'issue-5437-target',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '',
+})
+class Issue5437TargetComponent {
+  public constructor(public readonly service: Issue5437Service) {}
+}
+
+@NgModule({
+  declarations: [Issue5437TargetComponent],
+})
+class Issue5437Module {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/5437
+// ngMocks.faster used to discard the TestBed module reference without destroying
+// its injector, so kept providers never received ngOnDestroy between tests.
+describe('issue-5437', () => {
+  ngMocks.faster();
+
+  beforeEach(() =>
+    MockBuilder(Issue5437TargetComponent, Issue5437Module).keep(
+      Issue5437Service,
+    ),
+  );
+
+  it('creates the kept service', () => {
+    const fixture = MockRender(Issue5437TargetComponent);
+
+    expect(fixture.point.componentInstance.service).toBeTruthy();
+    expect(destroyCalls).toBe(0);
+  });
+
+  it('destroys the kept service after the previous test', () => {
+    expect(destroyCalls).toBe(1);
+
+    const fixture = MockRender(Issue5437TargetComponent);
+    expect(fixture.point.componentInstance.service).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Why:

- `ngMocks.faster()` previously discarded the TestBed module reference without destroying its injector, so kept providers did not receive `ngOnDestroy` between tests.
- The lifecycle gap reported in #5437 was fixed by #10825, but the existing unit coverage only verifies that `tearDownTestingModule()` is invoked.

What:

- Add an independent issue regression that renders a kept root provider and verifies its real `ngOnDestroy` lifecycle between tests.
- Run the regression on Angular 13+, where TestBed teardown is enabled by default.

Where:

- `tests/issue-5437/test.spec.ts`
- `test-spread.conf`

Closes #5437