### PR TITLE
fix(MockRender): support readonly signal input bindings #14692

### DIFF
--- a/libs/ng-mocks/src/lib/mock-render/types.ts
+++ b/libs/ng-mocks/src/lib/mock-render/types.ts
@@ -47,6 +47,30 @@ type MockRenderInputBinding<T> = 0 extends 1 & T
       ? WriteT
       : T;
 
-export type DefaultRenderComponent<MComponent> = {
-  [K in keyof MComponent]: MockRenderInputBinding<MComponent[K]>;
+type MockRenderInputSignalKeys<MComponent> = {
+  [K in keyof MComponent]-?: 0 extends 1 & MComponent[K]
+    ? never
+    : [MockRenderInputSignalNode<MComponent[K]>] extends [never]
+      ? never
+      : K;
+}[keyof MComponent];
+
+type MockRenderInputSignals<MComponent> = Pick<MComponent, MockRenderInputSignalKeys<MComponent>>;
+
+type MockRenderInputBindings<MComponent> = {
+  -readonly [K in keyof MockRenderInputSignals<MComponent>]: MockRenderInputBinding<
+    MockRenderInputSignals<MComponent>[K]
+  >;
 };
+
+type MockRenderComponentBindings<MComponent> = Pick<
+  MComponent,
+  Exclude<keyof MComponent, MockRenderInputSignalKeys<MComponent>>
+> &
+  MockRenderInputBindings<MComponent>;
+
+export type DefaultRenderComponent<MComponent> = 0 extends 1 & MComponent
+  ? MComponent
+  : MComponent extends object
+    ? MockRenderComponentBindings<MComponent>
+    : MComponent;

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -85,6 +85,7 @@ file|tests/issue-13089/test.spec.ts|features=signalForms
 file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
+file|tests/issue-14692/test.spec.ts|features=signalInputs
 file|tests/issue-7976/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-9684/test.spec.ts|features=signalInputs

--- a/tests/issue-14692/test.spec.ts
+++ b/tests/issue-14692/test.spec.ts
@@ -1,4 +1,9 @@
-import { Component, input, NgModule } from '@angular/core';
+import {
+  Component,
+  input,
+  NgModule,
+  reflectComponentType,
+} from '@angular/core';
 
 import { MockBuilder, MockRender } from 'ng-mocks';
 
@@ -18,6 +23,18 @@ class TargetModule {}
 
 // @see https://github.com/help-me-mom/ng-mocks/issues/14692
 describe('issue-14692', () => {
+  if (
+    !reflectComponentType(TargetComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'myInput',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
   beforeEach(() => MockBuilder(TargetComponent, TargetModule));
 
   it('updates a signal input through the generated wrapper', () => {

--- a/tests/issue-14692/test.spec.ts
+++ b/tests/issue-14692/test.spec.ts
@@ -1,0 +1,36 @@
+import { Component, input, NgModule } from '@angular/core';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target-14692',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ myInput() }}',
+})
+class TargetComponent {
+  public readonly myInput = input<string | null>(null);
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14692
+describe('issue-14692', () => {
+  beforeEach(() => MockBuilder(TargetComponent, TargetModule));
+
+  it('updates a signal input through the generated wrapper', () => {
+    const fixture = MockRender(TargetComponent);
+
+    // `readonly` protects the signal reference on TargetComponent. The
+    // generated wrapper owns a separate, writable binding value.
+    fixture.componentInstance.myInput = 'myValue';
+    fixture.detectChanges();
+
+    expect(fixture.point.componentInstance.myInput()).toEqual(
+      'myValue',
+    );
+    expect(fixture.nativeElement.textContent).toContain('myValue');
+  });
+});


### PR DESCRIPTION
Fixes #14692

Why:

- Angular recommends declaring signal input fields as `readonly`.
- `DefaultRenderComponent` currently carries that modifier onto its separate wrapper binding value.
- Tests therefore cannot assign a new signal input value through `MockRender`.

What:

- Add a regression for a styleguide-compliant readonly signal input.
- Remove `readonly` only from structurally detected signal-input binding keys.
- Preserve component modifiers for ordinary fields and signals, plus transformed-input write types.

Impact:

- `MockRender(...).componentInstance` exposes a writable host-side value for readonly signal inputs.
- The rendered component keeps its readonly `InputSignal` reference and Angular-managed update path.

Where:

- `tests/issue-14692/test.spec.ts`
- `test-spread.conf`
- `libs/ng-mocks/src/lib/mock-render/types.ts`
