### PR TITLE
fix(e2e/a17): compile signal inputs #7976

### DIFF
--- a/e2e/a17/package-lock.json
+++ b/e2e/a17/package-lock.json
@@ -28,7 +28,7 @@
         "@types/jest": "29.5.14",
         "jasmine-core": "5.1.2",
         "jest": "29.7.0",
-        "jest-preset-angular": "13.1.6",
+        "jest-preset-angular": "14.6.2",
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.2.0",
         "karma-coverage": "2.2.1",
@@ -10218,32 +10218,37 @@
       }
     },
     "node_modules/jest-preset-angular": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.1.6.tgz",
-      "integrity": "sha512-0pXSm6168Qn+qKp7DpzYoaIp0uyMHdQaWYVp8jlw7Mh+NEBtrBjKqts3kLeBHgAhGMQArp07S2IxZ6eCr8fc7Q==",
+      "version": "14.6.2",
+      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.6.2.tgz",
+      "integrity": "sha512-QWnjfXrnYJX65D+iZXBrdQ0ABHSo6DGvcmL3dGYOdF+V2ZhDlqJwKTmt7nyiOcORPdCL+20P8y+Q1mmnjZTHKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
-        "esbuild-wasm": ">=0.13.8",
-        "jest-environment-jsdom": "^29.0.0",
-        "jest-util": "^29.0.0",
-        "pretty-format": "^29.0.0",
-        "ts-jest": "^29.0.0"
+        "esbuild-wasm": ">=0.15.13",
+        "jest-environment-jsdom": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "ts-jest": "^29.3.0"
       },
       "engines": {
         "node": "^14.15.0 || >=16.10.0"
       },
       "optionalDependencies": {
-        "esbuild": ">=0.13.8"
+        "esbuild": ">=0.15.13"
       },
       "peerDependencies": {
-        "@angular-devkit/build-angular": ">=13.0.0 <18.0.0",
-        "@angular/compiler-cli": ">=13.0.0 <18.0.0",
-        "@angular/core": ">=13.0.0 <18.0.0",
-        "@angular/platform-browser-dynamic": ">=13.0.0 <18.0.0",
+        "@angular/compiler-cli": ">=15.0.0 <21.0.0",
+        "@angular/core": ">=15.0.0 <21.0.0",
+        "@angular/platform-browser-dynamic": ">=15.0.0 <21.0.0",
         "jest": "^29.0.0",
-        "typescript": ">=4.4"
+        "jsdom": ">=20.0.0",
+        "typescript": ">=4.8"
+      },
+      "peerDependenciesMeta": {
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-regex-util": {

--- a/e2e/a17/package.json
+++ b/e2e/a17/package.json
@@ -36,7 +36,7 @@
     "@types/jest": "29.5.14",
     "jasmine-core": "5.1.2",
     "jest": "29.7.0",
-    "jest-preset-angular": "13.1.6",
+    "jest-preset-angular": "14.6.2",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",
     "karma-coverage": "2.2.1",

--- a/e2e/a17/src/setup-jest.ts
+++ b/e2e/a17/src/setup-jest.ts
@@ -1,4 +1,6 @@
-import 'jest-preset-angular/setup-jest';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone'; // eslint-disable-line import-x/order
+
+setupZoneTestEnv();
 
 import { MockService, ngMocks } from 'ng-mocks'; // eslint-disable-line import-x/order
 

--- a/tests/issue-7976/test.spec.ts
+++ b/tests/issue-7976/test.spec.ts
@@ -51,15 +51,35 @@ describe('issue-7976', () => {
     return;
   }
 
-  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+  describe('direct component', () => {
+    beforeEach(() =>
+      MockBuilder(UserProfileCardComponent, TargetModule),
+    );
 
-  it('binds required signal inputs on mocked components', () => {
-    const fixture = MockRender(TargetComponent);
-    const mocked = ngMocks.find(
-      UserProfileCardComponent,
-    ).componentInstance;
+    it('binds required signal inputs from params', () => {
+      const fixture = MockRender(UserProfileCardComponent, {
+        user: {
+          name: 'test',
+        },
+      });
 
-    expect(isSignal(mocked.user)).toBe(true);
-    expect(mocked.user()).toBe(fixture.point.componentInstance.user);
+      expect(fixture.nativeElement.textContent).toContain('test');
+    });
+  });
+
+  describe('mocked component', () => {
+    beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+    it('binds required signal inputs on mocked components', () => {
+      const fixture = MockRender(TargetComponent);
+      const mocked = ngMocks.find(
+        UserProfileCardComponent,
+      ).componentInstance;
+
+      expect(isSignal(mocked.user)).toBe(true);
+      expect(mocked.user()).toBe(
+        fixture.point.componentInstance.user,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

- update Angular 17 to a signal-aware `jest-preset-angular` compiler pipeline
- migrate its Jest setup to `setupZoneTestEnv()`
- cover both direct `MockRender` params and mocked required signal inputs

## Root cause

The library support is present, but Angular 17's Jest project still used `jest-preset-angular@13.1.6`. That preset does not emit signal input metadata, so the existing regression silently took its metadata-unavailable branch and the original direct `MockRender` case still failed with `NG0950`.

## Validation

- focused Angular 17 Jest regression: 2 passed
- `sh test.sh a17`: Jasmine 1365 passed; Jest 422 suites and 1365 tests passed
- `sh test.sh root`: 1731 passed
- `npm run prettier:check` in the root container
- `npm run lint` in the root container

Closes #7976
