### PR TITLE
test(BrowserAnimationsModule): restore Angular 19+ coverage #641

### DIFF
--- a/tests/issue-641/test.spec.ts
+++ b/tests/issue-641/test.spec.ts
@@ -10,7 +10,6 @@ import {
   Component,
   NgModule,
   RendererFactory2,
-  VERSION,
 } from '@angular/core';
 import { fakeAsync, flush, tick } from '@angular/core/testing';
 import {
@@ -52,15 +51,6 @@ class TargetModule {}
 
 // @see https://github.com/help-me-mom/ng-mocks/issues/641
 describe('issue-641', () => {
-  if (Number.parseInt(VERSION.major, 10) >= 19) {
-    it('a19', () => {
-      // TODO pending('Need Angular < 19');
-      expect(true).toBeTruthy();
-    });
-
-    return;
-  }
-
   beforeAll(() =>
     ngMocks.globalReplace(
       BrowserAnimationsModule,
@@ -71,14 +61,6 @@ describe('issue-641', () => {
 
   describe('BrowserAnimationsModule:default', () => {
     beforeEach(() => MockBuilder(TargetComponent, TargetModule));
-
-    it('works on whenStable and due to NoopAnimationsModule', async () => {
-      const fixture = MockRender(TargetComponent);
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      expect(ngMocks.formatText(fixture)).toEqual('target');
-    });
 
     it('works on whenStable and due to NoopAnimationsModule', async () => {
       const fixture = MockRender(TargetComponent);
@@ -122,13 +104,13 @@ describe('issue-641', () => {
       ),
     );
 
-    it('fails due to missing BrowserAnimationsModule', () => {
+    it('fails due to missing animation providers', () => {
       try {
         MockRender(TargetComponent);
         fail('an error expected');
       } catch (error) {
-        expect((error as Error).message).toContain(
-          'BrowserAnimationsModule',
+        expect((error as Error).message).toMatch(
+          /BrowserAnimationsModule|provide(?:Noop)?Animations/,
         );
       }
     });


### PR DESCRIPTION
Why:

- The BrowserAnimationsModule replacement behavior from #641 still works, but its regression suite returned early on Angular 19+.
- Angular 19 changed the missing-animation diagnostic from the legacy BrowserAnimationsModule text to provider-based guidance, leaving current supported majors without real coverage.

What:

- Run the issue-641 replacement scenarios on every supported Angular version.
- Accept both the legacy module diagnostic and the current animation-provider diagnostic for the exclude case.
- Remove the duplicate default replacement scenario.

Where:

- tests/issue-641/test.spec.ts

Refs #641