### PR TITLE
fix(MockBuilder): mock inject dependencies in classic components #14560

### DIFF
--- a/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.ts
@@ -91,7 +91,12 @@ export class MockBuilderPromise implements IMockBuilder {
       handleEntryComponents(ngModule);
       applyPlatformModules();
 
-      const runtimeInjectProvider = createRuntimeInjectProvider(this.keepDef, this.configDef, ngModule.providers);
+      const runtimeInjectProvider = createRuntimeInjectProvider(
+        this.keepDef,
+        this.configDef,
+        ngModule.providers,
+        this.configDefault.dependency !== true,
+      );
       if (runtimeInjectProvider) {
         ngModule.providers.push(runtimeInjectProvider);
       }

--- a/libs/ng-mocks/src/lib/mock-builder/promise/create-runtime-inject-provider.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/create-runtime-inject-provider.spec.ts
@@ -49,6 +49,7 @@ describe('create-runtime-inject-provider', () => {
         [TargetWithoutDependencies, { shallow: false }],
       ]),
       providers,
+      false,
     );
 
     const destroyCallbacks: Array<() => void> = [];

--- a/libs/ng-mocks/src/lib/mock-builder/promise/create-runtime-inject-provider.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/promise/create-runtime-inject-provider.ts
@@ -7,16 +7,30 @@ import { isStandalone } from '../../common/func.is-standalone';
 import { installRuntimeInject, runRuntimeInject } from '../../common/ng-mocks-runtime-inject';
 import ngMocksUniverse from '../../common/ng-mocks-universe';
 
-export default (keepDef: Set<any>, configDef: Map<any, any>, providers: any[]): Provider | undefined => {
+export default (
+  keepDef: Set<any>,
+  configDef: Map<any, any>,
+  providers: any[],
+  autoMockRootProviders: boolean,
+): Provider | undefined => {
   const environmentInitializer = (angularCore as any).ENVIRONMENT_INITIALIZER;
   if (!environmentInitializer || keepDef.has(NG_MOCKS_ROOT_PROVIDERS)) {
     return undefined;
   }
 
   const declarations = new Set<any>();
+  // Kept modules preserve their root providers, but one-argument MockBuilder
+  // calls auto-mock root dependencies for classic declarations too.
+  let autoMockDeclarations = autoMockRootProviders;
+  for (const def of keepDef) {
+    if (isNgDef(def, 'm')) {
+      autoMockDeclarations = false;
+      break;
+    }
+  }
   for (const def of keepDef) {
     const isDeclaration = isNgDef(def, 'c') || isNgDef(def, 'd') || isNgDef(def, 'p');
-    if (isStandalone(def) && isDeclaration) {
+    if ((isStandalone(def) || autoMockDeclarations) && isDeclaration) {
       declarations.add(def);
     }
     if (!isDeclaration && configDef.get(def).shallow === false && typeof def === 'function' && def.ɵprov?.factory) {

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -55,6 +55,7 @@ file|tests/issue-4282/*.ts|versions=6+
 file|tests/issue-14528/*.ts|versions=6+
 file|tests/issue-14544/test.spec.ts|features=injectFn
 file|tests/issue-14544/service.spec.ts|versions=22
+file|tests/issue-14560/*.ts|features=injectFn
 file|tests/issue-9397/*.ts|features=injectFn
 file|tests/issue-10760/*.ts|features=injectFn
 file|examples/ngMocksGlobalMock/*.spec.ts|features=injectFn

--- a/tests/issue-14560/test.spec.ts
+++ b/tests/issue-14560/test.spec.ts
@@ -1,0 +1,84 @@
+import { Component, inject, Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Injectable({ providedIn: 'root' })
+class TargetService {
+  public static constructed = 0;
+
+  public constructor() {
+    TargetService.constructed += 1;
+  }
+
+  public echo(): string {
+    return 'real';
+  }
+}
+
+@Component({
+  selector: 'target-field-14560',
+  standalone: false,
+  template: '',
+})
+class TargetFieldComponent {
+  public readonly service = inject(TargetService);
+}
+
+@Component({
+  selector: 'target-constructor-14560',
+  standalone: false,
+  template: '',
+})
+class TargetConstructorComponent {
+  public readonly service: TargetService;
+
+  public constructor() {
+    this.service = inject(TargetService);
+  }
+}
+
+// The runtime inject hook covered standalone declarations but skipped classic
+// components, so their inject() calls resolved real root services. Auto-mock
+// mode now wraps both declaration styles while kept modules retain their roots.
+// @see https://github.com/help-me-mom/ng-mocks/issues/14560
+describe('issue-14560', () => {
+  beforeEach(() =>
+    ngMocks.autoSpy(typeof jest === 'undefined' ? 'jasmine' : 'jest'),
+  );
+  afterEach(() => ngMocks.autoSpy('reset'));
+
+  beforeEach(() => {
+    TargetService.constructed = 0;
+  });
+
+  describe('field injection', () => {
+    beforeEach(() => MockBuilder(TargetFieldComponent));
+
+    it('mocks inject() dependencies of kept components', () => {
+      const fixture = MockRender(TargetFieldComponent);
+      const service = TestBed.inject(TargetService);
+
+      service.echo();
+
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(service.echo).toHaveBeenCalledTimes(1);
+      expect(TargetService.constructed).toBe(0);
+    });
+  });
+
+  describe('constructor body injection', () => {
+    beforeEach(() => MockBuilder(TargetConstructorComponent));
+
+    it('mocks inject() dependencies of kept components', () => {
+      const fixture = MockRender(TargetConstructorComponent);
+      const service = TestBed.inject(TargetService);
+
+      service.echo();
+
+      expect(fixture.point.componentInstance.service).toBe(service);
+      expect(service.echo).toHaveBeenCalledTimes(1);
+      expect(TargetService.constructed).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Runtime `inject()` support covered standalone declarations and was recently extended to kept services, but classic non-standalone components remained outside both factory hooks.

In one-argument `MockBuilder(Component)` auto-mock mode, moving a dependency from a constructor parameter to a field initializer or constructor-body `inject()` therefore resolved the real root service.

## What

- Enable the existing runtime injection hook for classic kept declarations in one-argument auto-mock mode.
- Preserve existing root-provider behavior for two-argument builders and explicitly kept modules.
- Add regressions for both field-initializer and constructor-body `inject()` calls.
- Spread the regression across Angular versions that expose the `inject()` API.

## Impact

Classic components retain MockBuilder auto-mocking after constructor injection is migrated to `inject()`. Standalone declarations, kept services, and kept-module root-provider semantics remain unchanged.

Related to #9397 and #14544.

Fixes #14560