### PR TITLE
fix(build): restore CommonJS Angular initialization order

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,29 @@
 const path = require('node:path');
 
+const { BannerPlugin, Compilation } = require('webpack');
+
+class AngularCommonJsOrderPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap(AngularCommonJsOrderPlugin.name, compilation => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: AngularCommonJsOrderPlugin.name,
+          stage: Compilation.PROCESS_ASSETS_STAGE_REPORT,
+        },
+        () => {
+          const source = compilation.getAsset('index.js')?.source.source().toString() ?? '';
+          const coreTestingIndex = source.indexOf('@angular/core/testing');
+          const commonIndex = source.indexOf('@angular/common');
+
+          if (coreTestingIndex === -1 || commonIndex === -1 || coreTestingIndex > commonIndex) {
+            throw new Error('index.js must load @angular/core/testing before @angular/common');
+          }
+        },
+      );
+    });
+  }
+}
+
 const performance = {
   hints: 'error',
   maxAssetSize: 800 * 1024,
@@ -22,6 +46,15 @@ module.exports = [
     },
     externals: /^@angular\//,
     performance,
+    plugins: [
+      // The UMD external order is not stable across webpack versions. In CommonJS,
+      // core/testing must register Angular's JIT facade before common is evaluated.
+      new BannerPlugin({
+        banner: "if (typeof exports === 'object' && typeof module === 'object') require('@angular/core/testing');",
+        raw: true,
+      }),
+      new AngularCommonJsOrderPlugin(),
+    ],
     module: {
       rules: [
         {


### PR DESCRIPTION
Closes #14545

Why:

- Webpack 5.109 changed the generated UMD external order, allowing `@angular/common` to evaluate before `@angular/core/testing` registers Angular's JIT facade.
- Zoneless Jest consumers that do not otherwise load `@angular/compiler` then fail while importing `ng-mocks`.

What:

- Preload `@angular/core/testing` only on the CommonJS path before the UMD wrapper resolves Angular externals.
- Fail the webpack build if the final CommonJS bundle does not load `@angular/core/testing` before `@angular/common`.

Where:

- `webpack.config.js`
