### PR TITLE
fix(core): removing eval

### DIFF
--- a/libs/ng-mocks/src/lib/common/core.helpers.spec.ts
+++ b/libs/ng-mocks/src/lib/common/core.helpers.spec.ts
@@ -1,5 +1,91 @@
-import { extendClass, extractDependency } from './core.helpers';
+import {
+  extendClass,
+  extendClassicClass,
+  extractDependency,
+} from './core.helpers';
 import decorateMock from './decorate.mock';
+import funcGetGlobal from './func.get-global';
+
+describe('extendClassicClass', () => {
+  it('preserves custom constructor stringification and its receiver', () => {
+    const calls: any[] = [];
+    class Base {
+      public static toString() {
+        calls.push(this);
+        return 'custom constructor';
+      }
+    }
+
+    const Child = extendClassicClass(Base);
+
+    expect(Child.toString()).toBe('custom constructor');
+    expect(calls).toEqual([Child]);
+  });
+
+  it('constructs subclasses when Proxy is unavailable', () => {
+    const glb = funcGetGlobal();
+    const originalProxy = glb.Proxy;
+    class Base {
+      public constructor(public value: string) {}
+    }
+
+    try {
+      glb.Proxy = undefined;
+      const Child = extendClassicClass(Base);
+      class Grandchild extends Child {}
+      const instance = new Grandchild('value');
+
+      expect(instance.value).toBe('value');
+      expect(instance instanceof Grandchild).toBe(true);
+      expect(instance instanceof Child).toBe(true);
+      expect(instance instanceof Base).toBe(true);
+      expect(instance.constructor).toBe(Grandchild);
+    } finally {
+      glb.Proxy = originalProxy;
+    }
+  });
+
+  it('constructs subclasses when Reflect is unavailable', () => {
+    const glb = funcGetGlobal();
+    const originalReflect = glb.Reflect;
+    class Base {
+      public constructor(public value: string) {}
+    }
+
+    try {
+      glb.Reflect = undefined;
+      const Child = extendClassicClass(Base);
+      const instance = new Child('value');
+
+      expect(instance.value).toBe('value');
+      expect(instance instanceof Child).toBe(true);
+      expect(instance instanceof Base).toBe(true);
+      expect(instance.constructor).toBe(Child);
+    } finally {
+      glb.Reflect = originalReflect;
+    }
+  });
+
+  it('constructs subclasses when Reflect.construct is unavailable', () => {
+    const originalConstruct = Reflect.construct;
+    class Base {
+      public constructor(public value: string) {}
+    }
+
+    try {
+      Reflect.construct = undefined as never;
+      const Child = extendClassicClass(Base);
+      const instance = new Child('value');
+
+      expect(instance.value).toBe('value');
+      expect(instance instanceof Child).toBe(true);
+      expect(instance instanceof Base).toBe(true);
+      expect(instance.constructor).toBe(Child);
+    } finally {
+      Reflect.construct = originalConstruct;
+    }
+  });
+});
 
 describe('DebuggableMock', () => {
   it('prefixes the class name with MockOf', () => {

--- a/libs/ng-mocks/src/lib/common/core.helpers.ts
+++ b/libs/ng-mocks/src/lib/common/core.helpers.ts
@@ -3,7 +3,6 @@ import { getTestBed } from '@angular/core/testing';
 import coreDefineProperty from './core.define-property';
 import coreReflectParametersResolve from './core.reflect.parameters-resolve';
 import { AnyDeclaration, AnyType, Type } from './core.types';
-import funcGetGlobal from './func.get-global';
 import funcGetName from './func.get-name';
 import ngMocksUniverse from './ng-mocks-universe';
 
@@ -114,28 +113,30 @@ export const extractDependency = (deps: any[], set?: Set<any>): void => {
 };
 
 export const extendClassicClass = <I>(base: AnyType<I>): Type<I> => {
-  let child: any;
   const index = ngMocksUniverse.index();
+  const construct = typeof Reflect !== 'undefined' && typeof Reflect.construct === 'function' && Reflect.construct;
 
-  const glb = funcGetGlobal();
-  glb.ngMocksParent = base;
+  class MockMiddleware extends (base as any) {
+    public constructor(...args: any[]) {
+      // The ES5 bundle must construct native Angular classes instead of calling apply.
+      if (construct) {
+        return construct(base, args, new.target);
+      }
+      super(...args);
+    }
+  }
 
-  // First we try to eval es2015 style and if it fails to use es5 transpilation in the catch block.
-  // The next step is to respect constructor parameters as the parent class via jitReflector.
-  // istanbul ignore next
-  try {
-    eval(`
-      var glb = typeof window === 'undefined' ? global : window;
-      class MockMiddleware${index} extends glb.ngMocksParent {};
-      glb.ngMocksResult = MockMiddleware${index};
-    `);
-    child = glb.ngMocksResult;
-  } catch {
-    class MockMiddleware extends glb.ngMocksParent {}
-    child = MockMiddleware;
-  } finally {
-    glb.ngMocksResult = undefined;
-    glb.ngMocksParent = undefined;
+  let child: any = MockMiddleware;
+  if (construct && typeof Proxy === 'function') {
+    // ES5 lowers new.target to this.constructor, which a derived prototype can override.
+    child = new Proxy(MockMiddleware, {
+      construct: (_target, args, newTarget) => construct(base, args, newTarget),
+    });
+    coreDefineProperty(child.prototype, 'constructor', child);
+    // Angular 5 reads toString, but Node 8 cannot stringify a callable Proxy.
+    if (MockMiddleware.toString === Function.prototype.toString) {
+      coreDefineProperty(child, 'toString', MockMiddleware.toString.bind(MockMiddleware));
+    }
   }
 
   // A16: adding unique property.


### PR DESCRIPTION
## Why

The ES5 package must extend native ES2015 Angular classes without calling their constructors as ordinary functions. The existing workaround evaluates a generated subclass. An eval failure falls back to ES5 inheritance and can produce `Class constructor CommonModule cannot be invoked without 'new'`, as seen with Happy DOM.

## What

Use `Reflect.construct` to invoke the parent constructor and preserve the instance prototype. A guarded construct trap preserves native `new.target` when consuming the ES5 bundle, and ordinary inheritance remains available when Reflect construction is absent. Preserve constructor stringification for Angular's reflection on Node 8, while retaining custom stringification methods.

Remove the evaluated declarations and temporary global properties. Add helper behavior specs for custom constructor stringification and construction when Proxy, Reflect, or Reflect.construct is unavailable.

## Impact

The constructor helper no longer requires eval. The change remains internal; public API documentation is unchanged.

Related to #158 and #5465.