### PR TITLE
ci: share dependency caches across worker CPU models

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -53,8 +53,8 @@ Create and maintain a plain Markdown checklist:
    - do not discard unrelated local changes in the original checkout; the worktree isolates the issue branch from them
    - run installs, builds, tests, checks, and commits from the issue worktree; do not use the original checkout as a
      fallback working directory or change its branch
-   - do not mount the original checkout or its `.git` directory into the worktree's Docker containers; report linked
-     Git metadata failures and discuss a supported solution without weakening worktree isolation
+   - do not mount the original checkout into the worktree's Docker containers; shared Git metadata may be mounted
+     only for commit-hook setup and execution as described in `AGENTS.md`, never for ordinary validation
 
    ```bash
    git fetch upstream --prune

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
+          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
       - run:
           name: NPM Install
           command: |
@@ -119,7 +119,7 @@ commands:
             fi
             mkdir -p "$HOME/.cache/puppeteer"
       - save_cache:
-          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
+          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
           paths:
             - ./e2e/<< parameters.dir >>/node_modules
             - ~/.cache/puppeteer
@@ -144,7 +144,7 @@ commands:
       - attach_workspace:
           at: dist
       - restore_cache:
-          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
+          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
       - run:
           name: Spreading Build
           command: npm run s:<< parameters.dir >>
@@ -179,7 +179,7 @@ commands:
       - attach_workspace:
           at: dist
       - restore_cache:
-          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
+          key: << parameters.dir >>-<< pipeline.parameters.lockindex >>-{{ checksum "e2e/<< parameters.dir >>/package.json" }}-{{ checksum "e2e/<< parameters.dir >>/package-lock.json" }}
       - run:
           name: Spreading Build
           command: npm run s:<< parameters.dir >>
@@ -196,7 +196,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: root-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: root-<< pipeline.parameters.lockindex >>-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
       - run:
           name: NPM Install
           command: |
@@ -207,7 +207,7 @@ jobs:
             md5sum -c package.md5
             rm package.md5
       - save_cache:
-          key: root-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          key: root-<< pipeline.parameters.lockindex >>-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
             - ~/.cache/puppeteer
@@ -287,7 +287,7 @@ jobs:
             - attach_workspace:
                 at: dist
             - restore_cache:
-                key: tests-e2e-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "tests-e2e/package.json" }}-{{ checksum "tests-e2e/package-lock.json" }}
+                key: tests-e2e-<< pipeline.parameters.lockindex >>-{{ checksum "tests-e2e/package.json" }}-{{ checksum "tests-e2e/package-lock.json" }}
             - run:
                 name: NPM Install
                 command: |
@@ -298,7 +298,7 @@ jobs:
                   md5sum -c package.md5
                   rm package.md5
             - save_cache:
-                key: tests-e2e-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "tests-e2e/package.json" }}-{{ checksum "tests-e2e/package-lock.json" }}
+                key: tests-e2e-<< pipeline.parameters.lockindex >>-{{ checksum "tests-e2e/package.json" }}-{{ checksum "tests-e2e/package-lock.json" }}
                 paths:
                   - ./tests-e2e/node_modules
                   - ~/.cache/puppeteer
@@ -328,7 +328,7 @@ jobs:
           steps:
             - checkout
             - restore_cache:
-                key: docs-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "docs/package.json" }}-{{ checksum "docs/package-lock.json" }}
+                key: docs-<< pipeline.parameters.lockindex >>-{{ checksum "docs/package.json" }}-{{ checksum "docs/package-lock.json" }}
             - run:
                 name: NPM Install
                 command: |
@@ -339,7 +339,7 @@ jobs:
                   md5sum -c package.md5
                   rm package.md5
             - save_cache:
-                key: docs-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "docs/package.json" }}-{{ checksum "docs/package-lock.json" }}
+                key: docs-<< pipeline.parameters.lockindex >>-{{ checksum "docs/package.json" }}-{{ checksum "docs/package-lock.json" }}
                 paths:
                   - ./docs/node_modules
                   - ~/.cache/puppeteer
@@ -366,7 +366,7 @@ jobs:
           steps:
             - checkout
             - restore_cache:
-                key: root-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+                key: root-<< pipeline.parameters.lockindex >>-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
             - run:
                 name: Default
                 command: KARMA_SUITE=tests-performance/test.spec.ts npm run test
@@ -414,7 +414,7 @@ jobs:
             - attach_workspace:
                 at: dist
             - restore_cache:
-                key: a5es5-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/a5es5/package.json" }}-{{ checksum "e2e/a5es5/package-lock.json" }}
+                key: a5es5-windows-<< pipeline.parameters.lockindex >>-{{ checksum "e2e/a5es5/package.json" }}-{{ checksum "e2e/a5es5/package-lock.json" }}
             - run: nvm install $(cat e2e/a5es5/.nvmrc)
             - run: nvm use $(cat e2e/a5es5/.nvmrc)
             - run:
@@ -430,7 +430,7 @@ jobs:
                   md5sum -c package.md5
                   rm package.md5
             - save_cache:
-                key: a5es5-<< pipeline.parameters.lockindex >>-{{ arch }}-{{ checksum "e2e/a5es5/package.json" }}-{{ checksum "e2e/a5es5/package-lock.json" }}
+                key: a5es5-windows-<< pipeline.parameters.lockindex >>-{{ checksum "e2e/a5es5/package.json" }}-{{ checksum "e2e/a5es5/package-lock.json" }}
                 paths:
                   - ./e2e/a5es5/node_modules
                   - ~/.cache/puppeteer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@
   authorize custom executable validation.
 - If an approved command fails or the available tooling cannot perform a required operation, report the command,
   error, and remaining work to the user and discuss the solution before trying a workaround. Do not silently switch
-  runtimes or images, bypass hooks or checks, add temporary Compose overrides, or create new validation tooling.
+  runtimes or images, bypass hooks or checks, add temporary Compose overrides outside the commit-hook exception
+  below, or create new validation tooling.
 - If multiple worktrees or agent sessions run in parallel, set a unique compose namespace:
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh compose.sh <target>`
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh test.sh <target>`
@@ -60,9 +61,15 @@
 - Perform issue edits, dependency installation, builds, tests, checks, and commits in the issue's independent worktree
   and branch. Do not use the primary project checkout as a working directory or change its working files or branch.
 - Run the existing Docker commands from that worktree so their bind mounts and generated files belong to it.
-- Do not mount the primary checkout or its `.git` directory into a worktree's containers to repair tooling failures.
-  A linked worktree's normal Git metadata sharing does not authorize using the primary checkout as a build workspace
-  or adding it as a Docker mount.
+- Do not mount the primary checkout into a worktree's containers or use it as a build workspace.
+- For commit-hook setup and execution only, a temporary Compose override may mount the shared `.git` directory
+  and the current worktree at their original absolute host paths so linked Git metadata resolves inside Docker.
+  Set the container's working directory to the current worktree and keep all file edits there.
+- Scope that override to hook setup and `git commit`. Do not use it for dependency installation, ordinary builds,
+  tests, checks, or pushes. Keep the normal commit hooks enabled and use the existing Docker image and commands.
+- Keep hook configuration local to the commit operation. When installing Husky, direct its Git configuration write
+  to a temporary container file with `GIT_CONFIG`, then select `.husky/_` through `git -c core.hooksPath=.husky/_`
+  for the commit. Do not persist changes to the shared repository's hook configuration.
 - If a tool cannot work with the isolated worktree, report the error and discuss a supported solution with the user.
   Do not move execution to the primary checkout or weaken the isolation to make a check pass.
 


### PR DESCRIPTION
## Why

PR #14860 failed in `jest:build` with `ng: not found` even though dependency installation and the Jest tests passed. CircleCI saved the dependencies under an `arch1-linux-amd64-6_85` cache key, but the build ran on a worker reporting `arch1-linux-amd64-6_106` and could not restore them.

The `{{ arch }}` template includes the CPU model, so identical Docker executors can produce different keys when CircleCI schedules jobs on different host hardware.

## What

Remove `{{ arch }}` from all dependency-cache restore and save keys. Keep the project prefixes, cache version, and package manifest and lockfile checksums. Give the Windows IE cache an explicit `a5es5-windows` prefix to keep its dependencies separate from Linux.

Document a commit-only exception for mounting shared Git metadata from linked worktrees, and align the issue workflow guidance with it. Hook setup uses temporary Git configuration; normal builds, tests, and pushes retain the existing isolated mounts.

## Impact

Install, test, and build jobs can share the same dependency cache across CircleCI's Linux amd64 CPU models. The new keys will populate fresh caches on their first use. Contributors can run normal commit hooks in linked worktrees while keeping working files isolated. Changes are limited to CI configuration and contributor guidance; public API documentation is unaffected.

Related to #14860.
