### PR TITLE
fix(TestBed): respect explicit MockModule boundaries #14653

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.extract-deps.ts
+++ b/libs/ng-mocks/src/lib/common/func.extract-deps.ts
@@ -11,6 +11,7 @@ export const funcExtractDeps = (
   result: Set<AnyDeclaration<any>>,
   recursive = false,
   visited = new Set<AnyDeclaration<any>>(),
+  shouldTraverse?: (dependency: AnyDeclaration<any>) => boolean,
 ): Set<AnyDeclaration<any>> => {
   const visit = (current: any): void => {
     if (visited.has(current)) {
@@ -35,7 +36,7 @@ export const funcExtractDeps = (
         // istanbul ignore if: it is here for standalone things, however they don't support modules with providers.
         const itemType = funcGetType(item);
         result.add(itemType);
-        if (recursive) {
+        if (recursive && (!shouldTraverse || shouldTraverse(itemType))) {
           visit(itemType);
         }
       }

--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -16,7 +16,7 @@ import coreInjector from './core.injector';
 import coreReflectMeta from './core.reflect.meta';
 import coreReflectProvidedIn from './core.reflect.provided-in';
 import { NG_MOCKS, NG_MOCKS_ROOT_PROVIDERS, NG_MOCKS_TOUCHES } from './core.tokens';
-import { AnyType, dependencyKeys } from './core.types';
+import { AnyDeclaration, AnyType, dependencyKeys } from './core.types';
 import { funcExtractDeps } from './func.extract-deps';
 import { getSourceOfMock } from './func.get-source-of-mock';
 import funcGetType from './func.get-type';
@@ -266,10 +266,23 @@ const configureTestingModule =
       let builder = MockBuilder(NG_MOCKS_ROOT_PROVIDERS);
 
       const realDependencies = new Set<AnyType<any>>();
+      const explicitMockDefinitions = new Set<AnyDeclaration<any>>();
       const visitedDependencies = new Set<AnyType<any>>();
       for (const [source, , isMock] of mockBuilder) {
+        if (isMock) {
+          explicitMockDefinitions.add(funcGetType(source));
+        }
+      }
+      const shouldTraverse = (dependency: AnyDeclaration<any>): boolean => {
+        const resolution = ngMocksUniverse.getResolution(dependency);
+
+        // Explicit mocks and non-keep resolutions stop inferred keeps, but shared
+        // dependencies can still be kept when another real path reaches them.
+        return !explicitMockDefinitions.has(dependency) && (!resolution || resolution === 'keep');
+      };
+      for (const [source, , isMock] of mockBuilder) {
         if (!isMock) {
-          funcExtractDeps(funcGetType(source), realDependencies, true, visitedDependencies);
+          funcExtractDeps(funcGetType(source), realDependencies, true, visitedDependencies, shouldTraverse);
         }
       }
       for (const dependency of mapValues(realDependencies)) {

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -60,6 +60,7 @@ file|tests/issue-14544/test.spec.ts|features=injectFn
 file|tests/issue-14544/service.spec.ts|versions=22
 file|tests/issue-14560/*.ts|features=injectFn
 file|tests/issue-14613/*.ts|versions=17+
+file|tests/issue-14653/*.ts|features=standalone
 file|tests/issue-9397/*.ts|features=injectFn
 file|tests/issue-10760/*.ts|features=injectFn
 file|examples/ngMocksGlobalMock/*.spec.ts|features=injectFn

--- a/tests/issue-14653/test.spec.ts
+++ b/tests/issue-14653/test.spec.ts
@@ -1,0 +1,95 @@
+import {
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  Directive,
+  ElementRef,
+  NgModule,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+} from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+import { MockModule } from 'ng-mocks';
+
+@Directive({
+  selector: 'target-14653',
+  host: {
+    '(toggled)': 'handleChangeEvent($event.target.checked)',
+  },
+  standalone: false,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: ToggleValueAccessor,
+      multi: true,
+    },
+  ],
+})
+class ToggleValueAccessor implements ControlValueAccessor {
+  private lastValue: unknown;
+  private onChange: (value: unknown) => void = () => undefined;
+
+  public constructor(private readonly elementRef: ElementRef) {}
+
+  public writeValue(value: unknown): void {
+    this.elementRef.nativeElement.checked = this.lastValue =
+      value ?? false;
+  }
+
+  public handleChangeEvent(value: unknown): void {
+    this.lastValue = value;
+    this.onChange(value);
+  }
+
+  public registerOnChange(fn: (value: unknown) => void): void {
+    this.onChange = fn;
+  }
+
+  public registerOnTouched(): void {}
+}
+
+@NgModule({
+  declarations: [ToggleValueAccessor],
+  exports: [ToggleValueAccessor],
+})
+class UiModule {}
+
+@Component({
+  selector: 'host-14653',
+  standalone: true,
+  imports: [UiModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template:
+    '<target-14653 (toggled)="onToggled($event)"></target-14653>',
+})
+class HostComponent {
+  public value?: boolean;
+
+  public onToggled(event: Event): void {
+    this.value = (event as CustomEvent<boolean>).detail;
+  }
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14653
+describe('issue-14653', () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent, MockModule(UiModule)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it('does not invoke a host listener from a mocked module', () => {
+    const toggle = fixture.debugElement.query(By.css('target-14653'));
+
+    toggle.triggerEventHandler('toggled', { detail: true });
+    expect(fixture.componentInstance.value).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The mixed TestBed bridge recursively preserves dependencies of real declarations and imports. That traversal continued through an explicitly supplied `MockModule`, so declarations inside the mocked module were added as inferred real dependencies. The original directive and its host listener therefore remained active.

## What

- Treat explicit mocks as dependency-traversal boundaries while rebuilding mixed TestBed configurations.
- Apply the same precedence to global mock, replace, and exclude resolutions while retaining explicit keeps.
- Keep shared dependencies real when another real TestBed path reaches them independently.
- Add cross-version regression coverage for a standalone host importing an explicitly mocked NgModule.

## Impact

`MockModule(UiModule)` once again mocks declarations beneath that module in mixed standalone TestBed configurations. Recursive preservation for unmocked real paths remains intact, including the behavior covered by #8649.

Fixes #14653