### PR TITLE
docs(router): complete guard coverage and documentation #1008

### DIFF
--- a/docs/articles/api/MockBuilder.md
+++ b/docs/articles/api/MockBuilder.md
@@ -483,11 +483,16 @@ It covers `canActivate`, `canActivateChild`, `canDeactivate`, `canLoad`, and `ca
 with class guards, injection tokens, and functional guards.
 It's useful if you want to test a specific guard. 
 To do so, you need to [`.exclude`](#exclude) `NG_MOCKS_GUARDS` and to [`.keep`](#keep) the guard.
+Keep [`NG_MOCKS_ROOT_PROVIDERS`](#ng_mocks_root_providers-token) as well so the router's root services remain available.
 
 ```ts
 beforeEach(() => {
   return MockBuilder(
-      [RouterModule, RouterTestingModule.withRoutes([])],
+      [
+        RouterModule,
+        RouterTestingModule.withRoutes([]),
+        NG_MOCKS_ROOT_PROVIDERS,
+      ],
       ModuleWithRoutes,
     )
     .exclude(NG_MOCKS_GUARDS) // <- removes all guards

--- a/docs/articles/api/MockBuilder.md
+++ b/docs/articles/api/MockBuilder.md
@@ -478,7 +478,9 @@ even if it has been imported or declared in nested modules.
 
 ### `NG_MOCKS_GUARDS` token
 
-`NG_MOCKS_GUARDS` helps to **remove guards from all routes** in a test.
+`NG_MOCKS_GUARDS` helps to **remove guards from routes processed by `MockBuilder`**, including nested `children`.
+It covers `canActivate`, `canActivateChild`, `canDeactivate`, `canLoad`, and `canMatch`,
+with class guards, injection tokens, and functional guards.
 It's useful if you want to test a specific guard. 
 To do so, you need to [`.exclude`](#exclude) `NG_MOCKS_GUARDS` and to [`.keep`](#keep) the guard.
 
@@ -493,6 +495,14 @@ beforeEach(() => {
   ;
 });
 ```
+
+Mocked guards are removed from route arrays even when customized with `.mock(...)`; their mock providers remain available.
+A guard kept with `.keep(...)` remains in those arrays. Pair `.keep(...)` with `.provide(...)` if you also want to override its provider.
+Without `.exclude(NG_MOCKS_GUARDS)`, guards remain in the route configuration unless individually excluded.
+The original route arrays are not modified.
+
+Routes supplied directly through `.provide(provideRouter(...))` are used as supplied, and lazy-loading callbacks are not executed to discover more routes.
+See [testing routing guards](../guides/routing-guard.md) for navigation assertions and lazy-module setup.
 
 ### `NG_MOCKS_RESOLVERS` token
 

--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -8,10 +8,10 @@ If you have not read ["How to test a route"](route.md), please do it first.
 
 To test a guard means that we need to mock everything except the guard and `RouterModule`.
 But, what if we have several guards? If we mocked them they would block routes due to falsy returns of their mocked methods.
-**To remove guards in Angular tests, `ng-mocks` provides the `NG_MOCKS_GUARDS` token**. We should pass it into `.exclude`, then all other guards will be
+**To remove guards in Angular tests, `ng-mocks` provides the [`NG_MOCKS_GUARDS` token](/api/MockBuilder.md#ng_mocks_guards-token)**. We should pass it into `.exclude`, then all other guards will be
 removed from the route configuration processed by `MockBuilder`, and we can be sure that we are **testing only the guard we want**.
 
-The same `MockBuilder` setup applies to all five guard properties, including class and token guards.
+The same [`MockBuilder`](/api/MockBuilder.md) setup applies to all five guard properties, including class and token guards.
 The functional examples require Angular 14.2 or newer:
 
 - `canActivate` -
@@ -42,7 +42,7 @@ A guard resides in the configuration of routes,
 which is defined as an import of `RouterModule.forRoot` or `RouterModule.forChild` in a module.
 
 To test a guard, you need the guard and the module which defines a route with the guard.
-For simplicity, let's call the guard `loginGuard`, and the module `TargetModule`.
+For simplicity, let's call the guard `canActivateGuard`, and the module `TargetModule`, as in the [live example](#live-example).
 
 The guard should be tested in isolation, to avoid side effects of other guards.
 Also, `RouterModule` and its dependencies should be provided in a test
@@ -70,8 +70,8 @@ beforeEach(() =>
   .exclude(NG_MOCKS_GUARDS)
   
   // chain
-  // keeping loginGuard for testing
-  .keep(loginGuard)
+  // keeping canActivateGuard for testing
+  .keep(canActivateGuard)
 );
 ```
 
@@ -84,13 +84,13 @@ Let's assert that:
 1. initialize navigation
 1. assert the location
 
-To render a router outlet, you can use `MockRender` with empty parameters.
+To render a router outlet, use [`MockRender`](/api/MockRender.md) with an empty object as the second parameter to leave the outlet's inputs untouched.
 
 ```ts
 const fixture = MockRender(RouterOutlet, {});
 ```
 
-Now, you can get `Router` and `Location`.
+Now, you can get `Router` and `Location` with [`ngMocks.get`](/api/ngMocks/get.md).
 The first one is needed for the initialization,
 the second one for assertion.
 
@@ -116,7 +116,9 @@ expect(location.path()).toEqual('/login');
 ```
 
 
-Profit, [an example of a test for a functional guard](#live-example).
+The [live example](#live-example) also uses [`ngMocks.find`](/api/ngMocks/find.md) to assert which component the route rendered.
+
+### Choosing the navigation to test
 
 Choose a navigation that actually invokes the guard under test:
 
@@ -134,20 +136,32 @@ See Angular's [guard return types](https://angular.dev/guide/routing/route-guard
 
 ### Testing lazy loading
 
-`canLoad` runs before loading a lazy module. Assert both the navigation result and whether the loader ran:
+`canLoad` runs before loading a lazy module. In the [canLoad example](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-load.spec.ts),
+the setup keeps `canLoadGuard` and the mocked `LoginService` starts with `isLoggedIn = false`.
+Render the outlet, spy on the second route's lazy loader, and assert both navigation and loading:
 
 ```ts
-const loader = spyOn(router.config[1], 'loadChildren').and.callThrough();
-const result = await (fixture.ngZone
-  ? fixture.ngZone.run(() => router.navigateByUrl('/dashboard'))
-  : router.navigateByUrl('/dashboard'));
-await fixture.whenStable();
+const fixture = MockRender(RouterOutlet, {});
+const router = ngMocks.get(Router);
 
-expect(result).toEqual(false);
-expect(loader).not.toHaveBeenCalled();
+// Observe loading without replacing the module returned by the callback.
+const loader = spyOn(router.config[1], 'loadChildren').and.callThrough();
+
+// Attempt navigation before the lazy module has been loaded.
+if (fixture.ngZone) {
+  const result = await fixture.ngZone.run(() =>
+    router.navigateByUrl('/dashboard'),
+  );
+  await fixture.whenStable();
+
+  expect(result).toEqual(false);
+  expect(loader).not.toHaveBeenCalled();
+  expect(router.url).toEqual('/');
+}
 ```
 
-Use a fresh test setup for the allowed case, then assert `true`, one loader call, and the dashboard component.
+Use a fresh test setup for the allowed case, set `ngMocks.get(LoginService).isLoggedIn = true`,
+then assert `true`, one loader call, and the dashboard component.
 Once Angular has loaded the module, subsequent navigation does not run `canLoad` again.
 The lazy module in the [canLoad example](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-load.spec.ts)
 is loaded as-is: its declarations belong to that module alone.
@@ -269,6 +283,11 @@ checks both removal and a retained guard that blocks lazy loading.
 - [Try it on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
 - [View the standalone example source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/standalone.spec.ts)
 
+:::note
+The snippet omits compatibility metadata. In Angular 19 and newer, add `standalone: false` to both component decorators
+because these components are declared in `TargetModule`. The executable source includes this metadata.
+:::
+
 ```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-activate.spec.ts"
 import { Location } from '@angular/common';
 import {
@@ -321,7 +340,6 @@ const sideEffectGuard: CanActivateFn = () => {
 // It will be replaced with a mock copy.
 @Component({
   selector: 'login',
-  standalone: false,
   template: 'login',
 })
 class LoginComponent {}
@@ -330,7 +348,6 @@ class LoginComponent {}
 // It will be replaced with a mock copy.
 @Component({
   selector: 'dashboard',
-  standalone: false,
   template: 'dashboard',
 })
 class DashboardComponent {}
@@ -357,7 +374,7 @@ class DashboardComponent {}
 class TargetModule {}
 
 describe('TestRoutingGuard:canActivate', () => {
-  // Because we want to test a canActive guard, it means that we want to
+  // Because we want to test a canActivate guard, it means that we want to
   // test its integration with RouterModule.
   // Therefore, RouterModule and the guard should be kept,
   // and the rest of the module which defines the route can be mocked.

--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -9,9 +9,10 @@ If you have not read ["How to test a route"](route.md), please do it first.
 To test a guard means that we need to mock everything except the guard and `RouterModule`.
 But, what if we have several guards? If we mocked them they would block routes due to falsy returns of their mocked methods.
 **To remove guards in Angular tests, `ng-mocks` provides the `NG_MOCKS_GUARDS` token**. We should pass it into `.exclude`, then all other guards will be
-excluded from `TestBed`, and we can be sure that we are **testing only the guard we want**.
+removed from the route configuration processed by `MockBuilder`, and we can be sure that we are **testing only the guard we want**.
 
-The example below is applicable for all types of guards:
+The same `MockBuilder` setup applies to all five guard properties, including class and token guards.
+The functional examples require Angular 14.2 or newer:
 
 - `canActivate` -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate),
@@ -28,7 +29,7 @@ The example below is applicable for all types of guards:
 - `canLoad` -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/can-load.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanLoad),
   [StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-load.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanLoad)
-- standalone applications (Angular 14+) -
+- standalone applications (Angular 14.2+) -
   [tested source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/standalone.spec.ts)
 - class guards (legacy) -
   [CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestRoutingGuard/test.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3Atest),
@@ -36,7 +37,7 @@ The example below is applicable for all types of guards:
 
 ## Functional Guards
 
-A functional guard is a simple function, and not a service or a token how it was before Angular 14.
+A functional guard is a function used directly in a route configuration. Angular 14.2 introduced the functional guard APIs.
 A guard resides in the configuration of routes,
 which is defined as an import of `RouterModule.forRoot` or `RouterModule.forChild` in a module.
 
@@ -108,9 +109,6 @@ if (fixture.ngZone) {
 }
 ```
 
-For lazy-route guards such as `canLoad` and `canMatch`, it is often more useful to call `router.navigateByUrl(...)`
-for the protected URL and assert its boolean result before checking the rendered route.
-
 Now, the location can be asserted.
 
 ```ts
@@ -119,6 +117,46 @@ expect(location.path()).toEqual('/login');
 
 
 Profit, [an example of a test for a functional guard](#live-example).
+
+Choose a navigation that actually invokes the guard under test:
+
+| Guard | Navigation to test | When the guard returns `false` |
+| --- | --- | --- |
+| `canActivate` | Enter the guarded route. | Navigation is cancelled. |
+| `canActivateChild` | Enter a child of the guarded route. | Navigation to the child is cancelled. |
+| `canDeactivate` | Enter the component's route first, then navigate away. | The current route and component remain active. |
+| `canMatch` | Navigate to a URL matching the guarded route. | Angular tries the next matching route; a fallback can still make navigation succeed. |
+| `canLoad` | Navigate to an unloaded route with `loadChildren`. | Navigation is cancelled and the lazy loader is not called. |
+
+A `false` result does not redirect by itself. The activation examples explicitly navigate to `/login`;
+the `canMatch` example reaches `/login` through its wildcard fallback.
+See Angular's [guard return types](https://angular.dev/guide/routing/route-guards#route-guard-return-types).
+
+### Testing lazy loading
+
+`canLoad` runs before loading a lazy module. Assert both the navigation result and whether the loader ran:
+
+```ts
+const loader = spyOn(router.config[1], 'loadChildren').and.callThrough();
+const result = await (fixture.ngZone
+  ? fixture.ngZone.run(() => router.navigateByUrl('/dashboard'))
+  : router.navigateByUrl('/dashboard'));
+await fixture.whenStable();
+
+expect(result).toEqual(false);
+expect(loader).not.toHaveBeenCalled();
+```
+
+Use a fresh test setup for the allowed case, then assert `true`, one loader call, and the dashboard component.
+Once Angular has loaded the module, subsequent navigation does not run `canLoad` again.
+The lazy module in the [canLoad example](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-load.spec.ts)
+is loaded as-is: its declarations belong to that module alone.
+`MockBuilder` does not execute `loadChildren` to discover and mock its returned module.
+To isolate routes inside a lazy module, pass that module to `MockBuilder` as the module under test.
+
+Angular [deprecates `canLoad` in favor of `canMatch`](https://angular.dev/api/router/CanLoad).
+`canMatch` also works on eager routes; its `false` result skips a route instead of cancelling the whole navigation.
+
 
 ## Functional Guards In Standalone Applications
 
@@ -143,7 +181,9 @@ bootstrapApplication(TargetComponent, {
 });
 ```
 
-The test can pass the same standalone router providers to `MockBuilder` without introducing an extra `NgModule`.
+The test can pass standalone router providers to `MockBuilder` without introducing an extra `NgModule`.
+Providers passed through `.provide(...)` are used as supplied. Include only the guards under test in those routes;
+`.exclude(NG_MOCKS_GUARDS)` does not filter a route configuration supplied directly through `.provide(...)`.
 
 ```ts
 beforeEach(() => {
@@ -185,7 +225,7 @@ The full runnable example is available in [the standalone routing guard example]
 
 ## Class Guards (legacy)
 
-If your code has guards which a classes and angular services,
+If your guards are classes provided as Angular services,
 the process is exactly the same as for [functional guards](#functional-guards).
 
 For example, if the class of the guard is called `LoginGuard`,
@@ -217,7 +257,11 @@ beforeEach(() =>
 );
 ```
 
-Profit.
+For a guard referenced by an injection token, keep the token used in the route, for example `.keep(LOGIN_GUARD)`.
+Calling `.mock(LoginGuard)` still creates a mock provider, but `.exclude(NG_MOCKS_GUARDS)` removes that mocked guard from routes.
+To retain a guard with a controlled implementation, use `.keep(LoginGuard)` and spy on its method. You can also pair `.keep(LoginGuard)` with `.provide(...)` to override its provider.
+The [class canLoad regression](https://github.com/help-me-mom/ng-mocks/blob/main/tests/issue-1008/test.spec.ts)
+checks both removal and a retained guard that blocks lazy loading.
 
 ## Live example
 
@@ -269,7 +313,9 @@ const canActivateGuard: CanActivateFn = (route, state) => {
 
 // Another guard like in a real world example.
 // The guard should be removed from testing to avoid side effects on the route.
-const sideEffectGuard: CanActivateFn = () => false;
+const sideEffectGuard: CanActivateFn = () => {
+  throw new Error('An excluded guard must not run');
+};
 
 // A simple component pretending a login form.
 // It will be replaced with a mock copy.
@@ -277,8 +323,7 @@ const sideEffectGuard: CanActivateFn = () => false;
   selector: 'login',
   template: 'login',
 })
-class LoginComponent {
-}
+class LoginComponent {}
 
 // A simple component pretending a protected dashboard.
 // It will be replaced with a mock copy.
@@ -286,8 +331,7 @@ class LoginComponent {
   selector: 'dashboard',
   template: 'dashboard',
 })
-class DashboardComponent {
-}
+class DashboardComponent {}
 
 // Definition of the routing module.
 @NgModule({
@@ -337,7 +381,6 @@ describe('TestRoutingGuard:canActivate', () => {
 
   // It is important to wait for routing to become stable.
   it('redirects to login', async () => {
-
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
     const location = ngMocks.get(Location);

--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -284,9 +284,9 @@ checks both removal and a retained guard that blocks lazy loading.
 - [Try it on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestRoutingGuard/can-activate.spec.ts&initialpath=%3Fspec%3DTestRoutingGuard%3AcanActivate)
 - [View the standalone example source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/standalone.spec.ts)
 
-:::note
-The components use `standalone: false` because they are declared in `TargetModule`.
-Keep this metadata when copying the example: Angular 19 and newer make components standalone by default.
+:::note Angular version
+This NgModule snippet uses Angular 14.2–18, where components belong to an NgModule by default.
+For standalone components, follow the [standalone guard setup](#functional-guards-in-standalone-applications).
 :::
 
 ```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-activate.spec.ts"
@@ -341,7 +341,6 @@ const sideEffectGuard: CanActivateFn = () => {
 // It will be replaced with a mock copy.
 @Component({
   selector: 'login',
-  standalone: false,
   template: 'login',
 })
 class LoginComponent {}
@@ -350,7 +349,6 @@ class LoginComponent {}
 // It will be replaced with a mock copy.
 @Component({
   selector: 'dashboard',
-  standalone: false,
   template: 'dashboard',
 })
 class DashboardComponent {}

--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -137,7 +137,8 @@ See Angular's [guard return types](https://angular.dev/guide/routing/route-guard
 ### Testing lazy loading
 
 `canLoad` runs before loading a lazy module. In the [canLoad example](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-load.spec.ts),
-the setup keeps `canLoadGuard` and the mocked `LoginService` starts with `isLoggedIn = false`.
+the setup keeps `canLoadGuard`. The test leaves the mocked `LoginService.isLoggedIn` unset,
+so the guard treats the user as logged out. Mock services do not run the original constructor or field initializers.
 Render the outlet, spy on the second route's lazy loader, and assert both navigation and loading:
 
 ```ts
@@ -284,8 +285,8 @@ checks both removal and a retained guard that blocks lazy loading.
 - [View the standalone example source](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/standalone.spec.ts)
 
 :::note
-The snippet omits compatibility metadata. In Angular 19 and newer, add `standalone: false` to both component decorators
-because these components are declared in `TargetModule`. The executable source includes this metadata.
+The components use `standalone: false` because they are declared in `TargetModule`.
+Keep this metadata when copying the example: Angular 19 and newer make components standalone by default.
 :::
 
 ```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestRoutingGuard/can-activate.spec.ts"
@@ -340,6 +341,7 @@ const sideEffectGuard: CanActivateFn = () => {
 // It will be replaced with a mock copy.
 @Component({
   selector: 'login',
+  standalone: false,
   template: 'login',
 })
 class LoginComponent {}
@@ -348,6 +350,7 @@ class LoginComponent {}
 // It will be replaced with a mock copy.
 @Component({
   selector: 'dashboard',
+  standalone: false,
   template: 'dashboard',
 })
 class DashboardComponent {}

--- a/docs/articles/guides/routing-guard.md
+++ b/docs/articles/guides/routing-guard.md
@@ -321,6 +321,7 @@ const sideEffectGuard: CanActivateFn = () => {
 // It will be replaced with a mock copy.
 @Component({
   selector: 'login',
+  standalone: false,
   template: 'login',
 })
 class LoginComponent {}
@@ -329,6 +330,7 @@ class LoginComponent {}
 // It will be replaced with a mock copy.
 @Component({
   selector: 'dashboard',
+  standalone: false,
   template: 'dashboard',
 })
 class DashboardComponent {}

--- a/examples/TestRoutingGuard/can-activate-child.spec.ts
+++ b/examples/TestRoutingGuard/can-activate-child.spec.ts
@@ -4,7 +4,6 @@ import {
   inject,
   Injectable,
   NgModule,
-  VERSION,
 } from '@angular/core';
 import {
   CanActivateChildFn,
@@ -42,7 +41,9 @@ const canActivateChildGuard: CanActivateChildFn = (route, state) => {
 
 // Another guard like in a real world example.
 // The guard should be removed from testing to avoid side effects on the route.
-const sideEffectGuard: CanActivateChildFn = () => false;
+const sideEffectGuard: CanActivateChildFn = () => {
+  throw new Error('An excluded guard must not run');
+};
 
 // A simple component pretending a login form.
 // It will be replaced with a mock copy.
@@ -103,7 +104,7 @@ describe('TestRoutingGuard:canActivateChild', () => {
   // The module with routes and the guard should be specified
   // as the second parameter of MockBuilder.
   // Then `NG_MOCKS_GUARDS` should be excluded to remove all guards,
-  // and `canActivateGuard` should be kept to let you test it.
+  // and `canActivateChildGuard` should be kept to let you test it.
   beforeEach(() => {
     return MockBuilder(
       [
@@ -119,12 +120,6 @@ describe('TestRoutingGuard:canActivateChild', () => {
 
   // It is important to wait for routing to become stable.
   it('redirects to login', async () => {
-    if (Number.parseInt(VERSION.major, 10) < 7) {
-      pending('Need Angular 7+'); // TODO pending
-
-      return;
-    }
-
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
     const location = ngMocks.get(Location);

--- a/examples/TestRoutingGuard/can-activate.spec.ts
+++ b/examples/TestRoutingGuard/can-activate.spec.ts
@@ -4,7 +4,6 @@ import {
   inject,
   Injectable,
   NgModule,
-  VERSION,
 } from '@angular/core';
 import {
   CanActivateFn,
@@ -42,7 +41,9 @@ const canActivateGuard: CanActivateFn = (route, state) => {
 
 // Another guard like in a real world example.
 // The guard should be removed from testing to avoid side effects on the route.
-const sideEffectGuard: CanActivateFn = () => false;
+const sideEffectGuard: CanActivateFn = () => {
+  throw new Error('An excluded guard must not run');
+};
 
 // A simple component pretending a login form.
 // It will be replaced with a mock copy.
@@ -114,12 +115,6 @@ describe('TestRoutingGuard:canActivate', () => {
 
   // It is important to wait for routing to become stable.
   it('redirects to login', async () => {
-    if (Number.parseInt(VERSION.major, 10) < 7) {
-      pending('Need Angular 7+'); // TODO pending
-
-      return;
-    }
-
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
     const location = ngMocks.get(Location);

--- a/examples/TestRoutingGuard/can-deactivate.spec.ts
+++ b/examples/TestRoutingGuard/can-deactivate.spec.ts
@@ -4,7 +4,6 @@ import {
   inject,
   Injectable,
   NgModule,
-  VERSION,
 } from '@angular/core';
 import {
   CanDeactivateFn,
@@ -31,19 +30,21 @@ class LoginService {
 
 // A guard we want to test.
 const canDeactivateGuard: CanDeactivateFn<LoginComponent> = (
-  route,
-  state,
+  component,
+  currentRoute,
 ) => {
   return (
-    (route && state && inject(LoginService).isLoggedIn) ||
-    state.url.length === 0 ||
-    state.url[0].path !== 'login'
+    (component && currentRoute && inject(LoginService).isLoggedIn) ||
+    currentRoute.url.length === 0 ||
+    currentRoute.url[0].path !== 'login'
   );
 };
 
 // Another guard like in a real world example,
 // which should be removed from testing to avoid side effects on the route.
-const sideEffectGuard: CanDeactivateFn<LoginComponent> = () => false;
+const sideEffectGuard: CanDeactivateFn<LoginComponent> = () => {
+  throw new Error('An excluded guard must not run');
+};
 
 // A simple component pretending a login form.
 // It will be replaced with a mock copy.
@@ -99,7 +100,7 @@ describe('TestRoutingGuard:canDeactivate', () => {
   // The module with routes and the guard should be specified
   // as the second parameter of MockBuilder.
   // Then `NG_MOCKS_GUARDS` should be excluded to remove all guards,
-  // and `canActivateGuard` should be kept to let you test it.
+  // and `canDeactivateGuard` should be kept to let you test it.
   beforeEach(() => {
     return MockBuilder(
       [
@@ -115,12 +116,6 @@ describe('TestRoutingGuard:canDeactivate', () => {
 
   // It is important to wait for routing to become stable.
   it('cannot leave login', async () => {
-    if (Number.parseInt(VERSION.major, 10) < 7) {
-      pending('Need Angular 7+'); // TODO pending
-
-      return;
-    }
-
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
     const location = ngMocks.get(Location);
@@ -140,9 +135,14 @@ describe('TestRoutingGuard:canDeactivate', () => {
 
     // Trying to leave /login page.
     if (fixture.ngZone) {
-      fixture.ngZone.run(() => router.navigate(['/dashboard']));
+      const result = await fixture.ngZone.run(() =>
+        router.navigate(['/dashboard']),
+      );
       await fixture.whenStable();
+      expect(result).toEqual(false);
     }
+
+    expect(ngMocks.find(DashboardComponent, null)).toBeNull();
 
     // We are still at /login page due to the guard.
     expect(location.path()).toEqual('/login');

--- a/examples/TestRoutingGuard/can-load.spec.ts
+++ b/examples/TestRoutingGuard/can-load.spec.ts
@@ -4,7 +4,6 @@ import {
   inject,
   Injectable,
   NgModule,
-  VERSION,
 } from '@angular/core';
 import {
   CanLoadFn,
@@ -23,7 +22,7 @@ import {
 } from 'ng-mocks';
 
 // A simple service simulating login check.
-// It will be replaced with it's mock copy.
+// It will be replaced with its mock copy.
 @Injectable()
 class LoginService {
   public isLoggedIn = false;
@@ -36,7 +35,9 @@ const canLoadGuard: CanLoadFn = (route, segments) => {
 
 // Another canLoad guard like in a real world example,
 // which should be removed from testing to avoid side effects on the route.
-const sideEffectCanLoadGuard: CanLoadFn = () => false;
+const sideEffectCanLoadGuard: CanLoadFn = () => {
+  throw new Error('An excluded guard must not run');
+};
 
 // A simple component pretending to be a login form.
 // It will be replaced with a mock copy.
@@ -45,16 +46,20 @@ const sideEffectCanLoadGuard: CanLoadFn = () => false;
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: 'login',
 })
-class LoginComponent {}
+class LoginComponent {
+  public loginTestRoutingGuardCanLoad() {}
+}
 
 // A simple component pretending to be a protected dashboard.
-// It will be replaced with a mock copy.
+// Angular loads it from the lazy module.
 @Component({
   selector: 'dashboard',
   ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
   template: 'dashboard',
 })
-class DashboardComponent {}
+class DashboardComponent {
+  public dashboardTestRoutingGuardCanLoad() {}
+}
 
 @NgModule({
   declarations: [DashboardComponent],
@@ -70,13 +75,14 @@ class DashboardComponent {}
       },
     ]),
   ],
-  exports: [],
 })
 class DashboardModule {}
 
+// The lazy module is loaded as-is by Angular. Its component is declared only
+// in DashboardModule; it is not part of the mocked root module.
 // Definition of the routing module.
 @NgModule({
-  declarations: [LoginComponent, DashboardComponent],
+  declarations: [LoginComponent],
   exports: [RouterModule],
   imports: [
     RouterModule.forRoot([
@@ -97,7 +103,7 @@ class TargetModule {}
 
 describe('TestRoutingGuard:canLoad', () => {
   // Because we want to test a canLoad guard, it means that we want to
-  // test it's integration with RouterModule.
+  // test its integration with RouterModule.
   // Therefore, RouterModule and guard should be kept,
   // and the rest of the module which defines the route can be mocked.
   // To configure the RouterModule for the test,
@@ -121,14 +127,12 @@ describe('TestRoutingGuard:canLoad', () => {
   });
 
   it('blocks dashboard and opens login', async () => {
-    if (Number.parseInt(VERSION.major, 10) < 7) {
-      pending('Need Angular  7+'); // TODO pending
-
-      return;
-    }
-
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
+    const loader = spyOn(
+      router.config[1],
+      'loadChildren',
+    ).and.callThrough();
     const location = ngMocks.get(Location);
 
     // First we need to initialize navigation.
@@ -140,6 +144,8 @@ describe('TestRoutingGuard:canLoad', () => {
       await fixture.whenStable();
 
       expect(result).toEqual(false);
+      expect(loader).not.toHaveBeenCalled();
+      expect(router.url).toEqual('/');
 
       await fixture.ngZone.run(() => router.navigateByUrl('/login'));
       await fixture.whenStable();
@@ -155,6 +161,10 @@ describe('TestRoutingGuard:canLoad', () => {
   it('loads dashboard', async () => {
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
+    const loader = spyOn(
+      router.config[1],
+      'loadChildren',
+    ).and.callThrough();
     const location = ngMocks.get(Location);
     const loginService = ngMocks.get(LoginService);
 
@@ -170,6 +180,7 @@ describe('TestRoutingGuard:canLoad', () => {
       await fixture.whenStable();
 
       expect(result).toEqual(true);
+      expect(loader).toHaveBeenCalledTimes(1);
     }
 
     // Because now we are logged in, the guard should let us land on

--- a/examples/TestRoutingGuard/can-load.spec.ts
+++ b/examples/TestRoutingGuard/can-load.spec.ts
@@ -129,10 +129,10 @@ describe('TestRoutingGuard:canLoad', () => {
   it('blocks dashboard and opens login', async () => {
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
-    const loader = spyOn(
-      router.config[1],
-      'loadChildren',
-    ).and.callThrough();
+    const loader =
+      typeof jest === 'undefined'
+        ? spyOn(router.config[1], 'loadChildren').and.callThrough()
+        : jest.spyOn(router.config[1], 'loadChildren');
     const location = ngMocks.get(Location);
 
     // First we need to initialize navigation.
@@ -161,10 +161,10 @@ describe('TestRoutingGuard:canLoad', () => {
   it('loads dashboard', async () => {
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
-    const loader = spyOn(
-      router.config[1],
-      'loadChildren',
-    ).and.callThrough();
+    const loader =
+      typeof jest === 'undefined'
+        ? spyOn(router.config[1], 'loadChildren').and.callThrough()
+        : jest.spyOn(router.config[1], 'loadChildren');
     const location = ngMocks.get(Location);
     const loginService = ngMocks.get(LoginService);
 

--- a/examples/TestRoutingGuard/can-match.spec.ts
+++ b/examples/TestRoutingGuard/can-match.spec.ts
@@ -4,7 +4,6 @@ import {
   inject,
   Injectable,
   NgModule,
-  VERSION,
 } from '@angular/core';
 import {
   CanMatchFn,
@@ -36,7 +35,9 @@ const canMatchGuard: CanMatchFn = (route, segments) => {
 
 // Another guard like in a real world example,
 // which should be removed from testing to avoid side effects on the route.
-const sideEffectGuard: CanMatchFn = () => false;
+const sideEffectGuard: CanMatchFn = () => {
+  throw new Error('An excluded guard must not run');
+};
 
 // A simple component pretending a login form.
 // It will be replaced with a mock copy.
@@ -96,7 +97,7 @@ describe('TestRoutingGuard:canMatch', () => {
   // The module with routes and the guard should be specified
   // as the second parameter of MockBuilder.
   // Then `NG_MOCKS_GUARDS` should be excluded to remove all guards,
-  // and `canActivateGuard` should be kept to let you test it.
+  // and `canMatchGuard` should be kept to let you test it.
   beforeEach(() => {
     return MockBuilder(
       [
@@ -112,28 +113,23 @@ describe('TestRoutingGuard:canMatch', () => {
 
   // It is important to wait for routing to become stable.
   it('redirects to login', async () => {
-    if (Number.parseInt(VERSION.major, 10) < 7) {
-      pending('Need Angular 7+'); // TODO pending
-
-      return;
-    }
-
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
     const location = ngMocks.get(Location);
 
     // First we need to initialize navigation.
     if (fixture.ngZone) {
-      await fixture.ngZone.run(() =>
+      const result = await fixture.ngZone.run(() =>
         router.navigateByUrl('/dashboard'),
       );
+      expect(result).toEqual(true);
       await fixture.whenStable(); // is needed for rendering of the current route.
     }
 
-    // Because by default we are not logged, the guard should
-    // redirect us /login page.
+    // Returning false skips the guarded route. The wildcard route redirects to login.
     expect(location.path()).toEqual('/login');
     expect(() => ngMocks.find(LoginComponent)).not.toThrow();
+    expect(ngMocks.find(DashboardComponent, null)).toBeNull();
   });
 
   it('loads dashboard', async () => {
@@ -147,9 +143,10 @@ describe('TestRoutingGuard:canMatch', () => {
 
     // First we need to initialize navigation.
     if (fixture.ngZone) {
-      await fixture.ngZone.run(() =>
+      const result = await fixture.ngZone.run(() =>
         router.navigateByUrl('/dashboard'),
       );
+      expect(result).toEqual(true);
       await fixture.whenStable(); // is needed for rendering of the current route.
     }
 

--- a/examples/TestRoutingGuard/can-match.spec.ts
+++ b/examples/TestRoutingGuard/can-match.spec.ts
@@ -143,10 +143,9 @@ describe('TestRoutingGuard:canMatch', () => {
 
     // First we need to initialize navigation.
     if (fixture.ngZone) {
-      const result = await fixture.ngZone.run(() =>
+      await fixture.ngZone.run(() =>
         router.navigateByUrl('/dashboard'),
       );
-      expect(result).toEqual(true);
       await fixture.whenStable(); // is needed for rendering of the current route.
     }
 

--- a/libs/ng-mocks/src/lib/mock-service/guards.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/guards.spec.ts
@@ -1,0 +1,164 @@
+import { Injectable, InjectionToken, NgModule } from '@angular/core';
+
+import { NG_MOCKS_GUARDS } from '../common/core.tokens';
+import { MockBuilder } from '../mock-builder/mock-builder';
+import { ngMocks } from '../mock-helper/mock-helper';
+
+@Injectable()
+class ClassGuard {
+  public canActivate() {
+    return true;
+  }
+}
+
+const functionGuard = () => true;
+const tokenGuard = new InjectionToken('tokenGuard');
+const routesToken = new InjectionToken<any>('routes');
+
+for (const guard of [
+  'canActivate',
+  'canActivateChild',
+  'canDeactivate',
+  'canLoad',
+  'canMatch',
+]) {
+  describe(`NG_MOCKS_GUARDS:${guard}`, () => {
+    const guards = [ClassGuard, functionGuard, tokenGuard];
+    const routes = [
+      {
+        path: 'parent',
+        children: [{ path: 'child', [guard]: guards }],
+      },
+    ];
+
+    @NgModule({
+      providers: [
+        ClassGuard,
+        { provide: tokenGuard, useValue: () => true },
+        { provide: routesToken, useValue: routes },
+      ],
+    })
+    class TargetModule {}
+
+    it('preserves guards by default without changing the original routes', async () => {
+      await MockBuilder().mock(TargetModule).keep(routesToken);
+
+      expect(ngMocks.get(routesToken)).toEqual(routes);
+      expect(routes[0].children[0][guard]).toEqual([
+        ClassGuard,
+        functionGuard,
+        tokenGuard,
+      ]);
+    });
+
+    it('removes all guards from nested routes without changing the original routes', async () => {
+      await MockBuilder()
+        .mock(TargetModule)
+        .keep(routesToken)
+        .exclude(NG_MOCKS_GUARDS);
+
+      expect(ngMocks.get(routesToken)).toEqual([
+        {
+          path: 'parent',
+          children: [{ path: 'child', [guard]: [] }],
+        },
+      ]);
+      expect(routes[0].children[0][guard]).toEqual([
+        ClassGuard,
+        functionGuard,
+        tokenGuard,
+      ]);
+    });
+
+    for (const keptGuard of guards) {
+      it(`keeps the selected ${keptGuard === ClassGuard ? 'class' : keptGuard === functionGuard ? 'function' : 'token'} guard`, async () => {
+        await MockBuilder()
+          .mock(TargetModule)
+          .keep(routesToken)
+          .exclude(NG_MOCKS_GUARDS)
+          .keep(keptGuard);
+
+        expect(ngMocks.get(routesToken)).toEqual([
+          {
+            path: 'parent',
+            children: [{ path: 'child', [guard]: [keptGuard] }],
+          },
+        ]);
+        expect(routes[0].children[0][guard]).toEqual([
+          ClassGuard,
+          functionGuard,
+          tokenGuard,
+        ]);
+      });
+    }
+
+    it('removes a mocked guard from routes while preserving its mock provider', async () => {
+      const mockGuard = { canActivate: () => false };
+      await MockBuilder()
+        .mock(TargetModule)
+        .keep(routesToken)
+        .exclude(NG_MOCKS_GUARDS)
+        .mock(ClassGuard, mockGuard);
+
+      expect(ngMocks.get(routesToken)).toEqual([
+        {
+          path: 'parent',
+          children: [{ path: 'child', [guard]: [] }],
+        },
+      ]);
+      expect(ngMocks.get(ClassGuard).canActivate()).toEqual(false);
+    });
+
+    it('uses directly provided routes as supplied', async () => {
+      await MockBuilder()
+        .exclude(NG_MOCKS_GUARDS)
+        .provide({ provide: routesToken, useValue: routes });
+
+      expect(ngMocks.get(routesToken)).toBe(routes);
+      expect(ngMocks.get(routesToken)[0].children[0][guard]).toEqual([
+        ClassGuard,
+        functionGuard,
+        tokenGuard,
+      ]);
+    });
+
+    it('uses an explicit provider for a kept guard', async () => {
+      const providedGuard = { canActivate: () => false };
+      await MockBuilder()
+        .mock(TargetModule)
+        .keep(routesToken)
+        .exclude(NG_MOCKS_GUARDS)
+        .keep(ClassGuard)
+        .provide({ provide: ClassGuard, useValue: providedGuard });
+
+      expect(ngMocks.get(routesToken)).toEqual([
+        {
+          path: 'parent',
+          children: [{ path: 'child', [guard]: [ClassGuard] }],
+        },
+      ]);
+      expect(ngMocks.get(ClassGuard)).toBe(providedGuard);
+    });
+
+    it('removes an individually excluded guard without removing other guards', async () => {
+      await MockBuilder()
+        .mock(TargetModule)
+        .keep(routesToken)
+        .exclude(tokenGuard);
+
+      expect(ngMocks.get(routesToken)).toEqual([
+        {
+          path: 'parent',
+          children: [
+            { path: 'child', [guard]: [ClassGuard, functionGuard] },
+          ],
+        },
+      ]);
+      expect(routes[0].children[0][guard]).toEqual([
+        ClassGuard,
+        functionGuard,
+        tokenGuard,
+      ]);
+    });
+  });
+}

--- a/tests/issue-1008/test.spec.ts
+++ b/tests/issue-1008/test.spec.ts
@@ -71,7 +71,13 @@ describe('issue-1008', () => {
     const loader =
       typeof jest === 'undefined'
         ? spyOn(router.config[0], 'loadChildren').and.callThrough()
-        : jest.spyOn(router.config[0], 'loadChildren');
+        : jest.spyOn(
+            // Older Angular versions also allow legacy string loaders.
+            router.config[0] as {
+              loadChildren: () => Promise<typeof LazyModule>;
+            },
+            'loadChildren',
+          );
 
     expect(router.config[0].canLoad).toEqual([]);
     const result = await (fixture.ngZone
@@ -105,7 +111,13 @@ describe('issue-1008', () => {
     const loader =
       typeof jest === 'undefined'
         ? spyOn(router.config[0], 'loadChildren').and.callThrough()
-        : jest.spyOn(router.config[0], 'loadChildren');
+        : jest.spyOn(
+            // Older Angular versions also allow legacy string loaders.
+            router.config[0] as {
+              loadChildren: () => Promise<typeof LazyModule>;
+            },
+            'loadChildren',
+          );
 
     const guard =
       typeof jest === 'undefined'

--- a/tests/issue-1008/test.spec.ts
+++ b/tests/issue-1008/test.spec.ts
@@ -68,10 +68,10 @@ describe('issue-1008', () => {
 
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
-    const loader = spyOn(
-      router.config[0],
-      'loadChildren',
-    ).and.callThrough();
+    const loader =
+      typeof jest === 'undefined'
+        ? spyOn(router.config[0], 'loadChildren').and.callThrough()
+        : jest.spyOn(router.config[0], 'loadChildren');
 
     expect(router.config[0].canLoad).toEqual([]);
     const result = await (fixture.ngZone
@@ -102,15 +102,20 @@ describe('issue-1008', () => {
 
     const fixture = MockRender(RouterOutlet, {});
     const router = ngMocks.get(Router);
-    const loader = spyOn(
-      router.config[0],
-      'loadChildren',
-    ).and.callThrough();
+    const loader =
+      typeof jest === 'undefined'
+        ? spyOn(router.config[0], 'loadChildren').and.callThrough()
+        : jest.spyOn(router.config[0], 'loadChildren');
 
-    const guard = spyOn(
-      ngMocks.get(Issue1008Guard),
-      'canLoad',
-    ).and.returnValue(false);
+    const guard =
+      typeof jest === 'undefined'
+        ? spyOn(
+            ngMocks.get(Issue1008Guard),
+            'canLoad',
+          ).and.returnValue(false)
+        : jest
+            .spyOn(ngMocks.get(Issue1008Guard), 'canLoad')
+            .mockReturnValue(false);
 
     expect(router.config[0].canLoad).toEqual([Issue1008Guard]);
     const result = await (fixture.ngZone

--- a/tests/issue-1008/test.spec.ts
+++ b/tests/issue-1008/test.spec.ts
@@ -1,0 +1,126 @@
+import { Location } from '@angular/common';
+import { Component, Injectable, NgModule } from '@angular/core';
+import {
+  CanLoad,
+  Router,
+  RouterModule,
+  RouterOutlet,
+} from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import {
+  MockBuilder,
+  MockRender,
+  NG_MOCKS_GUARDS,
+  NG_MOCKS_ROOT_PROVIDERS,
+  ngMocks,
+} from 'ng-mocks';
+
+@Injectable()
+class Issue1008Guard implements CanLoad {
+  public canLoad(): boolean {
+    throw new Error('The excluded canLoad guard must not run');
+  }
+}
+
+@Component({
+  selector: 'issue-1008-lazy',
+  ['standalone' as never]: false,
+  template: 'lazy destination',
+})
+class LazyComponent {}
+
+@NgModule({
+  declarations: [LazyComponent],
+  imports: [
+    RouterModule.forChild([{ path: '', component: LazyComponent }]),
+  ],
+})
+class LazyModule {}
+
+@NgModule({
+  imports: [
+    RouterModule.forRoot([
+      {
+        path: 'lazy',
+        canLoad: [Issue1008Guard],
+        loadChildren: () => Promise.resolve(LazyModule),
+      },
+    ]),
+  ],
+  providers: [Issue1008Guard],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/1008
+// Mocking a class guard leaves its method returning undefined. Excluding guards
+// must remove canLoad from the route before Angular attempts to load its module.
+describe('issue-1008', () => {
+  it('loads a lazy module without calling its excluded class guard', async () => {
+    await MockBuilder(
+      [
+        RouterModule,
+        RouterTestingModule.withRoutes([]),
+        NG_MOCKS_ROOT_PROVIDERS,
+      ],
+      TargetModule,
+    ).exclude(NG_MOCKS_GUARDS);
+
+    const fixture = MockRender(RouterOutlet, {});
+    const router = ngMocks.get(Router);
+    const loader = spyOn(
+      router.config[0],
+      'loadChildren',
+    ).and.callThrough();
+
+    expect(router.config[0].canLoad).toEqual([]);
+    const result = await (fixture.ngZone
+      ? fixture.ngZone.run(() => router.navigateByUrl('/lazy'))
+      : router.navigateByUrl('/lazy'));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(result).toEqual(true);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(ngMocks.get(Location).path()).toEqual('/lazy');
+    expect(
+      ngMocks.find(LazyComponent).nativeElement.textContent,
+    ).toEqual('lazy destination');
+  });
+
+  it('keeps a selected class guard and prevents lazy loading when it rejects navigation', async () => {
+    await MockBuilder(
+      [
+        RouterModule,
+        RouterTestingModule.withRoutes([]),
+        NG_MOCKS_ROOT_PROVIDERS,
+      ],
+      TargetModule,
+    )
+      .exclude(NG_MOCKS_GUARDS)
+      .keep(Issue1008Guard);
+
+    const fixture = MockRender(RouterOutlet, {});
+    const router = ngMocks.get(Router);
+    const loader = spyOn(
+      router.config[0],
+      'loadChildren',
+    ).and.callThrough();
+
+    const guard = spyOn(
+      ngMocks.get(Issue1008Guard),
+      'canLoad',
+    ).and.returnValue(false);
+
+    expect(router.config[0].canLoad).toEqual([Issue1008Guard]);
+    const result = await (fixture.ngZone
+      ? fixture.ngZone.run(() => router.navigateByUrl('/lazy'))
+      : router.navigateByUrl('/lazy'));
+    await fixture.whenStable();
+
+    expect(result).toEqual(false);
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(loader).not.toHaveBeenCalled();
+    expect(ngMocks.find(LazyComponent, null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

#1008 asks whether all routing guard variants are covered, including the class-based `canLoad` guard from the original report. The implementation already handles all five guard properties, but core guard-filtering assertions covered only `canActivate`. The examples and guide also left the differences between cancellation, route matching, and lazy loading unclear.

## What

- Cover each guard property with class, function, and injection-token references, including nested routes, selective keeping and exclusion, provider overrides, directly supplied routes, and preservation of the original configuration.
- Add the original class-based `canLoad` scenario under `tests/issue-1008`, checking successful lazy loading after guard exclusion and suppression of the loader when a retained guard rejects navigation.
- Strengthen the existing functional examples with guards that fail if unexpectedly executed, navigation-result assertions, and lazy-loader assertions using the appropriate runner spy API. Correct the lazy module's component ownership and remove obsolete version checks already handled by the spread configuration.
- Explain each guard's navigation behavior, the functional API version boundary, guard/provider selection, standalone provider handling, and lazy-module testing in the guide and `MockBuilder` token reference. Align the snippets with the executable examples, include router root providers in the API setup, identify the Angular versions used by the simplified NgModule snippet, and describe the mocked service's initial state accurately.

## Impact

All five guard variants have explicit coverage and corresponding testing guidance. The existing runtime implementation already supports these cases, so this change completes tests and documentation without changing the published runtime behavior.

Closes #1008
