### PR TITLE
chore(package): limit description to 255 characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@
 - Do not claim support beyond those tables unless you update the tables and the implementation together.
 - When enabling new recommended lint rules, keep fixes that remain compatible with the supported Angular, Node.js, and ES targets. Disable rules that require newer framework APIs or runtime features, and leave a short reason beside the override.
 
+## Package Metadata
+
+- Keep the `description` value in `libs/ng-mocks/package.json` at 255 characters or fewer, including spaces and
+  punctuation. Preserve this limit whenever updating the description.
+- List Angular major versions individually in the description for search visibility; do not compress them into
+  ranges. If space is needed, omit older versions from the description without changing the documented support.
+
 ## Spec and Documentation Examples
 
 ### Learn from existing examples

--- a/libs/ng-mocks/package.json
+++ b/libs/ng-mocks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng-mocks",
   "version": "0.0.0",
-  "description": "An Angular testing library for creating mock services, components, directives, pipes and modules in unit tests. It provides shallow rendering, precise stubs to fake child dependencies. ng-mocks works with Angular 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 using Jasmine or Jest, and with Angular 20 21 22 using the native Vitest runner.",
+  "description": "ng-mocks simplifies Angular testing with mock dependencies, shallow rendering and less boilerplate. Mock components, services, directives, pipes and modules in Angular 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 with Jasmine, Jest or Vitest.",
   "keywords": [
     "angular",
     "test",


### PR DESCRIPTION
## Why

The package description exceeds the 255-character limit. It needs to retain individually listed Angular major versions for search visibility while fitting that limit.

## What

Shorten the description to 246 characters, preserving the Angular version list and grouping the test runners as Jasmine, Jest or Vitest. Record the character limit and explicit-version guidance in AGENTS.md.

## Impact

This changes package metadata and agent guidance. Runtime behavior and documented compatibility remain unchanged. The `chore(package)` commit type does not trigger a release on its own; the updated description will ship with a later release.
