### PR TITLE
fix(core): preserve Angular EffectScheduler #14613

### DIFF
--- a/libs/ng-mocks/src/lib/common/core.config.ts
+++ b/libs/ng-mocks/src/lib/common/core.config.ts
@@ -29,6 +29,9 @@ export default {
     'IterableDiffers',
     'KeyValueDiffers',
 
+    // Angular 22 effects require the concrete root scheduler implementation.
+    'EffectScheduler',
+
     // Angular 16 adds underscores
     '_DomRendererFactory2',
     '_EventManager',
@@ -41,6 +44,7 @@ export default {
     '_Compiler',
     '_IterableDiffers',
     '_KeyValueDiffers',
+    '_EffectScheduler',
   ],
   neverMockToken: [
     'InjectionToken Set Injector scope.', // INJECTOR_SCOPE // ivy only

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -59,6 +59,7 @@ file|tests/issue-14528/*.ts|versions=6+
 file|tests/issue-14544/test.spec.ts|features=injectFn
 file|tests/issue-14544/service.spec.ts|versions=22
 file|tests/issue-14560/*.ts|features=injectFn
+file|tests/issue-14613/*.ts|versions=22
 file|tests/issue-9397/*.ts|features=injectFn
 file|tests/issue-10760/*.ts|features=injectFn
 file|examples/ngMocksGlobalMock/*.spec.ts|features=injectFn

--- a/tests/issue-14613/test.spec.ts
+++ b/tests/issue-14613/test.spec.ts
@@ -1,0 +1,24 @@
+import { effect, Injectable } from '@angular/core';
+
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Injectable({ providedIn: 'root' })
+class TargetInterceptor {
+  public constructor() {
+    effect(() => undefined);
+  }
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14613
+// Angular 22 effects require the framework's root EffectScheduler. MockBuilder
+// used to replace it with an empty class mock, so the first effect creation
+// failed because the mock scheduler did not implement `add`.
+describe('issue-14613', () => {
+  beforeEach(() => MockBuilder(TargetInterceptor));
+
+  it('creates a root service which registers an effect', () => {
+    expect(() =>
+      ngMocks.findInstance(TargetInterceptor),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

Angular 22 effects register themselves through the root `EffectScheduler`. `MockBuilder`
replaced that provider with an empty class mock, so the first effect creation failed when
Angular called the missing `add` method.

## What

- Preserve both Angular runtime names for `EffectScheduler` by default while keeping
  explicit `.mock(...)` overrides available.
- Add an Angular 22 regression test for a root service that creates an effect.
- Follow the framework root-provider preservation pattern introduced for #1932.

## Impact

Root injectables can create Angular 22 effects under `MockBuilder` in both zoned and
zoneless test profiles without requiring `NG_MOCKS_ROOT_PROVIDERS` workarounds.

Fixes #14613
