### PR TITLE
chore: defer quality checks until commits and containerize commitlint

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -22,7 +22,7 @@ Create and maintain a plain Markdown checklist:
 - [ ] Fix the implementation without changing the reproducer test
 - [ ] Clear affected Angular CLI caches and run coverage and e2e validation
 - [ ] Update the matching docs and review them against the executable examples
-- [ ] Prepare the commit and PR against `upstream/main`
+- [ ] Complete final formatting, ESLint, and TypeScript checks, then commit and prepare the PR against `upstream/main`
 - [ ] Verify the requested CI status on the current PR commit
 ```
 
@@ -75,6 +75,8 @@ Create and maintain a plain Markdown checklist:
    - Prefer existing ng-mocks helpers and patterns over new abstractions.
    - Add code comments only for non-obvious Angular behavior, compatibility constraints, or private API handling.
    - Do not hide failures with skips, broad version exclusions, relaxed assertions, or coverage ignores unless the issue truly cannot be represented otherwise.
+   - Use functional tests during investigation and implementation. Do not run formatting/Prettier, ESLint, or
+     TypeScript checks or fix their findings until the solution is ready to commit.
 6. Update and review documentation:
    - Keep testing a real declaration and mocking a dependency clear, with separate articles for independent APIs.
      Identify decorator and signal variants where both exist.
@@ -148,7 +150,17 @@ Do not infer a source regression from output that may have reused an older compi
 the current source or the focused reproducer, inspect `e2e/a<major>/node_modules/ng-mocks`, clear the target cache,
 and rerun the wrapper before changing implementation or test code.
 
-Before committing:
+Coverage expectations:
+
+- Treat `sh test.sh coverage` as required for source fixes.
+- Inspect changed source files in `test-reports/coverage/lcov.info` or the generated HTML report if coverage is uncertain.
+- The PR should keep project and patch coverage at 100%. If Codecov later reports uncovered patch lines, add assertions before updating the PR.
+
+Once the solution and functional validation are complete, run formatting/Prettier, ESLint, and TypeScript checks
+as the final checks immediately before committing. Keep normal commit hooks enabled and let them satisfy the
+required checks they already cover instead of running those checks separately first. Run any remaining required
+checks through Docker at this final stage, using the commands below, and resolve all findings before the commit
+succeeds:
 
 ```bash
 COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> docker compose run --rm ng-mocks npm run prettier:repo
@@ -156,12 +168,6 @@ COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> docker compose run 
 COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> docker compose run --rm ng-mocks npm run lint
 COMPOSE_PROJECT_NAME=ngmocks_issue<issue-number>_<timestamp> docker compose run --rm ng-mocks npm run ts:check
 ```
-
-Coverage expectations:
-
-- Treat `sh test.sh coverage` as required for source fixes.
-- Inspect changed source files in `test-reports/coverage/lcov.info` or the generated HTML report if coverage is uncertain.
-- The PR should keep project and patch coverage at 100%. If Codecov later reports uncovered patch lines, add assertions before updating the PR.
 
 ## Comments, Commit, PR
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx commitlint --edit $1
+docker compose run --rm -T ng-mocks npm run commitlint < "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,13 +172,18 @@
 
 ## Code Quality Commands
 
+- Run formatting/Prettier, ESLint, and TypeScript checks only after the solution and functional validation are
+  complete, as the final checks immediately before committing. During investigation and implementation, use
+  functional tests; do not run these quality checks or fix their findings yet.
 - Run root quality checks through the main service container:
   - `docker compose run --rm ng-mocks npm run prettier:repo`
   - `docker compose run --rm ng-mocks npm run prettier:check`
   - `docker compose run --rm ng-mocks npm run lint`
   - `docker compose run --rm ng-mocks npm run ts:check`
 - If multiple worktrees are active, prefix direct `docker compose` commands with the same `COMPOSE_PROJECT_NAME` you use for wrappers so the checks stay inside that worktree's compose project.
-- Run Prettier before `git commit`.
+- Keep normal commit hooks enabled. Let them satisfy the required checks they already cover instead of running
+  those checks separately first. Run any remaining required checks through Docker at this final stage, and resolve
+  all findings before the commit succeeds.
 - For tooling migrations, use official packages and their exported presets. Remove direct subpackages only when the official umbrella package replaces them and the repository no longer imports them.
 
 ## Lockfiles and Dependency Refresh

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "npm": "npm",
+    "commitlint": "commitlint",
     "release": "export $(cat .env) && semantic-release",
     "build": "npm run clean && npm run build:webpack && npm run build:types && cp CHANGELOG.md dist/libs/ng-mocks && cp README.md dist/libs/ng-mocks && cp LICENSE dist/libs/ng-mocks && cp libs/ng-mocks/package.json dist/libs/ng-mocks/package.json && cp libs/ng-mocks/migrations.json dist/libs/ng-mocks/migrations.json && cp examples/main/test.spec.ts dist/libs/ng-mocks/example.spec.ts",
     "build:dev": "MODE=development npm run build",


### PR DESCRIPTION
## Why

Agent guidance did not explicitly defer formatting, ESLint, and TypeScript checks until the solution was ready to commit. The commit-message hook also ran commitlint through the host's `npx`, despite using Docker for other commit checks.

## What

- Update `AGENTS.md` and the issue-triage workflow to use functional tests during implementation and run quality checks at the final commit stage.
- Let normal commit hooks satisfy the checks they already cover to avoid duplicate runs.
- Run commitlint through the root Docker service, streaming the commit message through stdin.

## Impact

Contributors use the configured container for commit-message validation, including when Git stores the message outside the mounted worktree. Agent workflows reserve formatting and quality checks for completed solutions.
