### PR TITLE
build(release): replace deprecated GitHub failure options

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -26,11 +26,16 @@ Create and maintain a plain Markdown checklist:
    - `git status --short`
    - `git remote -v`
    - `git fetch upstream --prune`
-   - read `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `compose.sh`, `test.sh`, `compose.yml`, `package.json`, `test-spread.conf`, and `test-spread-app.conf` when they affect the issue
+   - read `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `compose.sh`, `test.sh`, `compose.yml`, `package.json`,
+     `test-spread.conf`, and `test-spread-app.conf` when they affect the issue
+   - read `.commitlintrc.yml`, `.releaserc.yml`, and `semantic-release-release-notes.mjs` when the work changes release
+     behavior or the correct release classification is unclear
 2. Inspect issue context:
    - Use available GitHub access: `gh`, the GitHub web UI, the GitHub API, or any configured connector.
    - Prefer commands that are easy to reproduce, such as `gh issue view <issue-number> --repo help-me-mom/ng-mocks --comments`.
    - Search duplicates and related work with `gh issue list`, `gh pr list --search`, GitHub search, and local `git log --grep`.
+   - If current guidance and nearby code do not settle the pattern, inspect analogous local history or recent merged
+     non-bot PRs. Prefer human-authored examples over generated dependency-update text.
    - Inspect prior fixes with similar symptoms: `git log --no-merges --oneline --all -- 'tests/issue-*' 'tests-e2e/src/issue-*' 'e2e/*/src/tests/issue-*'`.
 3. Create a dedicated worktree before changing files:
    - default branch name: `issues/<issue-number>`
@@ -74,7 +79,9 @@ When adding a spread test:
 
 - Give selectors, classes, and marker methods issue-specific names where collisions are possible.
 - Match nearby compatibility style, including `VERSION.major` guards and metadata casts such as `['standalone' as never]` when older TypeScript or Angular targets still parse the file.
-- If a file imports APIs unavailable in older Angular targets, gate it in `test-spread.conf` with `versions=` or `features=` instead of relying only on runtime guards.
+- If a file imports APIs unavailable in older Angular targets, gate it in `test-spread.conf` at the actual
+  version, feature, and environment boundaries instead of relying only on runtime guards. Split independently testable
+  APIs when their boundaries differ; keep a cohesive regression at the first common boundary when necessary.
 - Prefer one `describe('issue-<number>')` suite with assertions that prove the reported failure and the expected behavior.
 - Add an in-file `// @see https://github.com/help-me-mom/ng-mocks/issues/<issue-number>` link near the regression suite. For subtle regressions, add a short comment block that explains the reported failure, the root cause, and the fix so future readers do not need to reconstruct the issue from the PR.
 
@@ -136,37 +143,44 @@ Coverage expectations:
 
 ## Comments, Commit, PR
 
-Use the same concise structure for issue comments, PR descriptions, and non-trivial commit bodies. Keep validation details internal to the agent run and final user summary; do not put validation commands, logs, or results in GitHub comments, commit bodies, or PR descriptions.
+Use this concise structure for pull request descriptions. Use equivalent prose in issue comments or non-trivial commit
+bodies only when it helps that artifact. Prefer `Impact` for user-visible or maintainer outcomes and `Where` when the
+affected locations are more informative. Keep validation details internal to the agent run and final user summary; do
+not put validation commands, logs, or results in GitHub comments, commit bodies, or PR descriptions.
 
 ```md
-Why:
+## Why
 
 - The reported failure happens when ...
 
-What:
+## What
 
 - Added `tests/issue-<issue-number>/test.spec.ts` to reproduce ...
 - Changed `libs/ng-mocks/...` so ...
 
-Where:
+## Impact
 
-- `tests/issue-<issue-number>/test.spec.ts`
-- `libs/ng-mocks/src/lib/...`
+- Callers now ... while ... remains unchanged.
 ```
 
 Commit message rules:
 
