### PR TITLE
docs(standalone): clarify Angular 15 circular imports #6143

### DIFF
--- a/docs/articles/guides/component-standalone.md
+++ b/docs/articles/guides/component-standalone.md
@@ -59,6 +59,31 @@ beforeEach(() => {
 });
 ```
 
+## Circular standalone imports on Angular 15
+
+Angular `15.0.0` through `15.2.3` cannot configure `TestBed` when standalone components form a circular import graph.
+For example, the error occurs when a child imports its parent with `forwardRef`, while the parent imports the child directly:
+
+```ts
+@Component({
+  standalone: true,
+  imports: [forwardRef(() => ParentComponent)],
+})
+class ChildComponent {}
+
+@Component({
+  standalone: true,
+  imports: [ChildComponent],
+})
+class ParentComponent {}
+```
+
+In those Angular versions, `TestBed` traverses the imports recursively before `ng-mocks` overrides can be applied and throws `RangeError: Maximum call stack size exceeded`.
+Angular fixed the traversal in [`15.2.4`](https://github.com/angular/angular/commit/bae6b5ceb16bd87c8146aa29564a8d29135a6f95).
+
+Upgrade all `@angular/*` packages to `15.2.4` or a newer matching patch version before testing circular standalone imports.
+See [Angular issue #49469](https://github.com/angular/angular/issues/49469) and [ng-mocks issue #6143](https://github.com/help-me-mom/ng-mocks/issues/6143) for the original reports.
+
 ## Live example
 
 - [Try it on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestStandaloneComponent/test.spec.ts&initialpath=%3Fspec%3DTestStandaloneComponent)

--- a/tests/issue-6143/test.spec.ts
+++ b/tests/issue-6143/test.spec.ts
@@ -3,13 +3,14 @@ import { Component, forwardRef } from '@angular/core';
 
 import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
 
+// @see https://github.com/help-me-mom/ng-mocks/issues/6143
 // Regression coverage for #6143:
 // - this standalone child imports its standalone parent via forwardRef
 // - the parent imports the child directly
 //
-// The same setup fails with a recursive stack overflow on v14.7.1 for the
-// Angular 15 line reported in the issue, but current main should keep rendering
-// both sides of the standalone graph correctly.
+// Angular 15.0.0 through 15.2.3 recursively traverse this graph before TestBed
+// applies ng-mocks overrides. Angular 15.2.4 fixed that upstream traversal, and
+// this spec protects the same graph on the fixed Angular matrix.
 @Component({
   selector: 'issue-6143-child',
   template: 'ChildComponent',


### PR DESCRIPTION
Closes #6143

Why:

- Angular 15.0.0 through 15.2.3 recursively traverse circular standalone imports before ng-mocks overrides can run.
- The existing regression test did not document that the traversal fix shipped in Angular 15.2.4 rather than ng-mocks.

What:

- Document Angular 15.2.4 as the minimum Angular 15 patch for circular standalone imports.
- Link Angular's upstream fix and correct the existing regression coverage context.

Where:

- docs/articles/guides/component-standalone.md
- tests/issue-6143/test.spec.ts