### PR TITLE
fix(core): preserve defer blocks with mocks #7742

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -376,8 +376,10 @@ const patchVcrInstance = (vcrInstance: ViewContainerRef) => {
   }
 };
 
+// istanbul ignore next: legacy Angular lacks __NG_ELEMENT_ID__; covered by the compatibility matrix.
 const createComponent =
   (original: TestBedStatic['createComponent'], instance: TestBedStatic): TestBedStatic['createComponent'] =>
+  // istanbul ignore next: legacy Angular lacks __NG_ELEMENT_ID__; covered by the compatibility matrix.
   (...args) => {
     const fixture = original.call(instance, ...args);
     try {
@@ -410,8 +412,13 @@ const viewContainerInstall = () => {
         }),
         true,
       );
+    } else {
+      coreDefineProperty(
+        TestBed,
+        'createComponent',
+        createComponent(TestBed.createComponent as never, TestBed as never),
+      );
     }
-    coreDefineProperty(TestBed, 'createComponent', createComponent(TestBed.createComponent as never, TestBed as never));
 
     coreDefineProperty(ViewContainerRef, 'ngMocksOverridesInstalled', true);
   }

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -73,6 +73,7 @@ file|tests/issue-7976/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-9684/test.spec.ts|features=signalInputs
 file|tests/issue-8649/*.ts|features=standalone
+file|tests/issue-7742/*.ts|features=defer
 file|tests/issue-4486/*.ts|features=standalone
 file|tests/issue-8627/*.ts|features=standalone
 file|tests/issue-6143/*.ts|versions=15+

--- a/tests/issue-7742/test.spec.ts
+++ b/tests/issue-7742/test.spec.ts
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+import {
+  DeferBlockBehavior,
+  DeferBlockState,
+  TestBed,
+} from '@angular/core/testing';
+
+import { isMockOf, MockComponents, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'dependency-7742',
+  template: 'dependency',
+  standalone: true,
+})
+class DependencyComponent {
+  public dependency7742() {}
+}
+
+@Component({
+  selector: 'target-7742',
+  template: `
+    @defer {
+      <dependency-7742 />
+    } @placeholder {
+      placeholder
+    }
+  `,
+  standalone: true,
+  imports: [DependencyComponent],
+})
+class TargetComponent {
+  public target7742() {}
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/7742
+describe('issue-7742', () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [TargetComponent],
+      deferBlockBehavior: DeferBlockBehavior.Manual,
+    })
+      .overrideComponent(TargetComponent, {
+        set: {
+          imports: MockComponents(DependencyComponent),
+        },
+      })
+      .compileComponents(),
+  );
+
+  it('returns defer blocks with a mocked dependency', async () => {
+    const fixture = TestBed.createComponent(TargetComponent);
+    await fixture.whenStable();
+
+    const deferBlocks = await fixture.getDeferBlocks();
+    expect(deferBlocks.length).toEqual(1);
+
+    await deferBlocks[0].render(DeferBlockState.Complete);
+
+    expect(
+      isMockOf(
+        ngMocks.findInstance(DependencyComponent),
+        DependencyComponent,
+      ),
+    ).toEqual(true);
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,12 @@ module.exports = [
     output: {
       path: path.resolve(__dirname, './dist/libs/ng-mocks/'),
       filename: 'index.mjs',
+      environment: {
+        // Angular 14 can concatenate ESM package sources into one scope.
+        // Generated lexical bindings would collide when the bundle is included more than once.
+        const: false,
+        let: false,
+      },
       library: {
         type: 'module',
       },


### PR DESCRIPTION
## Why

ng-mocks patches injected `ViewContainerRef` instances, but modern Angular already exposes the `__NG_ELEMENT_ID__` hook needed to intercept those injections. Wrapping `TestBed.createComponent` as well eagerly injected the root `ViewContainerRef`, which made `ComponentFixture.getDeferBlocks()` return an empty list on Angular 17 through 19.

The generated ESM bundle also declared Webpack runtime exports with top-level lexical bindings. Angular 14 can concatenate the package source more than once into one scope, causing `Identifier '__webpack_exports__' has already been declared` in its ES2015 build.

## What

- Use the `ViewContainerRef.__NG_ELEMENT_ID__` interception path on modern Angular and reserve the `TestBed.createComponent` wrapper for legacy Angular versions without that hook.
- Add an Angular 17+ regression that discovers and renders a defer block containing a mocked standalone dependency.
- Emit Webpack-generated ESM runtime bindings as `var` so Angular 14 can safely concatenate repeated package sources without changing the module format.

## Impact

`ComponentFixture.getDeferBlocks()` keeps returning the expected defer blocks when ng-mocks mocks are present, while dynamic `ViewContainerRef` operations remain patched. The ESM package also loads without duplicate `__webpack_exports__` declarations in Angular 14 ES2015 builds.

## Validation

- Root coverage: 1,737 passed, 2 skipped; 100% statements, branches, functions, and lines
- Angular 5 ES5: 1,228 browser tests; 393 Jest suites
- Angular 14 ES5 and ES2015: 1,339 browser tests and 411 Jest suites in each mode
- Angular 17: 1,365 browser tests; 423 Jest suites
- Angular 18: 1,365 browser tests; 423 Jest suites
- Angular 19 after rebase: 1,343 browser tests; 425 Jest suites
- Angular 20 after rebase: 1,345 browser tests; 426 Jest suites
- Lint and TypeScript checks

Closes #7742
