### PR TITLE
build(renovate): leave security updates to Dependabot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,12 @@ COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> sh ./test.sh e2e
 COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> docker compose run --rm ng-mocks npm run lint
 ```
 
+### Automated dependency updates
+
+Renovate handles regular dependency updates, and Dependabot handles security updates. Keep Renovate's
+`vulnerabilityAlerts.enabled` set to `false` so it does not create security-fix PRs alongside Dependabot.
+Regular Renovate updates still follow the compatibility restrictions in `renovate.json`.
+
 ### Zoned and zoneless Angular tests
 
 Angular 20.2 made zoneless change detection stable, and Angular 21 enables it by default. The `a20`, `a21`, and

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
   "additionalBranchPrefix": "{{#if (equals packageFileDir '')}}root{{else}}{{{packageFileDir}}}{{/if}}/",
   "branchTopic": "{{{depNameSanitized}}}-{{{newMajor}}}.{{{newMinor}}}.x",
   "vulnerabilityAlerts": {
-    "enabled": true
+    "enabled": false
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Why

Dependabot handles security updates for this repository, but Renovate is also configured to create vulnerability-fix PRs. In #14841, Renovate proposed upgrading Angular 20's Vitest dependency from 3.2.7 to 4.1.11. Angular 20's build package requires Vitest `^3.1.1`, so npm rejected the upgrade and Renovate could not update its lockfile.

The repository already disables major updates in versioned Angular projects, but its explicit `vulnerabilityAlerts.enabled: true` is copied into Renovate's forced update configuration and overrides those restrictions.

## What

Set `vulnerabilityAlerts.enabled` to `false` in `renovate.json`. Document that Renovate handles regular dependency updates and Dependabot handles security updates.

## Impact

Renovate stops creating vulnerability-fix PRs such as #14841. Its regular dependency updates continue to follow the existing compatibility rules, while Dependabot remains responsible for security updates.

Related to #14841.
