### PR TITLE
chore(e2e/a20): limit native Vitest to smoke spec

### DIFF
--- a/e2e/a20/package.json
+++ b/e2e/a20/package.json
@@ -17,7 +17,7 @@
     "test:jest:ivy-zoned": "jest --config jest.config.ivy-zoned.ts",
     "test:jest:ivy-zoneless": "jest --config jest.config.ivy-zoneless.ts",
     "test:jest:debug": "jest -i --watch",
-    "test:vitest:ivy-zoneless": "ng run a20:test-vitest:ivy-zoneless"
+    "test:vitest:ivy-zoneless": "ng run a20:test-vitest:ivy-zoneless --include=src/app/app.component.spec.ts"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Why

Angular 20's native Vitest builder isolates every test file while CI runs it with a single worker. Repeating Angular and jsdom setup for the complete zoneless corpus makes this one runner dominate the job time.

The full Angular 20 behavior corpus remains covered by Jasmine and Jest, while Angular 21 and 22 continue to run the complete native Vitest corpus.

## What

Pass the existing app component spec to the Angular 20 native Vitest runner through its supported `--include` option.

## Impact

Angular 20 retains a native Vitest and zoneless integration smoke check without creating another test or configuration. The runner now initializes one test file instead of the full generated corpus; Jasmine, Jest, and newer Angular Vitest coverage are unchanged.
