### PR TITLE
fix(MockService): harden function detection

### DIFF
--- a/libs/ng-mocks/src/lib/mock-service/check.is-func.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/check.is-func.spec.ts
@@ -27,10 +27,18 @@ describe('check.is-func', () => {
 
   it('detects downleveled unnamed classes', () => {
     expect(
-      guessClass('classTarget', 'function classTarget() {}', {
+      guessClass('class_1', 'function class_1() {}', {
         prototype: {},
       }),
     ).toEqual(true);
+  });
+
+  it('detects functions with a class prefix', () => {
+    const classify = () => undefined;
+    (classify as any).prototype = {};
+    classify.toString = () => 'function classify() {}';
+
+    expect(checkIsFunc(classify)).toEqual(true);
   });
 
   it('detects downleveled named classes using this', () => {
@@ -50,5 +58,14 @@ describe('check.is-func', () => {
     (test as any).prototype = {};
 
     expect(checkIsFunc(test)).toEqual(true);
+  });
+
+  it('detects downleveled classes with regexp characters', () => {
+    const target$ = () => undefined;
+    (target$ as any).prototype = {};
+    target$.toString = () =>
+      'function target$() { classCallCheck(this, target$); }';
+
+    expect(checkIsFunc(target$)).toEqual(false);
   });
 });

--- a/libs/ng-mocks/src/lib/mock-service/check.is-func.ts
+++ b/libs/ng-mocks/src/lib/mock-service/check.is-func.ts
@@ -15,9 +15,11 @@ const isAngularClass = (value: Record<keyof any, unknown>): boolean => {
   return false;
 };
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 export const guessClass = (name: string, proto: string, value: any): boolean => {
   // unnamed classes can be class_N
-  if (name.match(/^class/) !== null) {
+  if (/^class_\d+$/.test(name)) {
     return true;
   }
 
@@ -28,14 +30,14 @@ export const guessClass = (name: string, proto: string, value: any): boolean => 
 
   // let's consider a capital name and 'this' usage as a class
   const clsCode = name.codePointAt(0);
-  if (clsCode && clsCode >= 65 && clsCode <= 90 && proto.match(/\bthis\./gm) !== null) {
+  if (clsCode && clsCode >= 65 && clsCode <= 90 && /\bthis\./.test(proto)) {
     return true;
   }
 
   // webpack es5 class
-  const regEx = new RegExp(`\\(this,\\s*${name}\\)`, 'mg');
+  const regEx = new RegExp(`\\(this,\\s*${escapeRegExp(name)}\\)`);
   // istanbul ignore if
-  if (proto.match(regEx) !== null) {
+  if (regEx.test(proto)) {
     return true;
   }
 

--- a/tests/mock-service/test.spec.ts
+++ b/tests/mock-service/test.spec.ts
@@ -27,4 +27,21 @@ describe('mock-service', () => {
     );
     expect(instance.echo1()).toBeUndefined();
   });
+
+  it('mocks functions with a class prefix as functions', () => {
+    const classify = () => undefined;
+    (classify as any).prototype = {};
+    classify.toString = () => 'function classify() {}';
+
+    expect(typeof MockService(classify)).toEqual('function');
+  });
+
+  it('mocks downleveled classes with regexp characters as classes', () => {
+    const target$ = () => undefined;
+    (target$ as any).prototype = {};
+    target$.toString = () =>
+      'function target$() { classCallCheck(this, target$); }';
+
+    expect(typeof MockService(target$)).toEqual('object');
+  });
 });

--- a/tests/ng-mocks-crawl/test.spec.ts
+++ b/tests/ng-mocks-crawl/test.spec.ts
@@ -24,7 +24,7 @@ describe('ng-mocks-crawl', () => {
         <div>11</div>
         <div>12</div>
       </ng-container>
-    `.replace(new RegExp('s+', 'gm'), ''),
+    `.replace(/\s+/g, ''),
     );
 
     // in total, we have 30 nodes


### PR DESCRIPTION
## Why

`MockService` treated every function whose name started with `class` as a downleveled anonymous class, so ordinary callbacks such as `classify` were mocked as objects. Its webpack ES5 heuristic also interpolated function names directly into a regular expression, so valid names containing `$` were interpreted as regexp syntax and mocked as functions instead of classes.

## What

- Restrict anonymous downlevel class detection to TypeScript's `class_<number>` naming convention.
- Escape dynamic function names before matching webpack-style ES5 class calls and remove unnecessary regexp flags.
- Add internal and public `MockService` regressions for class-prefixed functions and `$` identifiers across the Angular spread.
- Correct the crawl test fixture's whitespace regular expression.

## Impact

`MockService` now distinguishes valid user functions from downleveled classes without changing normal class, function, Angular-decorated, or compiler-generated anonymous-class behavior.