### PR TITLE
feat(MockRender): support signal input initial values #11101

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -16,7 +16,7 @@ Create and maintain a plain Markdown checklist:
 - [ ] Create a dedicated issue worktree from `upstream/main`
 - [ ] Reproduce the bug with a local `issue-*` regression test
 - [ ] Fix the implementation without changing the reproducer test
-- [ ] Run coverage and affected e2e validation
+- [ ] Clear affected Angular CLI caches and run coverage and e2e validation
 - [ ] Prepare comments, commit message, and PR against `upstream/main`
 ```
 
@@ -104,6 +104,21 @@ Run affected e2e targets:
 - If `tests-e2e/src` changed, run `sh test.sh e2e`.
 - If files under a specific `e2e/<target>` project changed, run `sh compose.sh <target>` when dependencies changed and `sh test.sh <target>` afterward.
 
+Modern versioned Angular projects retain `.angular/cache` in the bind-mounted `e2e/a<major>` workspace across
+containers. For each affected target whose CLI supports `ng cache`, clear the cache inside Docker before its final
+run after source changes. Run `compose.sh` first when the target dependencies have not been prepared:
+
+```bash
+COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> sh compose.sh a<major>
+COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> \
+  docker compose run --rm a<major> npx ng cache clean
+COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> sh test.sh a<major>
+```
+
+Do not infer a source regression from output that may have reused an older compiled bundle. If a result contradicts
+the current source or the focused reproducer, inspect `e2e/a<major>/node_modules/ng-mocks`, clear the target cache,
+and rerun the wrapper before changing implementation or test code.
+
 Before committing:
 
 ```bash
@@ -161,6 +176,8 @@ PR rules:
 - Do not triage issue fixes in the original checkout; create or reuse a dedicated worktree based on `upstream/main` first.
 - Do not change the reproducer after fixing source behavior, except for mechanical compatibility edits that preserve the original failure.
 - Do not delete or regenerate lockfiles for ordinary issue fixes. If dependency refresh is required, use the `update-package-locks` skill.
+- Do not replace required Docker wrapper validation with local npm commands because of transient network, daemon,
+  or cache failures. Restore the Docker workflow and rerun it; local commands are diagnostic only.
 - Do not claim full matrix validation unless every affected target was run. State skipped targets and why.
 - Trust current scripts and config over stale docs, then update docs if the issue changes documented compatibility.
 - Keep the final patch scoped to the issue. Avoid unrelated refactors, formatting churn, and dependency changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,29 @@
 - For dependency bootstrap, lockfile refreshes, and test execution, use the repo wrappers instead of ad-hoc local installs:
   - `sh compose.sh <target>`
   - `sh test.sh <target>`
+- Do not replace required wrapper validation with local npm commands because Docker has a transient network,
+  daemon, or cache problem. Fix or retry the Docker workflow; use local commands only for explicitly identified
+  human debugging, and never report them as the required validation.
 - If multiple worktrees or agent sessions run in parallel, set a unique compose namespace:
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh compose.sh <target>`
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh test.sh <target>`
+
+## Angular CLI Cache
+
+- Modern versioned Angular projects retain `.angular/cache` in the bind-mounted `e2e/a<major>` workspace across
+  containers. Rebuilding and copying `ng-mocks` does not guarantee that the Angular CLI invalidates previously
+  compiled test bundles.
+- For each affected target whose CLI supports `ng cache`, clear the cache inside Docker before the final
+  `sh test.sh a<major>` validation. Use the same `COMPOSE_PROJECT_NAME` for both commands:
+
+  ```bash
+  COMPOSE_PROJECT_NAME=ngmocks_<unique> docker compose run --rm a<major> npx ng cache clean
+  COMPOSE_PROJECT_NAME=ngmocks_<unique> sh test.sh a<major>
+  ```
+
+- If a compatibility result contradicts the current source or a focused reproducer, inspect the package copied to
+  `e2e/a<major>/node_modules/ng-mocks`, clear the target cache, and rerun the wrapper before changing the source or
+  weakening the test.
 
 ## Local npm / nvm Flows
 