-- Use conventional commits accepted by `.commitlintrc.yml`.
-- Prefer `fix(<scope>): <imperative summary> #<issue-number>` for bug fixes, or `test(<scope>): ...` only for test-only changes.
+- Follow the canonical `Commit and Release Semantics` section in `AGENTS.md`. Make every local commit accurate; make
+  the PR title express the aggregate and highest release effect. Align them on a single-commit branch.
+- Prefer `fix(<scope>): <imperative summary> #<issue-number>` for fixes to published behavior, or
+  `test(<scope>): ...` for test-only changes. Classify release, build, and internal work by the AGENTS.md matrix.
 - Keep the issue number in the subject when it improves traceability.
-- Add a body with `Why`, `What`, and `Where` when the fix is subtle.
+- Add a body with `Why`, `What`, and `Impact` or `Where` when the fix is subtle.
 
 PR rules:
 
 - Open the PR against `help-me-mom/ng-mocks` base `main`, from the pushed issue branch.
 - Confirm the PR branch was created in the dedicated worktree from `upstream/main`.
-- Include `Closes #<issue-number>` or `Fixes #<issue-number>` in the PR body.
-- Describe the problem and how it was fixed; omit validation commands and results.
+- Use a conventional PR title that summarizes the complete change and its highest release effect.
+- Include `Closes #<issue-number>` or `Fixes #<issue-number>` when this PR completes the reported issue. Use
+  `Related to`, `Follow-up to`, or equivalent wording when it should not close the reference.
+- Describe the root cause, focused fix, regression coverage, documentation changes, and impact as applicable; omit
+  validation commands and results.
 - Link related issues, duplicate reports, and previous PRs when they influenced the fix.
 - Do not commit, push, post GitHub comments, or create a PR when the requester explicitly asks to review locally first.
 

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -30,8 +30,7 @@ plugins:
         [v${nextRelease.version}](https://github.com/help-me-mom/ng-mocks/releases/tag/v${nextRelease.version})
         has been released and contains a fix for the issue.
         Feel free to reopen the issue or to submit a new one if you meet any problems.
-      failTitle: false
-      failComment: false
+      failCommentCondition: false
       labels: false
       releasedLabels:
         - released

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@
   - `test.sh`
   - `compose.yml`
   - `package.json`
+  - `.commitlintrc.yml`
+  - `.releaserc.yml`
+  - `semantic-release-release-notes.mjs`
   - `test-spread.conf`
   - `test-spread-app.conf`
 - If docs and executable files disagree, trust the current scripts and config first, then update the docs.
@@ -83,6 +86,14 @@
 
 - Never add helper functions in tests. Keep the relevant setup, action, and assertion flow inline in each spec, even when that means duplicating a short block, so regressions stay obvious across Angular spread targets.
 - Prefer static ES imports in source and tests. Do not use `require` or dynamic module access unless there is a concrete technical reason; if an Angular API is unavailable in older spread targets, gate that file in `test-spread.conf` with `versions=` or `features=` instead of bypassing TypeScript compatibility.
+- Keep the direct reproducer for an issue in `tests/issue-<number>` when that is the appropriate runtime surface. Add
+  an in-file `@see` issue link near the suite and a concise root-cause comment when the failure is subtle. Put broader
+  adjacent-policy audits in the relevant feature suite instead of expanding the issue test indefinitely.
+- Gate spread tests at each API's actual introduction version, feature, and environment boundary, not only the
+  reporter's Angular version. Split independently testable APIs when they have different compatibility boundaries;
+  keep a cohesive regression at the first common boundary when it necessarily combines them.
+- For framework-internal or multi-branch fixes, pair a focused source-unit spec with a real-Angular spread regression.
+  Assert the reported outcome as well as preserved behavior and the absence of the relevant side effects.
 - When a spread test depends on Zone.js, gate it with `environments=zoned` in `test-spread.conf` so the zoned and
   zoneless corpora remain isolated without project-specific exclusions.
 - Keep CI-facing root test scripts named `test:<project>[:<es>]:<profile>`. Keep project-level profile script and
@@ -123,12 +134,83 @@
   4. Run `sh test.sh coverage` when core behavior or coverage-sensitive code changes
 - For docs-only or agent-guidance-only changes, tests may be skipped, but say so explicitly in the final summary.
 
-## GitHub Artifact Text
+## Commit and Release Semantics
 
-- Keep issue comments, pull request descriptions, and non-trivial commit bodies focused on the problem and how it was fixed.
-- Pull request descriptions may be detailed. Include enough `Why`, `What`, and `Impact` or `Where` context for reviewers to understand the complete change.
-- Keep every commit-message line, including body and footer lines, at 100 characters or fewer so it satisfies commitlint. Wrap longer prose instead of removing required context.
-- Do not include validation blocks, exact validation commands, logs, or local test results in PR descriptions or commit bodies. Treat those details as internal agent run notes unless the user asks to publish them.
+- Make every local commit subject conventional and accurate for that commit. For squash merges, make the PR title a
+  conventional summary of the complete PR and its highest release effect; align it with the local subject on a
+  single-commit branch. GitHub normally uses that title for the squash commit.
+- Use `type(optional-scope): imperative summary`: keep the type lowercase, preserve established scope casing such as
+  `MockBuilder`, `TestBed`, or `README`, and do not end the subject with a period.
+- `.commitlintrc.yml` accepts `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`,
+  and `test`. Choose the type from the effect represented by that subject, whether it describes an individual commit
+  or an aggregate PR, not merely the files touched and not the desired release outcome.
+
+  | Commit form                                                             | Use it when                                                 | semantic-release result |
+  | ----------------------------------------------------------------------- | ----------------------------------------------------------- | ----------------------- |
+  | `feat(<scope>): ...`                                                    | The published package gains a user-visible capability       | minor                   |
+  | `fix(<scope>): ...`                                                     | Published behavior is corrected                             | patch                   |
+  | `perf(<scope>): ...`                                                    | Published runtime performance improves                      | patch                   |
+  | recognized `revert: ...`                                                | A commit from an earlier release is conventionally reverted | patch                   |
+  | `docs(README): ...`                                                     | The packaged root README changes                            | patch                   |
+  | `build`, `chore`, `ci`, other `docs`, `refactor`, `style`, or `test`    | The change should wait for another release trigger          | no release              |
+  | any allowed type except `docs(README)` with a `BREAKING CHANGE:` footer | Published compatibility is intentionally broken             | major                   |
+
+- A release-silent commit does not start a release by itself and is normally omitted from generated notes. Changes it
+  makes to packaged inputs still ship once another commit triggers a package release. Use an accurate silent type for
+  CI, tests, internal
+  refactors, dependencies, agent guidance, or release tooling that does not change the published package. For
+  example, a semantic-release configuration repair should use `build(release): ...`, not `fix(release): ...`.
+- A conventional revert of an already released commit produces a patch. An original commit and its matching revert in
+  the same unreleased range cancel each other; a plain `revert: ...` without `This reverts commit <hash>` is silent.
+- `[skip release]` and `[release skip]` remove a commit from release analysis regardless of its type or footer. Use
+  those markers only with explicit maintainer direction for an exceptional generated or duplicate commit, never to
+  hide the release required by a user-visible change.
+- Do not downgrade a user-visible fix or feature to a silent type to avoid a release. If one PR contains several
+  related effects, select the type for the highest required release.
+- semantic-release uses the Angular commit parser. Use the canonical `BREAKING CHANGE:` footer for a major release;
+  do not rely on the `!` shorthand or `BREAKING-CHANGE:` because those forms do not trigger a major release here.
+  The custom `docs(README)` rule always resolves to patch when it matches, so it must not label a breaking source or
+  API change; the default Angular release notes still omit that docs entry.
+- For squash merges, ensure the resulting commit subject uses the conventional PR title. True merges and rebase merges
+  can also retain child commit messages. The highest release trigger among commits remaining after release-skip and
+  revert-pair filtering wins.
+- Keep commit headers and footer lines at 100 characters or fewer because commitlint enforces those limits. Wrap
+  commit body prose at 100 characters as a repository convention even though the configured body limit is relaxed.
+  Leave room in a PR title for GitHub's automatic ` (#<pr-number>)` suffix on the squash commit.
+
+## Pull Request Quality
+
+- If current guidance and nearby code do not settle an implementation or documentation pattern, inspect analogous
+  local history or recent merged non-bot PRs. Prefer human-authored examples over generated dependency-update text.
+- Keep implementation narrow and follow `Test Style` for issue reproducers, compatibility gates, layered coverage,
+  and preservation assertions.
+- Update API docs, compatibility tables, or migration guidance in the same PR when the documented public contract,
+  tested support claim, or a material upgrade path changes. Internal fixes that restore the documented contract do not
+  require public docs. For a shipped behavior change likely to require user code or test updates, add migration
+  guidance with affected versions, before/after examples, the safe update path, and explicitly unaffected cases.
+- Update `AGENTS.md` and the relevant repo skill only when current guidance is wrong or missing and the lesson is
+  repository-wide, repeated, or exposed by an actual workflow failure.
+- For build, packaging, and release-tooling bugs, validate the final generated artifact or loaded configuration when
+  practical. A deterministic offline assertion or probe is preferable to a check that publishes or mutates external
+  state.
+- Use a conventional PR title that summarizes the complete PR and accurately predicts the squash commit's release
+  effect. Keep issue comments, pull request descriptions, and non-trivial commit bodies focused on the problem and how
+  it was fixed.
+- Include the reported issue number in the title when it improves traceability and still fits the 100-character commit
+  header limit. Use the closing keyword in the PR body.
+- Prefer these PR body sections, using level-two Markdown headings:
+  - `Why`: explain the reported symptom and root cause, including relevant issue or prior-PR context.
+  - `What`: summarize the focused behavior, regression coverage, and documentation changes rather than listing raw
+    diffs.
+  - `Impact`: state the user or maintainer outcome, important preserved behavior or non-goals, and whether public docs
+    changed or were unnecessary.
+  - Use `Where` instead of `Impact` when the affected locations give reviewers more useful context than an outcome
+    section.
+- Use `Fixes #...` or `Closes #...` for a completed issue. Use `Related to #...`, `Follow-up to #...`, or equivalent
+  wording when the PR should not close the referenced issue.
+- Pull request descriptions may be detailed; commitlint's line limits do not apply to them. Do not include validation
+  blocks, exact validation commands, logs, or local test results in PR descriptions or commit bodies. Treat those
+  details as internal agent run notes unless the user asks to publish them.
 
 ## Git Safety
 


### PR DESCRIPTION
## Why

`@semantic-release/github` 12.0.9 warns after each release because the configuration disables failure issues through the deprecated `failTitle: false` and `failComment: false` options.

The repository guidance also did not explain that conventional PR titles become release metadata, including which commit types trigger a version and which remain release-silent.

## What

- Replace the deprecated failure options with `failCommentCondition: false`, preserving the existing skip behavior.
- Document the pinned commitlint and semantic-release type-to-version rules, parser edge cases, and squash-title behavior.
- Capture the implementation, regression, documentation, issue-link, and PR-body patterns used by recent merged work.
- Keep the issue-triage skill aligned with the central agent runbook.

## Impact

Releases no longer emit the deprecation warning and still do not create or close semantic-release failure issues. Future automated contributions can select the intended version impact and prepare reviewer-ready PRs without changing published ng-mocks behavior, so this PR remains release-silent.