### PR TITLE
build(release): align release docs and notes

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -16,7 +16,7 @@ plugins:
         docker compose run --rm ng-mocks npm run lint -- --ignore-pattern e2e/ &&
         docker compose run --rm ng-mocks npm run ts:check &&
         docker compose run --rm ng-mocks npm run build
-  - '@semantic-release/release-notes-generator'
+  - './semantic-release-release-notes.mjs'
   - - '@semantic-release/changelog'
     - changelogFile: CHANGELOG.md
   - - '@semantic-release/npm'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ The best way would be to discuss an issue or an improvement first:
 - [chat on gitter](https://gitter.im/ng-mocks/community)
 
 * [update docs](#update-docs)
-* [Requirements on Mac](#requiements-on-mac)
-* [Requirements on Linux](#requiements-on-linux)
-* [Requirements on Windows](#requiements-on-windows)
+* [Requirements on Mac](#requirements-on-mac)
+* [Requirements on Linux](#requirements-on-linux)
+* [Requirements on Windows](#requirements-on-windows)
 
 ## Update docs
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The current version of the library **has been tested** and **can be used** with:
 
 | angular | ng-mocks | jasmine | jest | ivy | standalone | signals | defer |
 | ------: | :------: | :-----: | :--: | :-: | :--------: | :-----: | :---: |
-|      22 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      21 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      20 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      19 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      18 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      17 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
+|      22 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      21 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      20 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      19 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      18 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      17 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
 |      16 |  latest  |   yes   | yes  | yes |    yes     |   yes   |       |
 |      15 |  latest  |   yes   | yes  | yes |    yes     |         |       |
 |      14 |  latest  |   yes   | yes  | yes |    yes     |         |       |

--- a/docs/articles/api/ngMocks/globalMock.md
+++ b/docs/articles/api/ngMocks/globalMock.md
@@ -39,8 +39,7 @@ ngMocks.defaultMock(BASE_PATH, () => '/api/test-path');
 
 The configured value is then available whenever `MockBuilder` keeps a component, directive, or pipe that injects the token:
 
-- [Try it on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/ngMocksGlobalMock/test.spec.ts&initialpath=%3Fspec%3DngMocks.globalMock%3Ainject)
-- [Try it on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/ngMocksGlobalMock/test.spec.ts&initialpath=%3Fspec%3DngMocks.globalMock%3Ainject)
+- [View the tested source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/ngMocksGlobalMock/test.spec.ts)
 
 ```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/ngMocksGlobalMock/test.spec.ts"
 import { Component, inject, InjectionToken } from '@angular/core';

--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -17,8 +17,8 @@ The example below is applicable for all types of guards:
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
 - `canActivateChild` -
-  [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-activateChild.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivateChild),
-  [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activateChild.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivateChild)
+  [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-activate-child.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivateChild),
+  [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activate-child.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivateChild)
 - `canDeactivate` -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-deactivate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanDeactivate),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-deactivate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanDeactivate)
@@ -29,8 +29,7 @@ The example below is applicable for all types of guards:
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-load.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanLoad),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-load.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanLoad)
 - standalone applications (Angular 14+) -
-  [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone),
-  [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone)
+  [tested source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/standalone.spec.ts)
 - class guards (legacy) -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/test.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Atest),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/test.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Atest)
@@ -224,8 +223,7 @@ Profit.
 
 - [Try it on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
 - [Try it on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
-- [Try the standalone example on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone)
-- [Try the standalone example on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/standalone.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Astandalone)
+- [View the standalone example source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/standalone.spec.ts)
 
 ```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-activate.spec.ts"
 import { Location } from '@angular/common';

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -28,12 +28,12 @@ The current version of `ng-mocks` has been tested and **can be used** with:
 
 | angular | ng-mocks | jasmine | jest | ivy | standalone | signals | defer |
 |--------:| :------: | :-----: | :--: | :-: | :--------: | :-----: | :---: |
-|      22 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      21 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      20 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      19 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      18 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
-|      17 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  no   |
+|      22 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      21 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      20 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      19 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      18 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
+|      17 |  latest  |   yes   | yes  | yes |    yes     |   yes   |  yes  |
 |      16 |  latest  |   yes   | yes  | yes |    yes     |   yes   |       |
 |      15 |  latest  |   yes   | yes  | yes |    yes     |         |       |
 |      14 |  latest  |   yes   | yes  | yes |    yes     |         |       |

--- a/semantic-release-release-notes.mjs
+++ b/semantic-release-release-notes.mjs
@@ -1,0 +1,40 @@
+import { generateNotes as generateReleaseNotes } from '@semantic-release/release-notes-generator';
+
+const pullRequestSuffix = /\s+\(#\d+\)$/u;
+
+const getSubject = commit => commit.subject ?? commit.message.split('\n', 1)[0];
+
+export const deduplicateCommits = commits => {
+  const uniqueCommits = [];
+  const commitIndexes = new Map();
+
+  for (const commit of commits) {
+    const subject = getSubject(commit);
+    const tree = commit.tree?.long;
+    const normalizedSubject = subject.replace(pullRequestSuffix, '');
+    const key = tree && normalizedSubject ? `${tree}\0${normalizedSubject}` : undefined;
+    const existingIndex = key && commitIndexes.get(key);
+
+    if (existingIndex === undefined) {
+      if (key) {
+        commitIndexes.set(key, uniqueCommits.length);
+      }
+      uniqueCommits.push(commit);
+      continue;
+    }
+
+    const existingSubject = getSubject(uniqueCommits[existingIndex]);
+    if (pullRequestSuffix.test(subject) && !pullRequestSuffix.test(existingSubject)) {
+      uniqueCommits[existingIndex] = commit;
+    }
+  }
+
+  return uniqueCommits;
+};
+
+export const generateNotes = (pluginConfig, context) =>
+  generateReleaseNotes(pluginConfig, {
+    ...context,
+    // Clean merges can expose both the merge and its already-contained commit.
+    commits: deduplicateCommits(context.commits),
+  });


### PR DESCRIPTION
## Why

- Angular 17–22 defer support is now covered by the issue #7742 regression and the `defer` spread matrix, but the public compatibility tables still reported it as unsupported.
- Several documentation links point to misspelled or unavailable sandbox files, and the contributing guide contains broken requirement anchors.
- The upcoming release notes list the circular standalone imports fix twice because clean merge #14507 and its contained commit have the same tree and subject.

## What

- Mark tested defer support consistently in `README.md` and the documentation index.
- Correct the contributing anchors and the `canActivateChild` sandbox filename, and use tested source links where the examples have not been published to the sandbox repository.
- Wrap release-note generation to collapse only same-tree, same-subject commit pairs while preferring the merge entry that includes its pull request reference.

## Impact

The published documentation now matches the tested Angular matrix, all corrected examples resolve to available code, and the generated 14.16.0 notes contain one PR-linked entry for the circular standalone imports fix. Existing changelog staging and npm package contents remain unchanged.