--- a/docs/articles/api/MockRender.md
+++ b/docs/articles/api/MockRender.md
@@ -271,7 +271,8 @@ It is essential to know how `MockRender` handles `params` in order to understand
 
 If `MockRender` has been called with no `params` or `null` or `undefined` as `params`,
 then it automatically binds all `inputs` and ignores all `outputs`.
-Therefore, no default values will be used in the tested component, all `inputs` will receive `null`.
+Signal inputs declared with `input(initialValue)` keep their initial value until their wrapper input is changed.
+Their transforms are not reapplied to the initial value. All other inputs receive `null`.
 
 :::tip
 Why `null`?
@@ -326,7 +327,7 @@ fixture.detectChanges();
 expect(fixture.point.componentInstance.input1).toEqual(1);
 ```
 
-Please proceed to the next section, if you want to use / test default values. 
+Please proceed to the next section, if you want to use / test ordinary input default values.
 
 ### Empty params
 

--- a/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.spec.ts
@@ -1,0 +1,122 @@
+import funcCreateWrapper from './func.create-wrapper';
+
+describe('funcCreateWrapper', () => {
+  it('uses signal defaults until the wrapper input is changed', () => {
+    class TargetComponent {}
+
+    const transform = (value: string) => `${value}-transformed`;
+    const signalNode: any = {
+      applyValueToInputSignal: () => undefined,
+      transformFn: transform,
+    };
+    const targetInput = () => 'signal-default';
+    Object.defineProperty(targetInput, Symbol('empty'), {
+      value: null,
+    });
+    Object.defineProperty(targetInput, Symbol('primitive'), {
+      value: () => undefined,
+    });
+    Object.defineProperty(targetInput, Symbol('no-transform'), {
+      value: { applyValueToInputSignal: () => undefined },
+    });
+    Object.defineProperty(targetInput, Symbol('no-apply'), {
+      value: {
+        applyValueToInputSignal: null,
+        transformFn: transform,
+      },
+    });
+    Object.defineProperty(targetInput, Symbol('signal'), {
+      value: signalNode,
+    });
+
+    const Wrapper: any = funcCreateWrapper(
+      TargetComponent,
+      {
+        inputs: [
+          {
+            alias: 'publicValue',
+            isSignal: true,
+            name: 'value',
+          },
+        ],
+        selector: 'target-11101-default',
+      } as any,
+      undefined,
+      {},
+    );
+    const instance: any = new Wrapper();
+    instance.__ngMocksPoint = { value: targetInput };
+
+    expect(instance.publicValue).toEqual('signal-default');
+    expect(signalNode.transformFn('signal-default')).toEqual(
+      'signal-default',
+    );
+    expect(signalNode.transformFn).toBe(transform);
+
+    instance.publicValue = 'updated';
+    expect(instance.publicValue).toEqual('updated');
+  });
+
+  it('keeps the null binding for required signal inputs', () => {
+    class TargetComponent {}
+
+    const signalNode = {
+      applyValueToInputSignal: () => undefined,
+      transformFn: undefined,
+    };
+    const targetInput = () => {
+      throw new Error('Required signal has no value');
+    };
+    Object.defineProperty(targetInput, Symbol('signal'), {
+      value: signalNode,
+    });
+
+    const Wrapper: any = funcCreateWrapper(
+      TargetComponent,
+      {
+        inputs: [
+          {
+            isSignal: true,
+            name: 'required',
+            required: true,
+          },
+        ],
+        selector: 'target-11101-required',
+      } as any,
+      undefined,
+      {},
+    );
+    const instance: any = new Wrapper();
+    instance.__ngMocksPoint = { required: targetInput };
+
+    expect(instance.required).toBeNull();
+    expect(instance.required).toBeNull();
+  });
+
+  it('waits until the rendered signal input is available', () => {
+    class TargetComponent {}
+
+    const Wrapper: any = funcCreateWrapper(
+      TargetComponent,
+      {
+        inputs: [
+          { isSignal: true, name: 'missing' },
+          { isSignal: true, name: 'notSignal' },
+        ],
+        selector: 'target-11101-missing',
+      } as any,
+      undefined,
+      {},
+    );
+    const instance: any = new Wrapper();
+
+    expect(instance.missing).toBeNull();
+
+    instance.__ngMocksPoint = {
+      missing: () => 'missing-node',
+      notSignal: null,
+    };
+    expect(instance.missing).toBeNull();
+    expect(instance.notSignal).toBeNull();
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, Directive } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Directive, ViewChild } from '@angular/core';
+import * as angularCore from '@angular/core';
 
 import coreConfig from '../common/core.config';
 import coreDefineProperty from '../common/core.define-property';
@@ -25,8 +26,26 @@ const generateWrapperOutput =
     instance[prop] = event;
   };
 
-const generateWrapperComponent = ({ bindings, options, inputs }: any) => {
+const getInputSignalNode = (value: any): any => {
+  for (const symbol of Object.getOwnPropertySymbols(value)) {
+    const node = value[symbol];
+    if (
+      node &&
+      typeof node === 'object' &&
+      'transformFn' in node &&
+      typeof node.applyValueToInputSignal === 'function'
+    ) {
+      return node;
+    }
+  }
+
+  return undefined;
+};
+
+const generateWrapperComponent = ({ bindings, options, inputs, signalInputs, template }: any) => {
   class MockRenderComponent {
+    private __ngMocksPoint?: any;
+
     public constructor() {
       coreDefineProperty(this, '__ngMocksOutput', generateWrapperOutput(this));
 
@@ -42,14 +61,50 @@ const generateWrapperComponent = ({ bindings, options, inputs }: any) => {
 
       if (!bindings) {
         for (const input of inputs) {
+          let initialized = !signalInputs[input];
           let value: any = null;
           helperDefinePropertyDescriptor(this, input, {
-            get: () => value,
-            set: (newValue: any) => (value = newValue),
+            get: () => {
+              if (!initialized) {
+                const targetInput = this.__ngMocksPoint?.[signalInputs[input]];
+                const signalNode = typeof targetInput === 'function' ? getInputSignalNode(targetInput) : undefined;
+
+                if (!signalNode) {
+                  return value;
+                }
+
+                try {
+                  value = (angularCore as any).untracked(targetInput);
+                  const transform = signalNode.transformFn;
+                  // Angular applies input transforms to bound values, but not
+                  // to the signal's own initializer. Bypass only the initial
+                  // wrapper write, then restore the original transform.
+                  signalNode.transformFn = (newValue: any) => {
+                    signalNode.transformFn = transform;
+
+                    return newValue;
+                  };
+                  initialized = true;
+                } catch {
+                  // Required signal inputs do not have an initial value.
+                  initialized = true;
+                }
+              }
+
+              return value;
+            },
+            set: (newValue: any) => {
+              initialized = true;
+              value = newValue;
+            },
           });
         }
       }
     }
+  }
+
+  if (Object.keys(signalInputs).length > 0) {
+    ViewChild(template, { static: true })(MockRenderComponent.prototype, '__ngMocksPoint');
   }
 
   // A16: adding unique property.
@@ -109,6 +164,18 @@ const getInputBindings = (inputs: DirectiveIo[]): string[] => {
   return result;
 };
 
+const getSignalInputBindings = (inputs: DirectiveIo[]): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const definition of inputs) {
+    const { name, alias, isSignal } = funcDirectiveIoParse(definition);
+    if (isSignal) {
+      result[alias || name] = name;
+    }
+  }
+
+  return result;
+};
+
 const getWrapperInputs = (inputBindings: string[], bindings: undefined | null | any[]): string[] => {
   if (!bindings) {
     return inputBindings;
@@ -155,6 +222,7 @@ export default (
   }
 
   const inputBindings = getInputBindings(inputs);
+  const signalInputs = getSignalInputBindings(inputs);
   const wrapperInputs = getWrapperInputs(inputBindings, bindings);
   const mockTemplate = funcGenerateTemplate(template, { selector: meta.selector, inputs, outputs, bindings });
   const options: Component = {
@@ -172,7 +240,13 @@ export default (
     standalone: false,
   };
 
-  ctor = generateWrapperComponent({ bindings, inputs: wrapperInputs, options });
+  ctor = generateWrapperComponent({
+    bindings,
+    inputs: wrapperInputs,
+    options,
+    signalInputs,
+    template,
+  });
   coreDefineProperty(ctor, 'cacheKey', cacheKey);
   coreDefineProperty(ctor, 'inputBindings', inputBindings);
   coreDefineProperty(ctor, 'tpl', mockTemplate);

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -68,6 +68,7 @@ file|tests/issue-7490/*.ts|versions=17+
 file|tests/issue-5437/*.ts|versions=13+
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-11001/test.spec.ts|features=signalInputs
+file|tests/issue-11101/test.spec.ts|features=signalInputs
 file|tests/issue-13089/test.spec.ts|features=signalForms
 file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs

--- a/tests/issue-11101/test.spec.ts
+++ b/tests/issue-11101/test.spec.ts
@@ -1,0 +1,101 @@
+import {
+  Component,
+  input,
+  NgModule,
+  reflectComponentType,
+} from '@angular/core';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+let transformations = 0;
+let requiredTransformations = 0;
+
+@Component({
+  selector: 'target-11101',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '',
+})
+class TargetComponent {
+  public readonly plain = input('plain-default');
+  public readonly transformed = input('transformed-default', {
+    alias: 'publicTransformed',
+    transform: (value: string) => {
+      transformations += 1;
+
+      return `${value}-transformed`;
+    },
+  });
+  public readonly required = input.required({
+    transform: (value: string) => {
+      requiredTransformations += 1;
+
+      return `${value}-required`;
+    },
+  });
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/11101
+describe('issue-11101', () => {
+  if (
+    !reflectComponentType(TargetComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'plain',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+  it('preserves signal input defaults until inputs are updated', () => {
+    transformations = 0;
+    requiredTransformations = 0;
+    const fixture = MockRender(TargetComponent);
+
+    expect(fixture.point.componentInstance.plain()).toEqual(
+      'plain-default',
+    );
+    expect(fixture.point.componentInstance.transformed()).toEqual(
+      'transformed-default',
+    );
+    expect((fixture.componentInstance as any).plain).toEqual(
+      'plain-default',
+    );
+    expect(
+      (fixture.componentInstance as any).publicTransformed,
+    ).toEqual('transformed-default');
+    expect(transformations).toEqual(0);
+    expect(fixture.point.componentInstance.required()).toEqual(
+      'null-required',
+    );
+    expect(requiredTransformations).toEqual(1);
+
+    fixture.componentRef.setInput('plain', 'plain-updated');
+    fixture.componentRef.setInput(
+      'publicTransformed',
+      'transformed-updated',
+    );
+    fixture.componentRef.setInput('required', 'required-updated');
+    fixture.detectChanges();
+
+    expect(fixture.point.componentInstance.plain()).toEqual(
+      'plain-updated',
+    );
+    expect(fixture.point.componentInstance.transformed()).toEqual(
+      'transformed-updated-transformed',
+    );
+    expect(transformations).toEqual(1);
+    expect(fixture.point.componentInstance.required()).toEqual(
+      'required-updated-required',
+    );
+    expect(requiredTransformations).toEqual(2);
+  });
+});


### PR DESCRIPTION
## Why

`MockRender(Component)` without params intentionally binds inputs to `null`. Applying that behavior to optional signal inputs discards `input(initialValue)`, so tests cannot observe the component default and must pass empty params as a workaround.

## What

- Preserve initialized signal input values in the generated `MockRender` wrapper.
- Keep aliases, required signals, input transforms, and later `setInput` updates consistent with Angular.
- Add focused source coverage and an Angular 17+ compatibility regression.
- Clarify the documented no-params behavior.
- Record clean Angular CLI cache and Docker recovery guardrails in the AI issue-triage guidance.

## Impact

`MockRender(Component)` without params now mirrors Angular component construction for optional signal input defaults. Ordinary inputs and required signal inputs retain their existing null-binding behavior. No public API is added.

Closes #11101