### PR TITLE
fix(MockRender): preserve middleware signal inputs #14839

### DIFF
--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.spec.ts
@@ -1,0 +1,184 @@
+import {
+  Component,
+  Directive,
+  Input,
+  input,
+  reflectComponentType,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import coreReflectDirectiveResolve from '../common/core.reflect.directive-resolve';
+
+import funcReflectTemplate from './func.reflect-template';
+
+describe('funcReflectTemplate', () => {
+  it('preserves signal inputs and ordinary input transforms on component clones', () => {
+    @Component({
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {
+      // Root tests transpile the fixture without Angular's signal transform.
+      @Input({ alias: 'publicValue', isSignal: true } as never)
+      public readonly value = input(0);
+
+      @Input({ alias: 'publicPlain', transform: String })
+      public plain = '';
+    }
+
+    const originalInputs =
+      reflectComponentType(TargetComponent)?.inputs;
+    const originalTemplateInputs = [
+      ...(coreReflectDirectiveResolve(TargetComponent).inputs || []),
+    ];
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.stub();
+
+    const template = funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    const inputs = reflectComponentType(child)?.inputs;
+    expect(inputs).toEqual(
+      jasmine.arrayContaining([
+        jasmine.objectContaining({
+          isSignal: true,
+          propName: 'value',
+          templateName: 'publicValue',
+        }),
+        jasmine.objectContaining({
+          isSignal: false,
+          propName: 'plain',
+          templateName: 'publicPlain',
+          transform: String,
+        }),
+      ]),
+    );
+    expect(inputs?.length).toEqual(2);
+    expect(reflectComponentType(TargetComponent)?.inputs).toEqual(
+      originalInputs,
+    );
+    expect(template.inputs?.length).toEqual(2);
+    expect(template.inputs).toEqual(originalTemplateInputs);
+    expect(
+      coreReflectDirectiveResolve(TargetComponent).inputs,
+    ).toEqual(originalTemplateInputs);
+    expect(
+      (TargetComponent as any).__prop__metadata__.value.length,
+    ).toEqual(1);
+    expect(
+      (TargetComponent as any).__prop__metadata__.plain.length,
+    ).toEqual(1);
+  });
+
+  it('preserves signal metadata from effective directive input overrides', () => {
+    @Directive({
+      selector: '[first],[second]',
+      standalone: false,
+    })
+    class TargetDirective {
+      @Input({ alias: 'publicValue', isSignal: true } as never)
+      public readonly value = input(0);
+    }
+
+    TestBed.configureTestingModule({});
+    spyOn((TestBed as any).ngMocksOverrides, 'get').and.returnValue({
+      override: {
+        set: {
+          inputs: [
+            {
+              alias: 'overrideValue',
+              isSignal: true,
+              name: 'value',
+              required: true,
+            },
+          ],
+        },
+      },
+    });
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.stub();
+
+    funcReflectTemplate(TargetDirective);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    expect(child.ɵdir.inputs.overrideValue[1]).toEqual(1);
+    expect(child.__prop__metadata__.value).toEqual([
+      jasmine.objectContaining({
+        alias: 'overrideValue',
+        isSignal: true,
+        required: true,
+      }),
+    ]);
+    expect((TargetDirective as any).__prop__metadata__.value).toEqual(
+      [
+        jasmine.objectContaining({
+          alias: 'publicValue',
+          isSignal: true,
+        }),
+      ],
+    );
+  });
+
+  it('preserves ordinary input alias precedence when a property is declared twice', () => {
+    @Component({
+      inputs: ['value:first', 'value:second'],
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {
+      public value = '';
+    }
+
+    const originalInputs =
+      reflectComponentType(TargetComponent)?.inputs;
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.stub();
+
+    funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    expect(reflectComponentType(child)?.inputs).toEqual(
+      originalInputs,
+    );
+    expect(originalInputs).toEqual([
+      jasmine.objectContaining({
+        propName: 'value',
+        templateName: 'second',
+      }),
+    ]);
+  });
+
+  it('accepts an override with undefined input metadata', () => {
+    @Component({
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {}
+
+    TestBed.configureTestingModule({});
+    spyOn((TestBed as any).ngMocksOverrides, 'get').and.returnValue({
+      override: {
+        set: { inputs: undefined },
+      },
+    });
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.stub();
+
+    funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    expect(reflectComponentType(child)?.inputs).toEqual([]);
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
@@ -3,7 +3,9 @@ import { TestBed } from '@angular/core/testing';
 
 import { extendClass } from '../common/core.helpers';
 import coreReflectDirectiveResolve from '../common/core.reflect.directive-resolve';
-import { AnyType } from '../common/core.types';
+import { AnyType, DirectiveIo } from '../common/core.types';
+import decorateInputs from '../common/decorate.inputs';
+import funcDirectiveIoParse from '../common/func.directive-io-parse';
 import { isNgDef } from '../common/func.is-ng-def';
 import { isStandalone } from '../common/func.is-standalone';
 
@@ -27,6 +29,15 @@ const registerTemplateMiddleware = (template: AnyType<any>, meta: Directive): vo
   } catch {
     // nothing to do
   }
+
+  // Reflecting the clone can append inputs, so keep its array separate from
+  // the metadata used to generate the wrapper's bindings.
+  set.inputs = [...({ ...meta, ...set }.inputs || [])];
+  // Angular JIT only preserves signal flags through property decorators.
+  decorateInputs(
+    child,
+    set.inputs.filter((input: DirectiveIo) => funcDirectiveIoParse(input).isSignal),
+  );
 
   if (isNgDef(template, 'c')) {
     Component({

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -86,6 +86,7 @@ file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-14692/test.spec.ts|features=signalInputs
+file|tests/issue-14839/test.spec.ts|features=signalInputs
 file|tests/issue-7976/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs
 file|tests/issue-9684/test.spec.ts|features=signalInputs

--- a/tests/issue-14839/test.spec.ts
+++ b/tests/issue-14839/test.spec.ts
@@ -1,0 +1,166 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  input,
+  isSignal,
+  Output,
+  reflectComponentType,
+} from '@angular/core';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+let transformations = 0;
+
+@Component({
+  selector: 'target-14839[myInput]',
+  standalone: true,
+  template: '{{ myInput() }}:{{ quantity() }}:{{ label }}',
+})
+class TargetComponent {
+  public readonly myInput = input.required<string>();
+  public readonly quantity = input(0, {
+    alias: 'publicQuantity',
+    transform: (value: number | string) => {
+      transformations += 1;
+
+      return Number(value) + 1;
+    },
+  });
+  @Input('publicLabel') public label = 'default-label';
+  @Output() public readonly changed = new EventEmitter<string>();
+}
+
+@Component({
+  standalone: true,
+  template: '{{ myInput() }}',
+})
+class SelectorlessComponent {
+  public readonly myInput = input('default-value');
+}
+
+@Component({
+  selector: 'target-14839-first, target-14839-second',
+  standalone: true,
+  template: '{{ myInput() }}',
+})
+class MultipleSelectorsComponent {
+  public readonly myInput = input.required<string>();
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14839
+describe('issue-14839', () => {
+  if (
+    !reflectComponentType(TargetComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'myInput',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() =>
+    MockBuilder([
+      TargetComponent,
+      SelectorlessComponent,
+      MultipleSelectorsComponent,
+    ]),
+  );
+
+  // Recompiling a complex selector must retain signal input metadata;
+  // otherwise Angular overwrites the signal function with the bound value.
+  it('binds required signals, aliases and transforms through an attribute selector', () => {
+    const changed =
+      typeof jest === 'undefined' ? jasmine.createSpy() : jest.fn();
+    transformations = 0;
+    const fixture = MockRender(TargetComponent, {
+      changed,
+      myInput: 'initial',
+      publicLabel: 'bound-label',
+      publicQuantity: '4',
+    });
+    const instance = fixture.point.componentInstance;
+    const myInput = instance.myInput;
+    const quantity = instance.quantity;
+
+    expect(isSignal(myInput)).toBe(true);
+    expect(isSignal(quantity)).toBe(true);
+    expect(myInput()).toEqual('initial');
+    expect(quantity()).toEqual(5);
+    expect(instance.label).toEqual('bound-label');
+    expect(fixture.nativeElement.textContent).toContain(
+      'initial:5:bound-label',
+    );
+    expect(transformations).toEqual(1);
+
+    instance.changed.emit('emitted');
+    expect(changed).toHaveBeenCalledWith('emitted');
+
+    fixture.componentRef.setInput('myInput', 'updated');
+    fixture.componentRef.setInput('publicQuantity', '6');
+    fixture.componentRef.setInput('publicLabel', 'updated-label');
+    expect(transformations).toEqual(1);
+    fixture.detectChanges();
+
+    expect(instance.myInput).toBe(myInput);
+    expect(instance.quantity).toBe(quantity);
+    expect(myInput()).toEqual('updated');
+    expect(quantity()).toEqual(7);
+    expect(instance.label).toEqual('updated-label');
+    expect(fixture.nativeElement.textContent).toContain(
+      'updated:7:updated-label',
+    );
+    expect(transformations).toEqual(2);
+  });
+
+  it('preserves defaults and updates a selectorless signal input without params', () => {
+    const fixture = MockRender(SelectorlessComponent);
+    const myInput = fixture.point.componentInstance.myInput;
+
+    expect(isSignal(myInput)).toBe(true);
+    expect(myInput()).toEqual('default-value');
+    expect(fixture.nativeElement.textContent).toContain(
+      'default-value',
+    );
+
+    fixture.componentInstance.myInput = 'updated';
+    fixture.detectChanges();
+
+    expect(fixture.point.componentInstance.myInput).toBe(myInput);
+    expect(myInput()).toEqual('updated');
+    expect(fixture.nativeElement.textContent).toContain('updated');
+  });
+
+  it('preserves unbound signal inputs with empty params', () => {
+    const fixture = MockRender(SelectorlessComponent, {});
+
+    expect(isSignal(fixture.point.componentInstance.myInput)).toBe(
+      true,
+    );
+    expect(fixture.point.componentInstance.myInput()).toEqual(
+      'default-value',
+    );
+    expect(fixture.nativeElement.textContent).toContain(
+      'default-value',
+    );
+  });
+
+  it('binds a required signal input through multiple selectors', () => {
+    const fixture = MockRender(MultipleSelectorsComponent, {
+      myInput: 'bound-value',
+    });
+
+    expect(isSignal(fixture.point.componentInstance.myInput)).toBe(
+      true,
+    );
+    expect(fixture.point.componentInstance.myInput()).toEqual(
+      'bound-value',
+    );
+    expect(fixture.nativeElement.textContent).toContain(
+      'bound-value',
+    );
+  });
+});


### PR DESCRIPTION
## Why

`MockRender` recompiles components with missing or complex selectors under a generated selector. Angular JIT treats inputs declared only in the decorator's `inputs` array as ordinary inputs, losing the signal flag and replacing an `InputSignal` with its bound value.

## What

- Apply signal input property decorators to the middleware using the existing metadata helper, while preserving input overrides and ordinary input handling.
- Give the middleware its own input array so reflecting the clone cannot add duplicate bindings to the generated wrapper template.
- Add the issue reproducer for attribute, multiple, and missing selectors, covering required inputs, defaults, aliases, updates, transform counts, and ordinary inputs and outputs. Add source regressions for metadata isolation and override and alias precedence.

## Impact

Raw input bindings keep the rendered component's signal callable, and each update runs its transform once. This restores the documented `MockRender` contract, so public documentation and migration guidance do not change.

Fixes #14839
