### PR TITLE
fix(MockComponent): handle circular standalone imports #8627

### DIFF
--- a/libs/ng-mocks/src/lib/mock-module/create-resolvers.ts
+++ b/libs/ng-mocks/src/lib/mock-module/create-resolvers.ts
@@ -73,6 +73,14 @@ const createResolve =
     if (resolutions.has(def)) {
       return createResolveExisting(def, resolutions, change);
     }
+    if (ngMocksUniverse.config.get('mockNgDefConstruction')?.has(def)) {
+      // Mock templates do not need an import which points back into their current
+      // construction path. Do not cache the omission: the outer resolver will
+      // publish the completed mock after its decorator returns.
+      change();
+
+      return undefined;
+    }
 
     const detectedDef = funcGetType(def);
     if (ngMocksUniverse.isExcludedDef(detectedDef)) {

--- a/libs/ng-mocks/src/lib/mock/get-mock.ts
+++ b/libs/ng-mocks/src/lib/mock/get-mock.ts
@@ -22,16 +22,30 @@ export default (def: any, type: any, func: string, cacheFlag: string, base: any,
   }
 
   const mock = extendClass(base);
-  decorator(def, mock);
-
-  // istanbul ignore else
-  if (ngMocksUniverse.flags.has(cacheFlag)) {
-    ngMocksUniverse.cacheDeclarations.set(def, mock);
+  const hasMockNgDefConstruction = ngMocksUniverse.config.has('mockNgDefConstruction');
+  if (!hasMockNgDefConstruction) {
+    ngMocksUniverse.config.set('mockNgDefConstruction', new Set());
   }
+  // Keep the active construction path separate from completed mock caches.
+  ngMocksUniverse.config.get('mockNgDefConstruction').add(def);
 
-  if (!hasNgMocksDepsResolution) {
-    ngMocksUniverse.config.delete('ngMocksDepsResolution');
+  try {
+    decorator(def, mock);
+
+    // istanbul ignore else
+    if (ngMocksUniverse.flags.has(cacheFlag)) {
+      ngMocksUniverse.cacheDeclarations.set(def, mock);
+    }
+
+    return mock as any;
+  } finally {
+    ngMocksUniverse.config.get('mockNgDefConstruction').delete(def);
+    if (!hasMockNgDefConstruction) {
+      ngMocksUniverse.config.delete('mockNgDefConstruction');
+    }
+
+    if (!hasNgMocksDepsResolution) {
+      ngMocksUniverse.config.delete('ngMocksDepsResolution');
+    }
   }
-
-  return mock as any;
 };

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -71,6 +71,7 @@ file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-9684/test.spec.ts|features=signalInputs
 file|tests/issue-8649/*.ts|features=standalone
 file|tests/issue-4486/*.ts|features=standalone
+file|tests/issue-8627/*.ts|features=standalone
 file|tests/issue-6143/*.ts|versions=15+
 file|tests/issue-7938/*.ts|versions=15+
 file|tests/issue-11324/test.spec.ts|versions=15+

--- a/tests/issue-8627/test.spec.ts
+++ b/tests/issue-8627/test.spec.ts
@@ -1,0 +1,53 @@
+import { Component, forwardRef } from '@angular/core';
+
+import { MockComponent } from 'ng-mocks';
+
+@Component({
+  selector: 'issue-8627-recursive',
+  template: 'dependency',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    RecursiveComponent,
+  ],
+})
+class RecursiveComponent {}
+
+@Component({
+  selector: 'issue-8627-cycle-a',
+  template: 'cycle-a',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    forwardRef(() => CycleBComponent),
+  ],
+})
+class CycleAComponent {}
+
+@Component({
+  selector: 'issue-8627-cycle-b',
+  template: 'cycle-b',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: true,
+  ['imports' as never /* TODO: remove after upgrade to a14 */]: [
+    CycleAComponent,
+  ],
+})
+class CycleBComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/8627
+// A standalone declaration can reference itself directly or through a longer import cycle.
+// Mock construction has to track its current path and omit back-edges from mock metadata,
+// otherwise ng-mocks or Angular recursively parses the same declarations until the stack overflows.
+describe('issue-8627', () => {
+  it('mocks a standalone component that imports itself', () => {
+    const mock = MockComponent(RecursiveComponent);
+
+    expect(mock).not.toBe(RecursiveComponent);
+  });
+
+  it('mocks both sides of a standalone dependency cycle', () => {
+    const mockA = MockComponent(CycleAComponent);
+    const mockB = MockComponent(CycleBComponent);
+
+    expect(mockA).not.toBe(CycleAComponent);
+    expect(mockB).not.toBe(CycleBComponent);
+  });
+});


### PR DESCRIPTION
## Why

When `MockComponent` decorates a standalone declaration, it resolves the declaration's imports before publishing the completed mock. A direct self-import or a longer import cycle can therefore re-enter mock construction for a declaration already being decorated and recurse until the stack overflows.

## What

- Track declarations currently being constructed separately from completed mock and provider resolutions.
- Treat imports that point back into the active construction path as back-edges and omit them from generated mock metadata without caching the omission.
- Clean up construction state on both successful and exceptional paths.
- Add standalone regression coverage for a direct self-import and a two-component cycle.

## Impact

Standalone components with direct or transitive circular imports can now be mocked without recursive parsing. Completed mock caching, provider resolution, and subsequent independent mock construction retain their existing behavior.

Fixes #8627