### PR TITLE
fix(MockBuilder): mock standalone inject services #9397

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -28,6 +28,7 @@ import {
   rememberMockDeclarations,
   resetInjectedDeclarations,
 } from './ng-mocks-injected-declarations';
+import { resetRuntimeInject } from './ng-mocks-runtime-inject';
 import { rememberTestModuleOptions, resetTestModuleOptions } from './ng-mocks-test-module-metadata';
 import ngMocksUniverse from './ng-mocks-universe';
 type NgMocksTestBed = TestBedStatic & {
@@ -336,6 +337,7 @@ const configureTestingModule =
 const resetTestingModule =
   (original: TestBedStatic['resetTestingModule'], instance: TestBedStatic): TestBedStatic['resetTestingModule'] =>
   () => {
+    resetRuntimeInject();
     ngMocksUniverse.global.delete('builder:config');
     ngMocksUniverse.global.delete('builder:module');
     resetTestModuleOptions();

--- a/libs/ng-mocks/src/lib/common/ng-mocks-runtime-inject.spec.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-runtime-inject.spec.ts
@@ -1,0 +1,119 @@
+import {
+  installRuntimeInject,
+  resetRuntimeInject,
+} from './ng-mocks-runtime-inject';
+
+class TargetService {
+  public echo(): string {
+    return 'real';
+  }
+}
+
+(TargetService as any).ɵprov = { providedIn: 'root' };
+
+describe('ng-mocks-runtime-inject', () => {
+  afterEach(() => resetRuntimeInject());
+
+  it('restores existing injector and declaration factory descriptors', () => {
+    const destroyCallbacks: Array<() => void> = [];
+    const originalGet = jasmine
+      .createSpy('get')
+      .and.callFake((provide: any) => new provide());
+    const injector = {
+      get: originalGet,
+      onDestroy: (callback: () => void) =>
+        destroyCallbacks.push(callback),
+    };
+    const definition = {
+      factory: null as null | (() => TargetService),
+    };
+    const declaration = {
+      ɵcmp: definition,
+      ɵfac: () => injector.get(TargetService),
+    };
+    const injectorDescriptor = Object.getOwnPropertyDescriptor(
+      injector,
+      'get',
+    );
+    const factoryDescriptor = Object.getOwnPropertyDescriptor(
+      definition,
+      'factory',
+    );
+
+    installRuntimeInject(injector, new Set([declaration]), new Set());
+
+    const service = definition.factory!();
+    service.echo();
+
+    expect(service.echo).toHaveBeenCalled();
+    expect(injector.get(TargetService)).toBe(service);
+    expect(originalGet).not.toHaveBeenCalled();
+
+    destroyCallbacks[0]();
+
+    expect(Object.getOwnPropertyDescriptor(injector, 'get')).toEqual(
+      injectorDescriptor,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(definition, 'factory'),
+    ).toEqual(factoryDescriptor);
+    expect(injector.get(TargetService)).not.toBe(service);
+    expect(originalGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('finds its construction window below a nested injector scope', () => {
+    const firstDestroyCallbacks: Array<() => void> = [];
+    const secondDestroyCallbacks: Array<() => void> = [];
+    const firstGet = jasmine
+      .createSpy('firstGet')
+      .and.callFake((provide: any) => new provide());
+    const secondGet = jasmine
+      .createSpy('secondGet')
+      .and.callFake((provide: any) => new provide());
+    const firstInjector = {
+      get: firstGet,
+      onDestroy: (callback: () => void) =>
+        firstDestroyCallbacks.push(callback),
+    };
+    const secondInjector = {
+      get: secondGet,
+      onDestroy: (callback: () => void) =>
+        secondDestroyCallbacks.push(callback),
+    };
+    const firstDefinition = {
+      factory: null as null | (() => TargetService),
+    };
+    const secondDefinition = {
+      factory: null as null | (() => TargetService),
+    };
+    const firstDeclaration = {
+      ɵcmp: firstDefinition,
+      ɵfac: () => secondDefinition.factory!(),
+    };
+    const secondDeclaration = {
+      ɵcmp: secondDefinition,
+      ɵfac: () => firstInjector.get(TargetService),
+    };
+
+    installRuntimeInject(
+      firstInjector,
+      new Set([firstDeclaration]),
+      new Set(),
+    );
+    installRuntimeInject(
+      secondInjector,
+      new Set([secondDeclaration]),
+      new Set(),
+    );
+
+    const service = firstDefinition.factory!();
+    service.echo();
+
+    expect(service.echo).toHaveBeenCalled();
+    expect(firstGet).not.toHaveBeenCalled();
+    expect(secondGet).not.toHaveBeenCalled();
+
+    secondDestroyCallbacks[0]();
+    firstDestroyCallbacks[0]();
+  });
+});

--- a/libs/ng-mocks/src/lib/common/ng-mocks-runtime-inject.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-runtime-inject.ts
@@ -1,0 +1,147 @@
+import helperMockService from '../mock-service/helper.mock-service';
+import helperUseFactory from '../mock-service/helper.use-factory';
+
+import coreConfig from './core.config';
+import coreDefineProperty from './core.define-property';
+import coreReflectProvidedIn from './core.reflect.provided-in';
+import ngMocksUniverse from './ng-mocks-universe';
+
+interface RuntimeInjectConfig {
+  injector: any;
+  mocks: Map<any, any>;
+  restore: () => void;
+  touches: Set<any>;
+}
+
+const active: RuntimeInjectConfig[] = [];
+const installed = new Set<RuntimeInjectConfig>();
+
+const shouldMock = (provide: any, config: RuntimeInjectConfig): boolean => {
+  if (
+    active.indexOf(config) === -1 ||
+    !helperMockService.mockFunction.customMockFunction ||
+    typeof provide !== 'function' ||
+    config.touches.has(provide) ||
+    coreConfig.neverMockProvidedFunction.indexOf(provide.name) !== -1
+  ) {
+    return false;
+  }
+
+  const resolution = ngMocksUniverse.getResolution(provide);
+  if (resolution === 'keep' || resolution === 'exclude') {
+    return false;
+  }
+
+  return coreReflectProvidedIn(provide) === 'root';
+};
+
+const getMock = (provide: any, config: RuntimeInjectConfig): any => {
+  if (!config.mocks.has(provide)) {
+    const provider = helperUseFactory(provide);
+    config.mocks.set(provide, provider.useFactory(config.injector));
+  }
+
+  return config.mocks.get(provide);
+};
+
+const installInjector = (config: RuntimeInjectConfig, restorers: Array<() => void>): void => {
+  const injector = config.injector;
+  const ownDescriptor = Object.getOwnPropertyDescriptor(injector, 'get');
+  const original = injector.get;
+
+  coreDefineProperty(
+    injector,
+    'get',
+    function (this: any, provide: any, ...args: any[]): any {
+      if (config.mocks.has(provide)) {
+        return config.mocks.get(provide);
+      }
+
+      const mock = shouldMock(provide, config);
+      let activeIndex = active.length - 1;
+      while (activeIndex >= 0 && active[activeIndex] !== config) {
+        activeIndex -= 1;
+      }
+      if (activeIndex === -1) {
+        return original.call(this, provide, ...args);
+      }
+
+      active.splice(activeIndex, 1);
+      try {
+        return mock ? getMock(provide, config) : original.call(this, provide, ...args);
+      } finally {
+        active.splice(activeIndex, 0, config);
+      }
+    },
+    true,
+  );
+
+  restorers.push(() => {
+    if (ownDescriptor) {
+      Object.defineProperty(injector, 'get', ownDescriptor);
+    } else {
+      delete injector.get;
+    }
+  });
+};
+
+const installDeclaration = (declaration: any, config: RuntimeInjectConfig, restorers: Array<() => void>): void => {
+  const definition = declaration.ɵcmp ?? declaration.ɵdir ?? declaration.ɵpipe;
+  const factoryDescriptor = definition && Object.getOwnPropertyDescriptor(definition, 'factory');
+  const definitionFactory = definition?.factory;
+  const factory = definitionFactory ?? declaration.ɵfac ?? declaration.ngFactoryDef;
+  if (!definition || !factory) {
+    return;
+  }
+
+  definition.factory = function (this: any, ...args: any[]): any {
+    active.push(config);
+    try {
+      return factory.apply(this, args);
+    } finally {
+      active.pop();
+    }
+  };
+
+  restorers.push(() => {
+    if (factoryDescriptor) {
+      Object.defineProperty(definition, 'factory', factoryDescriptor);
+    } else {
+      delete definition.factory;
+    }
+  });
+};
+
+export const installRuntimeInject = (injector: any, declarations: Set<any>, touches: Set<any>): void => {
+  const restorers: Array<() => void> = [];
+  const config: RuntimeInjectConfig = {
+    injector,
+    mocks: new Map(),
+    restore: () => {
+      while (restorers.length > 0) {
+        restorers.pop()?.();
+      }
+      for (let index = active.length - 1; index >= 0; index -= 1) {
+        if (active[index] === config) {
+          active.splice(index, 1);
+        }
+      }
+      installed.delete(config);
+    },
+    touches,
+  };
+
+  installInjector(config, restorers);
+  for (const declaration of declarations) {
+    installDeclaration(declaration, config, restorers);
+  }
+
+  installed.add(config);
+  injector.onDestroy?.(config.restore);
+};
+
+export const resetRuntimeInject = (): void => {
+  for (const config of installed) {
+    config.restore();
+  }
+};

--- a/libs/ng-mocks/src/lib/common/ng-mocks-runtime-inject.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-runtime-inject.ts
@@ -36,10 +36,8 @@ const shouldMock = (provide: any, config: RuntimeInjectConfig): boolean => {
 };
 
 const getMock = (provide: any, config: RuntimeInjectConfig): any => {
-  if (!config.mocks.has(provide)) {
-    const provider = helperUseFactory(provide);
-    config.mocks.set(provide, provider.useFactory(config.injector));
-  }
+  const provider = helperUseFactory(provide);
+  config.mocks.set(provide, provider.useFactory(config.injector));
 
   return config.mocks.get(provide);
 };
@@ -87,12 +85,8 @@ const installInjector = (config: RuntimeInjectConfig, restorers: Array<() => voi
 
 const installDeclaration = (declaration: any, config: RuntimeInjectConfig, restorers: Array<() => void>): void => {
   const definition = declaration.ɵcmp ?? declaration.ɵdir ?? declaration.ɵpipe;
-  const factoryDescriptor = definition && Object.getOwnPropertyDescriptor(definition, 'factory');
-  const definitionFactory = definition?.factory;
-  const factory = definitionFactory ?? declaration.ɵfac ?? declaration.ngFactoryDef;
-  if (!definition || !factory) {
-    return;
-  }
+  const factoryDescriptor = Object.getOwnPropertyDescriptor(definition, 'factory') as PropertyDescriptor;
+  const factory = declaration.ɵfac;
 
   definition.factory = function (this: any, ...args: any[]): any {
     active.push(config);
@@ -104,11 +98,7 @@ const installDeclaration = (declaration: any, config: RuntimeInjectConfig, resto
   };
 
   restorers.push(() => {
-    if (factoryDescriptor) {
-      Object.defineProperty(definition, 'factory', factoryDescriptor);
-    } else {
-      delete definition.factory;
-    }
+    Object.defineProperty(definition, 'factory', factoryDescriptor);
   });
 };
 
@@ -119,12 +109,7 @@ export const installRuntimeInject = (injector: any, declarations: Set<any>, touc
     mocks: new Map(),
     restore: () => {
       while (restorers.length > 0) {
-        restorers.pop()?.();
-      }
-      for (let index = active.length - 1; index >= 0; index -= 1) {
-        if (active[index] === config) {
-          active.splice(index, 1);
-        }
+        restorers.pop()!();
       }
       installed.delete(config);
     },
@@ -137,7 +122,7 @@ export const installRuntimeInject = (injector: any, declarations: Set<any>, touc
   }
 
   installed.add(config);
-  injector.onDestroy?.(config.restore);
+  injector.onDestroy(config.restore);
 };
 
 export const resetRuntimeInject = (): void => {

--- a/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.ts
@@ -16,6 +16,7 @@ import applyPlatformModules from './promise/apply-platform-modules';
 import createNgMocksOverridesToken from './promise/create-ng-mocks-overrides-token';
 import createNgMocksToken from './promise/create-ng-mocks-token';
 import createNgMocksTouchesToken from './promise/create-ng-mocks-touches-token';
+import createRuntimeInjectProvider from './promise/create-runtime-inject-provider';
 import handleEntryComponents from './promise/handle-entry-components';
 import handleRootProviders from './promise/handle-root-providers';
 import initNgModules from './promise/init-ng-modules';
@@ -89,6 +90,11 @@ export class MockBuilderPromise implements IMockBuilder {
       handleRootProviders(ngModule, params, defStack);
       handleEntryComponents(ngModule);
       applyPlatformModules();
+
+      const runtimeInjectProvider = createRuntimeInjectProvider(this.keepDef);
+      if (runtimeInjectProvider) {
+        ngModule.providers.push(runtimeInjectProvider);
+      }
 
       ngModule.providers.push(
         createNgMocksToken(),

--- a/libs/ng-mocks/src/lib/mock-builder/promise/create-runtime-inject-provider.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/create-runtime-inject-provider.ts
@@ -1,0 +1,31 @@
+import { Injector, Provider } from '@angular/core';
+import * as angularCore from '@angular/core';
+
+import { NG_MOCKS_ROOT_PROVIDERS, NG_MOCKS_TOUCHES } from '../../common/core.tokens';
+import { isNgDef } from '../../common/func.is-ng-def';
+import { isStandalone } from '../../common/func.is-standalone';
+import { installRuntimeInject } from '../../common/ng-mocks-runtime-inject';
+
+export default (keepDef: Set<any>): Provider | undefined => {
+  const environmentInitializer = (angularCore as any).ENVIRONMENT_INITIALIZER;
+  if (!environmentInitializer || keepDef.has(NG_MOCKS_ROOT_PROVIDERS)) {
+    return undefined;
+  }
+
+  const declarations = new Set<any>();
+  for (const def of keepDef) {
+    if (isStandalone(def) && (isNgDef(def, 'c') || isNgDef(def, 'd') || isNgDef(def, 'p'))) {
+      declarations.add(def);
+    }
+  }
+  if (declarations.size === 0) {
+    return undefined;
+  }
+
+  return {
+    deps: [Injector, NG_MOCKS_TOUCHES],
+    multi: true,
+    provide: environmentInitializer,
+    useFactory: (injector: Injector, touches: Set<any>) => () => installRuntimeInject(injector, declarations, touches),
+  };
+};

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -52,6 +52,7 @@ file|examples/TestRoutingResolver/fn.spec.ts|features=routerFns
 file|examples/TestRoutingResolver/standalone.spec.ts|features=standalone,routerFns
 file|tests/issue-7495/*.ts|features=standalone,routerFns
 file|tests/issue-4282/*.ts|versions=6+
+file|tests/issue-9397/*.ts|features=injectFn
 file|examples/TestRoutingGuard/test.spec.ts|versions=6+
 file|examples/TestRoutingResolver/test.spec.ts|versions=5+
 file|tests/mock-service/observable.spec.ts|versions=6+

--- a/tests/issue-9397/test.spec.ts
+++ b/tests/issue-9397/test.spec.ts
@@ -135,6 +135,42 @@ describe('issue-9397', () => {
     });
   });
 
+  describe('global keep', () => {
+    beforeEach(() => {
+      ngMocks.globalKeep(TargetService);
+
+      return MockBuilder(TargetComponent);
+    });
+    afterEach(() => ngMocks.globalWipe(TargetService));
+
+    it('preserves globally kept runtime dependencies', () => {
+      const fixture = MockRender(TargetComponent);
+      const service = TestBed.inject(TargetService);
+
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(service.echo()).toBe('real');
+      expect(TargetService.constructed).toBe(1);
+    });
+  });
+
+  describe('global exclude', () => {
+    beforeEach(() => {
+      ngMocks.globalExclude(TargetService);
+
+      return MockBuilder(TargetComponent);
+    });
+    afterEach(() => ngMocks.globalWipe(TargetService));
+
+    it('preserves globally excluded runtime dependencies', () => {
+      const fixture = MockRender(TargetComponent);
+      const service = TestBed.inject(TargetService);
+
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(service.echo()).toBe('real');
+      expect(TargetService.constructed).toBe(1);
+    });
+  });
+
   describe('kept standalone declarations', () => {
     beforeEach(() =>
       MockBuilder(HostComponent)

--- a/tests/issue-9397/test.spec.ts
+++ b/tests/issue-9397/test.spec.ts
@@ -1,0 +1,159 @@
+import { DOCUMENT } from '@angular/common';
+import {
+  Component,
+  Directive,
+  Inject,
+  inject,
+  Injectable,
+  OnInit,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MockBuilder,
+  MockInstance,
+  MockRender,
+  ngMocks,
+} from 'ng-mocks';
+
+@Injectable({ providedIn: 'root' })
+class TargetService {
+  public static constructed = 0;
+
+  public constructor(@Inject(DOCUMENT) document: Document) {
+    void document;
+    TargetService.constructed += 1;
+  }
+
+  public echo(): string {
+    return 'real';
+  }
+}
+
+@Component({
+  selector: 'target-9397',
+  standalone: true,
+  template: '',
+})
+class TargetComponent implements OnInit {
+  public readonly service = inject(TargetService);
+
+  public ngOnInit(): void {
+    this.service.echo();
+  }
+}
+
+@Directive({
+  selector: '[target-9397]',
+  standalone: true,
+})
+class TargetDirective implements OnInit {
+  public readonly service = inject(TargetService);
+
+  public ngOnInit(): void {
+    this.service.echo();
+  }
+}
+
+@Pipe({
+  name: 'target9397',
+  standalone: true,
+})
+class TargetPipe implements PipeTransform {
+  public readonly service = inject(TargetService);
+
+  public transform(value: string): string {
+    this.service.echo();
+
+    return value;
+  }
+}
+
+@Component({
+  imports: [TargetDirective, TargetPipe],
+  selector: 'host-9397',
+  standalone: true,
+  template: '<div target-9397>{{ "value" | target9397 }}</div>',
+})
+class HostComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/9397
+describe('issue-9397', () => {
+  beforeEach(() =>
+    ngMocks.autoSpy(typeof jest === 'undefined' ? 'jasmine' : 'jest'),
+  );
+  afterEach(() => ngMocks.autoSpy('reset'));
+
+  beforeEach(() => {
+    TargetService.constructed = 0;
+  });
+
+  describe('standalone component', () => {
+    beforeEach(() => MockBuilder(TargetComponent));
+
+    it('mocks inject() dependencies before the initial lifecycle', () => {
+      const fixture = MockRender(TargetComponent);
+      const service = TestBed.inject(TargetService);
+
+      expect(service.echo).toHaveBeenCalledTimes(1);
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(TargetService.constructed).toBe(0);
+    });
+  });
+
+  describe('customization', () => {
+    MockInstance.scope();
+
+    beforeEach(() => MockBuilder(TargetComponent));
+
+    it('applies MockInstance customizations to the runtime mock', () => {
+      MockInstance(TargetService, 'echo', () => 'custom');
+
+      const fixture = MockRender(TargetComponent);
+      const service = TestBed.inject(TargetService);
+
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(service.echo()).toBe('custom');
+      expect(TargetService.constructed).toBe(0);
+    });
+  });
+
+  describe('explicit keep', () => {
+    beforeEach(() =>
+      MockBuilder(TargetComponent).keep(TargetService),
+    );
+
+    it('preserves explicitly kept runtime dependencies', () => {
+      const fixture = MockRender(TargetComponent);
+      const service = TestBed.inject(TargetService);
+
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(service.echo()).toBe('real');
+      expect(TargetService.constructed).toBe(1);
+    });
+  });
+
+  describe('kept standalone declarations', () => {
+    beforeEach(() =>
+      MockBuilder(HostComponent)
+        .keep(TargetDirective)
+        .keep(TargetPipe),
+    );
+
+    it('mocks inject() dependencies for directives and pipes before use', () => {
+      const fixture = MockRender(HostComponent);
+      const service = TestBed.inject(TargetService);
+
+      expect(service.echo).toHaveBeenCalledTimes(2);
+      expect(
+        ngMocks.findInstance(fixture, TargetDirective).service,
+      ).toBe(service);
+      expect(ngMocks.findInstance(fixture, TargetPipe).service).toBe(
+        service,
+      );
+      expect(TargetService.constructed).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Dependencies requested through `inject()` field initializers are executable runtime dependencies, so they do not appear in Angular constructor metadata. `MockBuilder` therefore cannot register their root mocks during static dependency analysis, and kept standalone declarations receive the real root service.

Mutating service properties after `MockRender` is too late: constructors, field initializers, `ngOnInit`, effects, and the first change-detection pass have already run. It also leaves standalone directives and pipes uncovered.

## What

- Install a TestBed-scoped runtime provider for kept standalone components, directives, and pipes on Angular 14+.
- Resolve direct root-service requests through the existing ng-mocks provider factory while Angular constructs those declarations.
- Cache the discovered mock so the declaration and later `TestBed.inject` calls receive the same instance.
- Preserve explicit keep/exclude decisions, root-provider controls, `MockInstance` customization, non-standalone behavior, and transitive provider-factory injection.
- Restore the injector and declaration factories during TestBed teardown.
- Add issue regressions across the Angular 14-22 spread.

## Impact

Standalone components, directives, and pipes using `inject()` now receive auto-spied root services before their first lifecycle work. Existing NgModule behavior from #4282 and explicit provider choices remain unchanged.

Fixes #9397

Supersedes #13310.