### PR TITLE
fix(MockRender): hide internal query state from snapshots #14768

### DIFF
--- a/e2e/jest/src/tests/issue-14768/__snapshots__/test.spec.ts.snap
+++ b/e2e/jest/src/tests/issue-14768/__snapshots__/test.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`issue-14768 omits internal bookkeeping from fixture snapshots 1`] = `
+<mock-render>
+  <issue-14768-target>
+    <span>
+      test
+    </span>
+  </issue-14768-target>
+</mock-render>
+`;

--- a/e2e/jest/src/tests/issue-14768/test.spec.ts
+++ b/e2e/jest/src/tests/issue-14768/test.spec.ts
@@ -1,0 +1,26 @@
+import { Component, input } from '@angular/core';
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'issue-14768-target',
+  standalone: true,
+  template: '<span>{{ value() }}</span>',
+})
+class TargetComponent {
+  public readonly value = input('default');
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14768
+// The signal-input ViewChild becomes an enumerable wrapper property,
+// so the ng-snapshot serializer exposes internal state on <mock-render>.
+describe('issue-14768', () => {
+  beforeEach(() => MockBuilder(TargetComponent));
+
+  it('omits internal bookkeeping from fixture snapshots', () => {
+    const fixture = MockRender(TargetComponent, { value: 'test' });
+
+    expect(fixture.point.componentInstance.value()).toBe('test');
+    expect(fixture.nativeElement.textContent).toBe('test');
+    expect(fixture).toMatchSnapshot();
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
@@ -47,6 +47,8 @@ const generateWrapperComponent = ({ bindings, options, inputs, signalInputs, tem
     private __ngMocksPoint?: any;
 
     public constructor() {
+      // Angular assigns the query result later; keep it out of fixture snapshots.
+      coreDefineProperty(this, '__ngMocksPoint', undefined);
       coreDefineProperty(this, '__ngMocksOutput', generateWrapperOutput(this));
 
       // The getter helps to remove the __ngContext__ attribute from <mock-render> tag.


### PR DESCRIPTION
## Why

`MockRender` fixtures containing signal inputs expose the internal `__ngMocksPoint` query result as an enumerable property. The `jest-preset-angular` fixture serializer includes that property on `<mock-render>`, invalidating snapshots of otherwise unchanged components and tying them to component class names.

## What

- Define the query property as non-enumerable on each wrapper instance before Angular assigns its result, using the existing property helper.
- Add a Jest-only regression and expected fixture snapshot that check signal input rendering and the absence of internal bookkeeping in the serialized wrapper.

## Impact

Fixture snapshots no longer expose the internal query result. The property remains writable for Angular, preserving the signal input initialization and update path. Public documentation is unchanged because this restores the expected snapshot behavior.

Fixes #14768
