### PR TITLE
fix(core): preserve Angular runtime services

### DIFF
--- a/libs/ng-mocks/src/lib/common/core.config.ts
+++ b/libs/ng-mocks/src/lib/common/core.config.ts
@@ -22,6 +22,12 @@ export default {
     'DomSanitizer',
     'DomSanitizerImpl',
 
+    // Angular runtime primitives require their concrete root infrastructure.
+    'AfterRenderImpl',
+    'AfterRenderManager',
+    'PendingTasks',
+    'PendingTasksInternal',
+
     // ApplicationModule, A14 made them global at root level
     'ApplicationInitStatus',
     'ApplicationRef',
@@ -30,6 +36,10 @@ export default {
     'KeyValueDiffers',
 
     // Angular 16 adds underscores
+    '_AfterRenderImpl',
+    '_AfterRenderManager',
+    '_PendingTasks',
+    '_PendingTasksInternal',
     '_DomRendererFactory2',
     '_EventManager',
     '_Injector',

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -65,6 +65,7 @@ file|examples/ngMocksGlobalMock/*.spec.ts|features=injectFn
 file|examples/TestRoutingGuard/test.spec.ts|versions=6+
 file|examples/TestRoutingResolver/test.spec.ts|versions=5+
 file|tests/mock-service/observable.spec.ts|versions=6+
+file|tests/provider-never-mock/angular-22.spec.ts|versions=22
 file|tests/issue-1596/test.spec.ts|versions=5-21
 file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21

--- a/tests/provider-never-mock/angular-22.spec.ts
+++ b/tests/provider-never-mock/angular-22.spec.ts
@@ -1,0 +1,76 @@
+import {
+  afterNextRender,
+  ApplicationRef,
+  Injectable,
+  resource,
+  ɵEffectScheduler,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Injectable({ providedIn: 'root' })
+class AfterRenderTarget {
+  public called = false;
+
+  public constructor() {
+    afterNextRender(() => {
+      this.called = true;
+    });
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+class ResourceTarget {
+  public resolve?: (value: number) => void;
+  public readonly data = resource({
+    loader: () =>
+      new Promise<number>(resolve => {
+        this.resolve = resolve;
+      }),
+  });
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14613
+// The EffectScheduler report exposed the same root-mocking problem for other
+// Angular runtime services used by afterNextRender and resource.
+describe('provider-never-mock: Angular 22 runtime services', () => {
+  describe('afterNextRender', () => {
+    beforeEach(() => MockBuilder(AfterRenderTarget));
+
+    it('runs a callback registered by a root service', () => {
+      const target = ngMocks.findInstance(AfterRenderTarget);
+
+      TestBed.tick();
+
+      expect(target.called).toBe(true);
+    });
+  });
+
+  describe('resource stability', () => {
+    beforeEach(() =>
+      // The scheduler regression is fixed independently by PR #14614.
+      MockBuilder(ResourceTarget).keep(ɵEffectScheduler),
+    );
+
+    it('waits for an unresolved resource loader', async () => {
+      const target = ngMocks.findInstance(ResourceTarget);
+
+      TestBed.tick();
+      let stable = false;
+      const stability = TestBed.inject(ApplicationRef)
+        .whenStable()
+        .then(() => {
+          stable = true;
+        });
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(stable).toBe(false);
+
+      target.resolve?.(42);
+      await stability;
+
+      expect(stable).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The investigation for #14613 found the same root-provider mocking mechanism affecting
other Angular runtime primitives. `MockBuilder` can replace after-render and pending-task
infrastructure while constructing a kept root injectable.

That causes `afterNextRender()` callbacks to be discarded and allows
`ApplicationRef.whenStable()` to resolve before an unresolved `resource()` loader finishes.

## What

- Preserve `AfterRenderManager` and `AfterRenderImpl` by default.
- Preserve `PendingTasks` and `PendingTasksInternal` by default.
- Keep explicit `.mock(...)` overrides available.
- Add Angular 22 regressions for after-render callbacks and resource stability tracking.

## Impact

Kept root injectables retain Angular's after-render and stability contracts without requiring
`NG_MOCKS_ROOT_PROVIDERS` workarounds. Public application dependencies and unrelated defer
schedulers remain mockable.

Related to #14613.
Follow-up to #14614.
