### PR TITLE
fix(MockRender): preserve inherited metadata and model output bindings #14839

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
@@ -8,24 +8,26 @@ describe('funcDirectiveIoParse', () => {
     });
   });
 
-  it('normalizes signal model outputs from strings', () => {
+  it('preserves Change aliases from strings', () => {
     expect(funcDirectiveIoParse('value:valueChange')).toEqual({
-      name: 'valueChange',
+      alias: 'valueChange',
+      name: 'value',
     });
   });
 
-  it('normalizes signal model outputs from objects', () => {
+  it('preserves Change aliases from objects', () => {
     expect(
       funcDirectiveIoParse({
         alias: 'valueChange',
         name: 'value',
       }),
     ).toEqual({
-      name: 'valueChange',
+      alias: 'valueChange',
+      name: 'value',
     });
   });
 
-  it('keeps required metadata for signal model outputs', () => {
+  it('keeps required input metadata with Change aliases', () => {
     expect(
       funcDirectiveIoParse({
         alias: 'valueChange',
@@ -33,7 +35,8 @@ describe('funcDirectiveIoParse', () => {
         required: true,
       }),
     ).toEqual({
-      name: 'valueChange',
+      alias: 'valueChange',
+      name: 'value',
       required: true,
     });
   });

--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.ts
@@ -11,10 +11,6 @@ const normalize = ({ name, alias, required, isSignal, transform }: DirectiveIoPa
     return { name, ...metadata };
   }
 
-  if (name + 'Change' === alias) {
-    return { name: alias, ...metadata };
-  }
-
   return { name, alias, ...metadata };
 };
 

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.attributes.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.attributes.spec.ts
@@ -1,0 +1,211 @@
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  forwardRef,
+  Input,
+  input,
+  InjectionToken,
+  isSignal,
+  Output,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import decorateMock from '../common/decorate.mock';
+import { Mock } from '../common/mock';
+import { MockComponent } from '../mock-component/mock-component';
+import { MockRender } from '../mock-render/mock-render';
+
+import { ngMocks } from './mock-helper';
+
+@Component({
+  selector: 'target-output-attributes',
+  standalone: false,
+  template: '',
+})
+class TargetComponent {
+  // The source unit supplies compiler-equivalent model metadata. Real authoring
+  // functions are exercised by the compiled mock-render-metadata spread cases.
+  @Input({ alias: 'value', isSignal: true } as never)
+  @Output('valueChange')
+  public readonly valueChange = input<string>();
+}
+
+describe('mock-helper:attributes', () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      declarations: [MockComponent(TargetComponent)],
+    }).compileComponents(),
+  );
+
+  it('finds each aliased mock output without selecting another emitter', () => {
+    @Component({
+      selector: 'target-multiple-outputs',
+      standalone: false,
+      template: '',
+    })
+    class OutputsComponent {
+      @Output('publicFirst') public readonly first =
+        new EventEmitter<number>();
+      @Output('publicSecond') public readonly second =
+        new EventEmitter<number>();
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [MockComponent(OutputsComponent)],
+    });
+    const firstValues: number[] = [];
+    const secondValues: number[] = [];
+    MockRender(
+      `<target-multiple-outputs
+        (publicFirst)="firstValues.push($event)"
+        (publicSecond)="secondValues.push($event)">
+      </target-multiple-outputs>`,
+      { firstValues, secondValues },
+    );
+    const target = ngMocks.find(OutputsComponent);
+    const first = ngMocks.output(target, 'publicFirst');
+    const second = ngMocks.output(target, 'publicSecond');
+
+    expect(first).toBe(target.componentInstance.first);
+    expect(second).toBe(target.componentInstance.second);
+    expect(first).not.toBe(second);
+
+    first.emit(1);
+    second.emit(2);
+
+    expect(firstValues).toEqual([1]);
+    expect(secondValues).toEqual([2]);
+  });
+
+  it('uses declared output metadata when a custom mock has no output configuration', () => {
+    @Component({
+      selector: 'target-custom-output',
+      standalone: false,
+      template: '',
+    })
+    class OutputComponent {
+      @Output('publicChanged') public readonly changed =
+        new EventEmitter<number>();
+    }
+
+    @Component({
+      // eslint-disable-next-line @angular-eslint/no-outputs-metadata-property
+      outputs: ['changed:publicChanged'],
+      providers: [
+        {
+          provide: OutputComponent,
+          useExisting: forwardRef(() => CustomMock),
+        },
+      ],
+      selector: 'target-custom-output',
+      standalone: false,
+      template: '',
+    })
+    class CustomMock extends Mock {
+      public readonly changed = new EventEmitter<number>();
+    }
+
+    decorateMock(CustomMock, OutputComponent);
+    TestBed.configureTestingModule({ declarations: [CustomMock] });
+    const values: number[] = [];
+    MockRender(
+      '<target-custom-output (publicChanged)="values.push($event)"></target-custom-output>',
+      { values },
+    );
+    const target = ngMocks.find(OutputComponent);
+    const instance = target.componentInstance;
+    const emitter = ngMocks.output(target, 'publicChanged');
+
+    expect((instance as any).__ngMocksConfig.outputs).toBeUndefined();
+    expect(emitter).toBe(instance.changed);
+
+    emitter.emit(2);
+
+    expect(values).toEqual([2]);
+  });
+
+  it('skips unrelated provider aliases before looking up a child input or output', () => {
+    const parentToken = new InjectionToken<ParentDirective>(
+      'parent-attributes',
+    );
+
+    @Directive({
+      providers: [
+        {
+          provide: parentToken,
+          useExisting: forwardRef(() => ParentDirective),
+        },
+      ],
+      selector: '[parentAttributes]',
+      standalone: false,
+    })
+    class ParentDirective {}
+
+    @Directive({
+      providers: [
+        { provide: parentToken, useExisting: ParentDirective },
+      ],
+      selector: '[childAttributes]',
+      standalone: false,
+    })
+    class ChildDirective {
+      @Input('publicValue') public value = 0;
+      @Output('publicChanged') public readonly changed =
+        new EventEmitter<number>();
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [ParentDirective, ChildDirective],
+    });
+    const values: number[] = [];
+    MockRender(
+      `<div parentAttributes>
+        <span childAttributes [publicValue]="value" (publicChanged)="values.push($event)"></span>
+      </div>`,
+      { value: 1, values },
+    );
+    const parent = ngMocks.find('[parentAttributes]');
+    const child = ngMocks.find('[childAttributes]');
+
+    // This local token resolves to an inherited instance, which ngMocks.get excludes.
+    expect(child.injector.get(parentToken)).toBe(
+      parent.injector.get(parentToken),
+    );
+    expect(child.providerTokens.indexOf(parentToken)).toBeLessThan(
+      child.providerTokens.indexOf(ChildDirective),
+    );
+    expect(() => ngMocks.get(child, parentToken)).toThrow();
+    expect(ngMocks.input(child, 'publicValue')).toBe(1);
+    expect(ngMocks.output(child, 'publicChanged')).toBe(
+      ngMocks.get(child, ChildDirective).changed,
+    );
+
+    ngMocks.output(child, 'publicChanged').emit(2);
+
+    expect(values).toEqual([2]);
+  });
+
+  it('finds a model emitter through its public alias while keeping input lookup on the signal', () => {
+    const values: string[] = [];
+    const fixture = MockRender(
+      '<target-output-attributes [value]="value" (valueChange)="values.push($event)"></target-output-attributes>',
+      { value: 'initial', values },
+    );
+    const target = ngMocks.find(TargetComponent);
+    const inputSignal = target.componentInstance.valueChange;
+    const emitter = ngMocks.output(target, 'valueChange');
+
+    expect(isSignal(inputSignal)).toBe(true);
+    expect(ngMocks.input(target, 'value')).toBe('initial');
+    expect(emitter).not.toBe(inputSignal as never);
+
+    emitter.emit('child');
+    fixture.componentInstance.value = 'parent';
+    fixture.detectChanges();
+
+    expect(values).toEqual(['child']);
+    expect(target.componentInstance.valueChange).toBe(inputSignal);
+    expect(ngMocks.input(target, 'value')).toBe('parent');
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.attributes.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.attributes.ts
@@ -1,5 +1,6 @@
 import { DirectiveIo, DirectiveIoParsed } from '../common/core.types';
 import funcDirectiveIoParse from '../common/func.directive-io-parse';
+import funcIsMock from '../common/func.is-mock';
 import { MockedDebugElement } from '../mock-render/types';
 
 import mockHelperFind from './find/mock-helper.find';
@@ -36,7 +37,19 @@ const detectAttribute = (el: MockedDebugElement | null | undefined, attr: 'input
     for (const attrDef of meta[attr] || /* istanbul ignore next */ []) {
       const parsed = attrMatches(attrDef, sel);
       if (parsed) {
-        const value = mockHelperGet(el, token)[parsed.name];
+        const instance = mockHelperGet(el, token);
+        // Mock models keep their emitters separate from the original signal property.
+        let mockOutput: DirectiveIo | undefined;
+        if (attr === 'outputs' && funcIsMock(instance)) {
+          for (const output of instance.__ngMocksConfig.outputs || []) {
+            if (attrMatches(output, sel)) {
+              mockOutput = output;
+              break;
+            }
+          }
+        }
+        const name = mockOutput ? funcDirectiveIoParse(mockOutput).name : parsed.name;
+        const value = instance[name];
 
         return attr === 'inputs' && parsed.isSignal && typeof value === 'function' ? value() : value;
       }

--- a/libs/ng-mocks/src/lib/mock-render/func.inherit-definition.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.inherit-definition.spec.ts
@@ -1,0 +1,323 @@
+import funcInheritDefinition from './func.inherit-definition';
+
+describe('funcInheritDefinition', () => {
+  it('leaves declarations without Ivy definition getters unchanged', () => {
+    const definition = { hostAttrs: ['role', 'button'] };
+    const child = { ɵcmp: definition };
+    const descriptor = Object.getOwnPropertyDescriptor(child, 'ɵcmp');
+
+    funcInheritDefinition(child, { ɵcmp: { hostAttrs: [] } });
+
+    expect(child.ɵcmp).toBe(definition);
+    expect(Object.getOwnPropertyDescriptor(child, 'ɵcmp')).toEqual(
+      descriptor,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(child, 'ɵdir'),
+    ).toBeUndefined();
+  });
+
+  it('normalizes nonconfigurable Ivy getters without replacing their descriptor', () => {
+    const original = {
+      data: { animation: ['original'] },
+      findHostDirectiveDefs: jasmine.createSpy(
+        'findHostDirectiveDefs',
+      ),
+      hostAttrs: ['role', 'button'],
+      hostBindings: jasmine.createSpy('hostBindings'),
+      hostDirectives: [
+        {
+          directive: 'original',
+          inputs: { input: 'alias' },
+          outputs: {},
+        },
+      ],
+      hostVars: 1,
+      resolveHostDirectives: jasmine.createSpy(
+        'resolveHostDirectives',
+      ),
+    };
+    const definition: any = {
+      data: {
+        animation: ['original', 'original'],
+        retained: 'value',
+      },
+      hostVars: 2,
+    };
+    const child: any = { definition };
+    Object.defineProperty(child, 'ɵcmp', {
+      configurable: false,
+      enumerable: true,
+      get() {
+        return this.definition;
+      },
+    });
+    const descriptor = Object.getOwnPropertyDescriptor(child, 'ɵcmp');
+
+    expect(() =>
+      funcInheritDefinition(child, { ɵcmp: original }),
+    ).not.toThrow();
+
+    expect(Object.getOwnPropertyDescriptor(child, 'ɵcmp')).toEqual(
+      descriptor,
+    );
+    expect(child.ɵcmp).toBe(definition);
+    expect(definition.hostBindings).toBe(original.hostBindings);
+    expect(definition.hostVars).toBe(1);
+    expect(definition.hostAttrs).toEqual(['role', 'button']);
+    expect(definition.hostAttrs).not.toBe(original.hostAttrs);
+    expect(definition.data).toEqual({
+      animation: ['original'],
+      retained: 'value',
+    });
+    expect(definition.data.animation).not.toBe(
+      original.data.animation,
+    );
+    expect(definition.hostDirectives).toEqual(
+      original.hostDirectives,
+    );
+    expect(definition.hostDirectives).not.toBe(
+      original.hostDirectives,
+    );
+    expect(definition.hostDirectives[0].inputs).not.toBe(
+      original.hostDirectives[0].inputs,
+    );
+    expect(definition.findHostDirectiveDefs).toBe(
+      original.findHostDirectiveDefs,
+    );
+    expect(definition.resolveHostDirectives).toBe(
+      original.resolveHostDirectives,
+    );
+    expect(original.data.animation).toEqual(['original']);
+    expect(original.hostVars).toBe(1);
+  });
+
+  it('copies inherited side effects without mutating original metadata or other clone fields', () => {
+    class HostDirective {}
+    const lazyHostDirectives = jasmine.createSpy(
+      'lazyHostDirectives',
+    );
+    const original = {
+      data: { animation: [{ name: 'original' }] },
+      findHostDirectiveDefs: jasmine.createSpy(
+        'findHostDirectiveDefs',
+      ),
+      hostAttrs: ['role', 'button'],
+      hostBindings: jasmine.createSpy('hostBindings'),
+      hostDirectives: [
+        {
+          directive: HostDirective,
+          inputs: { input: 'publicInput' },
+          outputs: { output: 'publicOutput' },
+        },
+        lazyHostDirectives,
+      ],
+      hostVars: 2,
+      resolveHostDirectives: jasmine.createSpy(
+        'resolveHostDirectives',
+      ),
+    };
+    const inputs = { publicInput: ['input', 1] };
+    const outputs = { publicOutput: 'output' };
+    const contentQueries = jasmine.createSpy('contentQueries');
+    const viewQuery = jasmine.createSpy('viewQuery');
+    const providersResolver = jasmine.createSpy('providersResolver');
+    const template = jasmine.createSpy('template');
+    const data = {
+      animation: [{ name: 'duplicate' }],
+      retained: 'value',
+    };
+    const definition: any = {
+      contentQueries,
+      data,
+      inputs,
+      outputs,
+      providersResolver,
+      selectors: [['middleware']],
+      standalone: true,
+      template,
+      viewQuery,
+    };
+    const child: any = { definition };
+    Object.defineProperty(child, 'ɵcmp', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return this.definition;
+      },
+      set(value) {
+        this.definition = value;
+      },
+    });
+    const descriptor = Object.getOwnPropertyDescriptor(
+      child,
+      'ɵcmp',
+    )!;
+
+    funcInheritDefinition(child, { ɵcmp: original });
+
+    expect(child.ɵcmp).toBe(definition);
+    const inheritedAttrs = definition.hostAttrs;
+    const inheritedAnimations = definition.data.animation;
+    const inheritedHostDirectives = definition.hostDirectives;
+    expect(definition.hostBindings).toBe(original.hostBindings);
+    expect(definition.hostVars).toBe(2);
+    expect(inheritedAttrs).toEqual(original.hostAttrs);
+    expect(inheritedAttrs).not.toBe(original.hostAttrs);
+    expect(inheritedAnimations).toEqual(original.data.animation);
+    expect(inheritedAnimations).not.toBe(original.data.animation);
+    expect(definition.data.retained).toBe('value');
+    expect(data.animation).toEqual([{ name: 'duplicate' }]);
+    expect(inheritedHostDirectives).toEqual(original.hostDirectives);
+    expect(inheritedHostDirectives).not.toBe(original.hostDirectives);
+    expect(inheritedHostDirectives[0]).not.toBe(
+      original.hostDirectives[0],
+    );
+    expect(inheritedHostDirectives[0].inputs).not.toBe(
+      (original.hostDirectives[0] as any).inputs,
+    );
+    expect(inheritedHostDirectives[0].outputs).not.toBe(
+      (original.hostDirectives[0] as any).outputs,
+    );
+    expect(inheritedHostDirectives[1]).toBe(lazyHostDirectives);
+    expect(lazyHostDirectives).not.toHaveBeenCalled();
+    expect(definition.findHostDirectiveDefs).toBe(
+      original.findHostDirectiveDefs,
+    );
+    expect(definition.resolveHostDirectives).toBe(
+      original.resolveHostDirectives,
+    );
+    expect(definition.inputs).toBe(inputs);
+    expect(definition.outputs).toBe(outputs);
+    expect(definition.contentQueries).toBe(contentQueries);
+    expect(definition.viewQuery).toBe(viewQuery);
+    expect(definition.providersResolver).toBe(providersResolver);
+    expect(definition.template).toBe(template);
+    expect(definition.selectors).toEqual([['middleware']]);
+    expect(definition.standalone).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(child, 'ɵcmp')).toEqual({
+      ...descriptor,
+      get: jasmine.any(Function),
+    });
+
+    inheritedAttrs.push('title', 'clone');
+    inheritedAnimations.push({ name: 'clone' });
+    inheritedHostDirectives[0].inputs.input = 'cloneInput';
+    inheritedHostDirectives[0].outputs.output = 'cloneOutput';
+    inheritedHostDirectives.push(lazyHostDirectives);
+
+    // Repeated reads retain Angular's work on this same compiled definition.
+    expect(child.ɵcmp.hostAttrs).toBe(inheritedAttrs);
+    expect(child.ɵcmp.data.animation).toBe(inheritedAnimations);
+    expect(child.ɵcmp.hostDirectives).toBe(inheritedHostDirectives);
+    expect(original.hostAttrs).toEqual(['role', 'button']);
+    expect(original.data.animation).toEqual([{ name: 'original' }]);
+    expect(original.hostDirectives).toEqual([
+      {
+        directive: HostDirective,
+        inputs: { input: 'publicInput' },
+        outputs: { output: 'publicOutput' },
+      },
+      lazyHostDirectives,
+    ]);
+  });
+
+  it('refreshes inherited fields when TestBed replaces the original or clone definition', () => {
+    const firstOriginal = {
+      data: { animation: ['original'] },
+      hostAttrs: ['role', 'button'],
+      hostBindings: jasmine.createSpy('originalHostBindings'),
+      hostDirectives: [
+        { directive: 'original', inputs: {}, outputs: {} },
+      ],
+      hostVars: 1,
+    };
+    const template: any = { ɵcmp: firstOriginal };
+    const child: any = {
+      definition: { data: { retained: 'first' } },
+    };
+    Object.defineProperty(child, 'ɵcmp', {
+      configurable: true,
+      get() {
+        return this.definition;
+      },
+      set(value) {
+        this.definition = value;
+      },
+    });
+    funcInheritDefinition(child, template);
+    const firstDefinition = child.ɵcmp;
+    expect(firstDefinition.data.animation).toEqual(['original']);
+
+    // A metadata override can remove inherited effects instead of adding them.
+    template.ɵcmp = {
+      findHostDirectiveDefs: null,
+      hostAttrs: null,
+      hostBindings: null,
+      hostDirectives: null,
+      hostVars: 0,
+      resolveHostDirectives: null,
+    };
+
+    expect(child.ɵcmp).toBe(firstDefinition);
+    expect(firstDefinition.hostAttrs).toBeNull();
+    expect(firstDefinition.hostBindings).toBeNull();
+    expect(firstDefinition.hostVars).toBe(0);
+    expect(firstDefinition.hostDirectives).toBeNull();
+    expect(firstDefinition.findHostDirectiveDefs).toBeNull();
+    expect(firstDefinition.resolveHostDirectives).toBeNull();
+    expect(firstDefinition.data.animation).toBeUndefined();
+    expect(firstDefinition.data.retained).toBe('first');
+    expect(firstOriginal.hostAttrs).toEqual(['role', 'button']);
+    expect(firstOriginal.data.animation).toEqual(['original']);
+
+    const replacement = {
+      data: { animation: ['stale'], retained: 'replacement' },
+    };
+    child.ɵcmp = replacement;
+
+    expect(child.ɵcmp).toBe(replacement);
+    expect(child.definition).toBe(replacement);
+    expect(child.ɵcmp.hostBindings).toBeNull();
+    expect(child.ɵcmp.hostDirectives).toBeNull();
+    expect(child.ɵcmp.data).toEqual({
+      animation: undefined,
+      retained: 'replacement',
+    });
+  });
+
+  it('waits for directive definitions and leaves component-only data absent', () => {
+    const template: any = { ɵdir: { hostVars: 0 } };
+    const child: any = {};
+    Object.defineProperty(child, 'ɵdir', {
+      configurable: true,
+      get() {
+        return this.definition;
+      },
+    });
+
+    funcInheritDefinition(child, template);
+
+    expect(child.ɵdir).toBeUndefined();
+    template.ɵdir = undefined;
+    child.definition = { hostVars: 3 };
+    expect(child.ɵdir).toBe(child.definition);
+    expect(child.ɵdir.hostVars).toBe(3);
+
+    template.ɵdir = {
+      hostAttrs: [],
+      hostBindings: jasmine.createSpy('directiveHostBindings'),
+      hostDirectives: [],
+      hostVars: 0,
+    };
+
+    expect(child.ɵdir).toBe(child.definition);
+    expect(child.ɵdir.hostBindings).toBe(template.ɵdir.hostBindings);
+    expect(child.ɵdir.hostAttrs).toEqual([]);
+    expect(child.ɵdir.hostDirectives).toEqual([]);
+    expect(child.ɵdir.hostVars).toBe(0);
+    expect(child.ɵdir.data).toBeUndefined();
+    expect(child.ɵdir.findHostDirectiveDefs).toBeUndefined();
+    expect(child.ɵdir.resolveHostDirectives).toBeUndefined();
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-render/func.inherit-definition.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.inherit-definition.ts
@@ -1,0 +1,65 @@
+// Middleware declarations represent the same Angular declaration under a new
+// selector. Recompiling copied metadata must not add inherited side effects twice.
+const inheritDefinition = (definition: any, original: any): void => {
+  if (!definition || !original) {
+    return;
+  }
+
+  definition.hostBindings = original.hostBindings;
+  definition.hostVars = original.hostVars;
+  definition.hostAttrs = original.hostAttrs && [...original.hostAttrs];
+  if (definition.data) {
+    const animation = original.data?.animation;
+    definition.data = {
+      ...definition.data,
+      animation: animation && [...animation],
+    };
+  }
+  definition.hostDirectives =
+    original.hostDirectives &&
+    original.hostDirectives.map((hostDirective: any) =>
+      typeof hostDirective === 'function'
+        ? hostDirective
+        : {
+            ...hostDirective,
+            inputs: { ...hostDirective.inputs },
+            outputs: { ...hostDirective.outputs },
+          },
+    );
+  definition.findHostDirectiveDefs = original.findHostDirectiveDefs;
+  definition.resolveHostDirectives = original.resolveHostDirectives;
+};
+
+export default (child: any, template: any): void => {
+  for (const key of ['ɵcmp', 'ɵdir']) {
+    const descriptor = Object.getOwnPropertyDescriptor(child, key);
+    if (!descriptor?.get) {
+      continue;
+    }
+    const getter = descriptor.get;
+    if (!descriptor.configurable) {
+      // Production-mode JIT getters cannot be replaced, even by TestBed.
+      inheritDefinition(getter.call(child), template[key]);
+      continue;
+    }
+
+    let lastDefinition: any;
+    let lastOriginal: any;
+    Object.defineProperty(child, key, {
+      ...descriptor,
+      get() {
+        const definition = getter.call(this);
+        const original = template[key];
+        if (definition !== lastDefinition || original !== lastOriginal) {
+          // TestBed can recompile the original after the middleware was reflected.
+          // Read its effective definition here so overrides also take effect once.
+          inheritDefinition(definition, original);
+          lastDefinition = definition;
+          lastOriginal = original;
+        }
+
+        return definition;
+      },
+    });
+  }
+};

--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.spec.ts
@@ -1,9 +1,15 @@
+import { trigger } from '@angular/animations';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
+  HostListener,
+  Inject,
   Input,
   input,
+  InjectionToken,
   reflectComponentType,
+  ViewEncapsulation,
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
@@ -12,6 +18,291 @@ import coreReflectDirectiveResolve from '../common/core.reflect.directive-resolv
 import funcReflectTemplate from './func.reflect-template';
 
 describe('funcReflectTemplate', () => {
+  it('inherits class host bindings once and preserves decorated listeners', () => {
+    @Component({
+      host: {
+        '(click)': 'clicks = clicks + 1',
+        role: 'button',
+      },
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {
+      public clicks = 0;
+      public focuses = 0;
+
+      @HostListener('focus')
+      public onFocus(): void {
+        this.focuses += 1;
+      }
+    }
+
+    const originalHost = {
+      ...coreReflectDirectiveResolve(TargetComponent).host,
+    };
+    const originalBindings = (TargetComponent as any).ɵcmp
+      .hostBindings;
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.callThrough();
+
+    funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    const fixture = TestBed.createComponent<TargetComponent>(child);
+    fixture.detectChanges();
+    fixture.nativeElement.dispatchEvent(new Event('click'));
+    fixture.nativeElement.dispatchEvent(new Event('focus'));
+
+    expect(fixture.componentInstance.clicks).toEqual(1);
+    expect(fixture.componentInstance.focuses).toEqual(1);
+    expect(fixture.nativeElement.getAttribute('role')).toBe('button');
+    expect(coreReflectDirectiveResolve(TargetComponent).host).toEqual(
+      originalHost,
+    );
+    expect((TargetComponent as any).ɵcmp.hostBindings).toBe(
+      originalBindings,
+    );
+  });
+
+  it('preserves an effective host override without reviving the original handler', async () => {
+    @Component({
+      host: {
+        '(click)': 'originalClicks = originalClicks + 1',
+        role: 'button',
+      },
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {
+      public originalClicks = 0;
+      public overrideClicks = 0;
+    }
+
+    const originalHost = {
+      ...coreReflectDirectiveResolve(TargetComponent).host,
+    };
+    const override = {
+      set: {
+        host: {
+          '(click)': 'overrideClicks = overrideClicks + 1',
+          role: 'presentation',
+        },
+      },
+    };
+    TestBed.configureTestingModule({
+      declarations: [TargetComponent],
+    });
+    TestBed.overrideComponent(TargetComponent, override);
+    await TestBed.compileComponents();
+    spyOn((TestBed as any).ngMocksOverrides, 'get').and.returnValue({
+      override,
+    });
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.callThrough();
+
+    funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    const fixture = TestBed.createComponent<TargetComponent>(child);
+    fixture.detectChanges();
+    fixture.nativeElement.dispatchEvent(new Event('click'));
+
+    expect(fixture.componentInstance.originalClicks).toEqual(0);
+    expect(fixture.componentInstance.overrideClicks).toEqual(1);
+    expect(fixture.nativeElement.getAttribute('role')).toBe(
+      'presentation',
+    );
+    expect(coreReflectDirectiveResolve(TargetComponent).host).toEqual(
+      originalHost,
+    );
+    expect(override.set.host).toEqual({
+      '(click)': 'overrideClicks = overrideClicks + 1',
+      role: 'presentation',
+    });
+  });
+
+  it('preserves inherited animation order without duplicating or mutating metadata', () => {
+    const inherited = trigger('inherited', []);
+    const own = trigger('own', []);
+
+    @Component({
+      animations: [inherited],
+      selector: 'base-reflect-template-animation',
+      standalone: false,
+      template: '',
+    })
+    class BaseComponent {}
+
+    @Component({
+      animations: [own],
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent extends BaseComponent {}
+
+    const originalAnimations = [
+      ...(TargetComponent as any).ɵcmp.data.animation,
+    ];
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.stub();
+
+    const template = funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    expect(originalAnimations).toEqual([own, inherited]);
+    expect(child.ɵcmp.data.animation).toEqual(originalAnimations);
+    expect(child.ɵcmp.data.animation[0]).toBe(own);
+    expect(child.ɵcmp.data.animation[1]).toBe(inherited);
+    expect((TargetComponent as any).ɵcmp.data.animation).toEqual(
+      originalAnimations,
+    );
+    expect(
+      coreReflectDirectiveResolve(TargetComponent).animations,
+    ).toEqual([own]);
+    expect(
+      coreReflectDirectiveResolve(BaseComponent).animations,
+    ).toEqual([inherited]);
+    expect((template as Component).animations).toEqual([own]);
+  });
+
+  it('preserves an effective animation override without adding original animations', async () => {
+    const original = trigger('original', []);
+    const replacement = trigger('replacement', []);
+
+    @Component({
+      animations: [original],
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {}
+
+    const originalMetadata =
+      coreReflectDirectiveResolve(TargetComponent);
+    const override = { set: { animations: [replacement] } };
+    TestBed.configureTestingModule({
+      declarations: [TargetComponent],
+    });
+    TestBed.overrideComponent(TargetComponent, override);
+    await TestBed.compileComponents();
+    spyOn((TestBed as any).ngMocksOverrides, 'get').and.returnValue({
+      override,
+    });
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.stub();
+
+    funcReflectTemplate(TargetComponent);
+
+    const child =
+      configure.calls.mostRecent().args[0].declarations![0];
+    expect(child.ɵcmp.data.animation).toEqual([replacement]);
+    expect(child.ɵcmp.data.animation[0]).toBe(replacement);
+    expect((TargetComponent as any).ɵcmp.data.animation).toEqual([
+      replacement,
+    ]);
+    expect(originalMetadata.animations).toEqual([original]);
+    expect(override.set.animations).toEqual([replacement]);
+  });
+
+  it('copies component metadata that Angular does not inherit', () => {
+    const provider = new InjectionToken<string>('provider');
+    const viewProvider = new InjectionToken<string>('view-provider');
+
+    @Directive({
+      host: { 'data-dependency': 'present' },
+      selector: '[dependency]',
+      standalone: true,
+    })
+    class DependencyDirective {}
+
+    @Component({
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      encapsulation: ViewEncapsulation.None,
+      exportAs: 'metadataTarget',
+      imports: [DependencyDirective],
+      preserveWhitespaces: true,
+      providers: [{ provide: provider, useValue: 'provider value' }],
+      standalone: true,
+      styles: ['span { color: rgb(1, 2, 3); }'],
+      template: '<span dependency>{{ value }}</span>',
+      viewProviders: [
+        { provide: viewProvider, useValue: 'view value' },
+      ],
+    })
+    class TargetComponent {
+      public value = 'rendered';
+
+      public constructor(
+        @Inject(provider) public readonly injected: string,
+        @Inject(viewProvider) public readonly viewInjected: string,
+      ) {}
+    }
+
+    const originalMetadata =
+      coreReflectDirectiveResolve(TargetComponent);
+    const originalProviders = [...(originalMetadata.providers || [])];
+    const originalViewProviders = [
+      ...(originalMetadata.viewProviders || []),
+    ];
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.callThrough();
+
+    funcReflectTemplate(TargetComponent);
+
+    const child = configure.calls.mostRecent().args[0]
+      .imports![0] as any;
+    const metadata = coreReflectDirectiveResolve(child);
+    const fixture = TestBed.createComponent<TargetComponent>(child);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toBe('rendered');
+    expect(
+      fixture.nativeElement.querySelector('span').dataset.dependency,
+    ).toBe('present');
+    expect(fixture.componentInstance.injected).toBe('provider value');
+    expect(fixture.componentInstance.viewInjected).toBe('view value');
+    expect(fixture.debugElement.injector.get(TargetComponent)).toBe(
+      fixture.componentInstance,
+    );
+    expect(metadata).toEqual(
+      jasmine.objectContaining({
+        changeDetection: ChangeDetectionStrategy.OnPush,
+        encapsulation: ViewEncapsulation.None,
+        exportAs: 'metadataTarget',
+        imports: [DependencyDirective],
+        preserveWhitespaces: true,
+        standalone: true,
+        styles: ['span { color: rgb(1, 2, 3); }'],
+        template: '<span dependency>{{ value }}</span>',
+        viewProviders: originalViewProviders,
+      }),
+    );
+    expect(metadata.providers).toEqual([
+      ...originalProviders,
+      { provide: TargetComponent, useExisting: child },
+    ]);
+    expect(child.ɵcmp.onPush).toBe(true);
+    expect(child.ɵcmp.encapsulation).toBe(ViewEncapsulation.None);
+    expect(child.ɵcmp.styles).toEqual(originalMetadata.styles);
+    expect(child.ɵcmp.exportAs).toEqual(['metadataTarget']);
+    expect(originalMetadata.providers).toEqual(originalProviders);
+    expect(originalMetadata.viewProviders).toEqual(
+      originalViewProviders,
+    );
+  });
+
   it('preserves signal inputs and ordinary input transforms on component clones', () => {
     @Component({
       standalone: false,

--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
@@ -9,6 +9,8 @@ import funcDirectiveIoParse from '../common/func.directive-io-parse';
 import { isNgDef } from '../common/func.is-ng-def';
 import { isStandalone } from '../common/func.is-standalone';
 
+import funcInheritDefinition from './func.inherit-definition';
+
 const registerTemplateMiddleware = (template: AnyType<any>, meta: Directive): void => {
   const child = extendClass(template);
 
@@ -53,6 +55,7 @@ const registerTemplateMiddleware = (template: AnyType<any>, meta: Directive): vo
       ...set,
     })(child);
   }
+  funcInheritDefinition(child, template);
   TestBed.configureTestingModule({
     [isStandalone(child) ? 'imports' : 'declarations']: [child],
   });

--- a/libs/ng-mocks/src/lib/mock/decorate-declaration.outputs.spec.ts
+++ b/libs/ng-mocks/src/lib/mock/decorate-declaration.outputs.spec.ts
@@ -1,0 +1,322 @@
+import { EventEmitter, isSignal, ViewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { extendClass } from '../common/core.helpers';
+import funcDirectiveIoParse from '../common/func.directive-io-parse';
+import { Mock } from '../common/mock';
+import collectDeclarations from '../resolve/collect-declarations';
+
+import decorateDeclaration from './decorate-declaration';
+
+describe('decorate-declaration:outputs', () => {
+  it('creates a usable mock when a declaration has no binding or query metadata', () => {
+    class TargetComponent {}
+
+    const mock = extendClass(Mock);
+    decorateDeclaration(TargetComponent, mock, {}, {});
+    const instance: any = new mock();
+    const reflected = collectDeclarations(mock);
+
+    expect(instance instanceof TargetComponent).toBe(true);
+    expect(instance.__ngMocksConfig.inputs).toBeUndefined();
+    expect(instance.__ngMocksConfig.outputs).toEqual([]);
+    expect(instance.__ngMocksConfig.queryScanKeys).toEqual([]);
+    expect(reflected.inputs).toEqual([]);
+    expect(reflected.outputs).toEqual([]);
+  });
+
+  it('separates model emitters from their signal inputs only on the mock', () => {
+    class TargetComponent {}
+
+    const mock = extendClass(Mock);
+    const outputs = ['value:valueChange', 'label:publicLabelChange'];
+    decorateDeclaration(
+      TargetComponent,
+      mock,
+      {
+        inputs: [
+          { name: 'value', isSignal: true },
+          { name: 'label', alias: 'publicLabel', isSignal: true },
+        ] as never,
+        outputs,
+        queries: {},
+      },
+      {},
+    );
+    const instance: any = TestBed.runInInjectionContext(
+      () => new mock(),
+    );
+    const reflected = collectDeclarations(mock);
+    const values: string[] = [];
+    const labels: string[] = [];
+
+    expect(isSignal(instance.value)).toBe(true);
+    expect(isSignal(instance.label)).toBe(true);
+    expect(instance.valueChange).toEqual(jasmine.any(EventEmitter));
+    expect(instance.publicLabelChange).toEqual(
+      jasmine.any(EventEmitter),
+    );
+    expect(reflected.outputs).toEqual([
+      'publicLabelChange',
+      'valueChange',
+    ]);
+    expect(outputs).toEqual([
+      'value:valueChange',
+      'label:publicLabelChange',
+    ]);
+
+    instance.valueChange.subscribe((value: string) =>
+      values.push(value),
+    );
+    instance.publicLabelChange.subscribe((value: string) =>
+      labels.push(value),
+    );
+    instance.valueChange.emit('value');
+    instance.publicLabelChange.emit('label');
+
+    expect(values).toEqual(['value']);
+    expect(labels).toEqual(['label']);
+    expect(isSignal(instance.value)).toBe(true);
+    expect(isSignal(instance.label)).toBe(true);
+  });
+
+  it('preserves ordinary property names when an input or output alias ends in Change', () => {
+    class TargetComponent {}
+
+    const mock = extendClass(Mock);
+    decorateDeclaration(
+      TargetComponent,
+      mock,
+      {
+        inputs: ['value:valueChange'],
+        outputs: ['selected:selectedChange'],
+        queries: {},
+      },
+      {},
+    );
+    const instance: any = new mock();
+    const reflected = collectDeclarations(mock);
+    const values: string[] = [];
+
+    expect(reflected.inputs).toEqual(['value:valueChange']);
+    expect(reflected.outputs).toEqual(['selected:selectedChange']);
+    expect(instance.selected).toEqual(jasmine.any(EventEmitter));
+    expect(instance.selectedChange).toBeUndefined();
+
+    instance.selected.subscribe((value: string) =>
+      values.push(value),
+    );
+    instance.selected.emit('selected');
+
+    expect(values).toEqual(['selected']);
+  });
+
+  it('reserves a distinct model emitter property when its public output collides with inputs', () => {
+    class TargetComponent {}
+
+    const mock = extendClass(Mock);
+    decorateDeclaration(
+      TargetComponent,
+      mock,
+      {
+        inputs: [
+          { name: 'valueChange', alias: 'value', isSignal: true },
+          '__ngMocksOutput_valueChange',
+        ] as never,
+        outputs: ['valueChange'],
+        queries: {},
+      },
+      {},
+    );
+    const instance: any = TestBed.runInInjectionContext(
+      () => new mock(),
+    );
+    const output = funcDirectiveIoParse(
+      instance.__ngMocksConfig.outputs[0],
+    );
+    const values: string[] = [];
+
+    expect(output.alias).toBe('valueChange');
+    expect(output.name).not.toBe('valueChange');
+    expect(output.name).not.toBe('__ngMocksOutput_valueChange');
+    expect(isSignal(instance.valueChange)).toBe(true);
+    expect(instance.__ngMocksOutput_valueChange).toBeUndefined();
+    expect(instance[output.name]).toEqual(jasmine.any(EventEmitter));
+
+    instance[output.name].subscribe((value: string) =>
+      values.push(value),
+    );
+    instance[output.name].emit('child');
+
+    expect(values).toEqual(['child']);
+    expect(isSignal(instance.valueChange)).toBe(true);
+  });
+
+  it('preserves query properties when a model output uses the same public name', () => {
+    class TargetComponent {}
+
+    const mock = extendClass(Mock);
+    decorateDeclaration(
+      TargetComponent,
+      mock,
+      {
+        inputs: [
+          { name: 'count', alias: 'quantity', isSignal: true },
+        ] as never,
+        outputs: ['count:quantityChange'],
+        queries: { quantityChange: new ViewChild('child') },
+      },
+      {},
+    );
+    const instance: any = TestBed.runInInjectionContext(
+      () => new mock(),
+    );
+    const output = funcDirectiveIoParse(
+      instance.__ngMocksConfig.outputs[0],
+    );
+    const query = {};
+    const values: number[] = [];
+    instance.quantityChange = query;
+
+    expect(output.alias).toBe('quantityChange');
+    expect(output.name).not.toBe('quantityChange');
+    expect(instance[output.name]).toEqual(jasmine.any(EventEmitter));
+    expect(
+      collectDeclarations(mock).queries.quantityChange.selector,
+    ).toBe('child');
+
+    instance[output.name].subscribe((value: number) =>
+      values.push(value),
+    );
+    instance[output.name].emit(2);
+
+    expect(values).toEqual([2]);
+    expect(instance.quantityChange).toBe(query);
+    expect(isSignal(instance.count)).toBe(true);
+  });
+
+  it('preserves inherited methods and accessors beside model outputs with matching public names', () => {
+    class ParentComponent {
+      public quantityChange(): string {
+        return 'real';
+      }
+
+      public get totalChange(): string {
+        return 'real';
+      }
+    }
+
+    class TargetComponent extends ParentComponent {}
+
+    const mock = extendClass(Mock);
+    decorateDeclaration(
+      TargetComponent,
+      mock,
+      {
+        inputs: [
+          { name: 'count', alias: 'quantity', isSignal: true },
+          { name: 'other', alias: 'total', isSignal: true },
+        ] as never,
+        outputs: ['count:quantityChange', 'other:totalChange'],
+        queries: {},
+      },
+      {},
+    );
+    const instance: any = TestBed.runInInjectionContext(
+      () => new mock(),
+    );
+    const quantityOutput = funcDirectiveIoParse(
+      instance.__ngMocksConfig.outputs[0],
+    );
+    const totalOutput = funcDirectiveIoParse(
+      instance.__ngMocksConfig.outputs[1],
+    );
+    const method = instance.quantityChange;
+    const accessor = Object.getOwnPropertyDescriptor(
+      instance,
+      'totalChange',
+    );
+    const values: number[] = [];
+
+    expect(quantityOutput.name).not.toBe('quantityChange');
+    expect(totalOutput.name).not.toBe('totalChange');
+    expect(typeof method).toBe('function');
+    expect(accessor?.get).toBeDefined();
+    expect(instance.totalChange).toBeUndefined();
+
+    instance[quantityOutput.name].subscribe((value: number) =>
+      values.push(value),
+    );
+    instance[totalOutput.name].subscribe((value: number) =>
+      values.push(value),
+    );
+    instance[quantityOutput.name].emit(2);
+    instance[totalOutput.name].emit(3);
+
+    expect(values).toEqual([2, 3]);
+    expect(instance.quantityChange).toBe(method);
+    expect(
+      Object.getOwnPropertyDescriptor(instance, 'totalChange')?.get,
+    ).toBe(accessor?.get);
+    expect(isSignal(instance.count)).toBe(true);
+    expect(isSignal(instance.other)).toBe(true);
+  });
+
+  it('preserves host binding and listener properties beside model outputs with matching public names', () => {
+    class TargetComponent {}
+
+    const mock = extendClass(Mock);
+    decorateDeclaration(
+      TargetComponent,
+      mock,
+      {
+        inputs: [
+          { name: 'count', alias: 'quantity', isSignal: true },
+          { name: 'other', alias: 'total', isSignal: true },
+        ] as never,
+        outputs: ['count:quantityChange', 'other:totalChange'],
+        queries: {},
+        hostBindings: [['quantityChange', 'attr.data-quantity']],
+        hostListeners: [['totalChange', 'click', []]],
+      },
+      {},
+    );
+    const instance: any = TestBed.runInInjectionContext(
+      () => new mock(),
+    );
+    const quantityOutput = funcDirectiveIoParse(
+      instance.__ngMocksConfig.outputs[0],
+    );
+    const totalOutput = funcDirectiveIoParse(
+      instance.__ngMocksConfig.outputs[1],
+    );
+    const binding = Object.getOwnPropertyDescriptor(
+      instance,
+      'quantityChange',
+    );
+    const listener = instance.totalChange;
+    const values: number[] = [];
+
+    expect(quantityOutput.name).not.toBe('quantityChange');
+    expect(totalOutput.name).not.toBe('totalChange');
+    expect(binding?.get).toBeDefined();
+    expect(binding?.set).toBeDefined();
+    expect(typeof listener).toBe('function');
+
+    instance[quantityOutput.name].subscribe((value: number) =>
+      values.push(value),
+    );
+    instance[totalOutput.name].subscribe((value: number) =>
+      values.push(value),
+    );
+    instance[quantityOutput.name].emit(2);
+    instance[totalOutput.name].emit(3);
+
+    expect(values).toEqual([2, 3]);
+    expect(
+      Object.getOwnPropertyDescriptor(instance, 'quantityChange')
+        ?.get,
+    ).toBe(binding?.get);
+    expect(instance.totalChange).toBe(listener);
+  });
+});

--- a/libs/ng-mocks/src/lib/mock/decorate-declaration.ts
+++ b/libs/ng-mocks/src/lib/mock/decorate-declaration.ts
@@ -6,6 +6,8 @@ import decorateInputs from '../common/decorate.inputs';
 import decorateMock from '../common/decorate.mock';
 import decorateOutputs from '../common/decorate.outputs';
 import decorateQueries from '../common/decorate.queries';
+import funcDirectiveIoBuild from '../common/func.directive-io-build';
+import funcDirectiveIoParse from '../common/func.directive-io-parse';
 import { ngMocksMockConfig } from '../common/mock';
 import ngMocksUniverse from '../common/ng-mocks-universe';
 import mockNgDef from '../mock-module/mock-ng-def';
@@ -31,6 +33,34 @@ const buildConfig = (
     queryScanKeys: [],
     setControlValueAccessor: setControlValueAccessor,
   };
+};
+
+const getMockOutputs = (inputs: DirectiveIo[] = [], outputs: DirectiveIo[] = [], reserved: string[]): DirectiveIo[] => {
+  const properties = new Set([...reserved, ...[...inputs, ...outputs].map(value => funcDirectiveIoParse(value).name)]);
+
+  return outputs.map(output => {
+    const { name, alias } = funcDirectiveIoParse(output);
+    const publicName = alias || name;
+    const model = inputs.some(input => {
+      const parsed = funcDirectiveIoParse(input);
+
+      return parsed.isSignal && parsed.name === name && `${parsed.alias || parsed.name}Change` === publicName;
+    });
+
+    if (!model) {
+      return output;
+    }
+
+    // A real model stores its input and output on one signal. Mock inputs use
+    // input signals, so only the mock needs a separate Change EventEmitter.
+    let property = publicName;
+    while (properties.has(property)) {
+      property = `__ngMocksOutput_${property}`;
+    }
+    properties.add(property);
+
+    return funcDirectiveIoBuild({ name: property, alias: publicName });
+  });
 };
 
 export default <T extends Component & Directive>(
@@ -100,11 +130,17 @@ export default <T extends Component & Directive>(
     options.viewProviders = viewProviders;
   }
 
+  const properties = [
+    ...Object.keys(meta.queries || {}),
+    ...(meta.hostBindings || []).map(([name]) => name),
+    ...(meta.hostListeners || []).map(([name]) => name),
+  ];
+  const methods = helperMockService.extractMethodsFromPrototype(source.prototype, properties);
+  const outputs = getMockOutputs(meta.inputs, meta.outputs, [...properties, ...methods]);
   const config: ngMocksMockConfig = buildConfig(
     source,
-    meta,
-    setControlValueAccessor ??
-      helperMockService.extractMethodsFromPrototype(source.prototype).indexOf('writeValue') !== -1,
+    { ...meta, outputs },
+    setControlValueAccessor ?? methods.indexOf('writeValue') !== -1,
   );
   decorateMock(mock, source, config);
 
@@ -112,7 +148,7 @@ export default <T extends Component & Directive>(
   if (meta.queries) {
     decorateInputs(mock, meta.inputs, Object.keys(meta.queries));
   }
-  decorateOutputs(mock, meta.outputs);
+  decorateOutputs(mock, outputs);
   config.queryScanKeys = decorateQueries(mock, meta.queries);
 
   config.hostBindings = [];

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.inputs.spec.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.inputs.spec.ts
@@ -1,0 +1,204 @@
+import funcGetGlobal from '../common/func.get-global';
+
+import collectDeclarations from './collect-declarations';
+
+describe('collect-declarations:inputs', () => {
+  afterEach(() => {
+    delete funcGetGlobal().__ngMocksReflectComponentType;
+  });
+
+  it('uses the effective compiled transform while retaining explicit required metadata', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = [
+      { name: 'value', required: true, transform: String },
+    ];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Component', inputs }],
+      ɵcmp: {
+        declaredInputs: { value: 'value' },
+        inputs: { value: ['value', 0, Number] },
+      },
+    });
+
+    expect(actual.Component.inputs).toEqual([
+      { name: 'value', required: true, transform: Number },
+    ]);
+    expect(actual.Component.inputs).not.toBe(inputs);
+    expect(inputs).toEqual([
+      { name: 'value', required: true, transform: String },
+    ]);
+  });
+
+  it('removes a class input transform when the effective compiled binding has none', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = [{ name: 'value', transform: String }];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Component', inputs }],
+      ɵcmp: {
+        declaredInputs: { value: 'value' },
+        inputs: { value: ['value', 0, null] },
+      },
+    });
+
+    expect(actual.Component.inputs).toEqual(['value']);
+    expect(actual.Component.inputs).not.toBe(inputs);
+    expect(inputs).toEqual([{ name: 'value', transform: String }]);
+  });
+
+  it('preserves legacy directive transforms stored by the compiled runtime field name', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = [
+      { name: 'value', alias: 'publicValue', transform: Number },
+    ];
+    const inputTransforms = { a: Number };
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Directive', inputs }],
+      ɵdir: {
+        declaredInputs: { publicValue: 'value' },
+        inputs: { publicValue: 'a' },
+        inputTransforms,
+      },
+    });
+
+    expect(actual.Directive.inputs).toEqual([
+      { name: 'value', alias: 'publicValue', transform: Number },
+    ]);
+    expect(actual.Directive.inputs).not.toBe(inputs);
+    expect(inputs).toEqual([
+      { name: 'value', alias: 'publicValue', transform: Number },
+    ]);
+    expect(inputTransforms).toEqual({ a: Number });
+  });
+
+  it('deduplicates formatted input aliases without modifying their annotation array', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = ['value : publicValue'];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Component', inputs }],
+      ɵcmp: {
+        declaredInputs: { publicValue: 'value' },
+        inputs: { publicValue: 'value' },
+      },
+    });
+
+    expect(actual.Component.inputs).toEqual(['value : publicValue']);
+    expect(actual.Component.inputs).not.toBe(inputs);
+    expect(inputs).toEqual(['value : publicValue']);
+  });
+
+  it('enriches existing input metadata with signal flags and transforms while preserving required', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = [
+      { name: 'value', alias: 'publicValue', required: true },
+    ];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Component', inputs }],
+      ɵcmp: {
+        declaredInputs: { publicValue: 'value' },
+        inputs: { publicValue: ['value', 1, String] },
+      },
+    });
+
+    expect(actual.Component.inputs).toEqual([
+      {
+        name: 'value',
+        alias: 'publicValue',
+        required: true,
+        isSignal: true,
+        transform: String,
+      },
+    ]);
+    expect(inputs).toEqual([
+      { name: 'value', alias: 'publicValue', required: true },
+    ]);
+  });
+
+  it('uses explicit class input names when an older compiler reports the alias as the declared name', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const actual = collectDeclarations({
+      __annotations__: [
+        {
+          ngMetadataName: 'Component',
+          inputs: ['value : publicValue'],
+        },
+      ],
+      ɵcmp: {
+        declaredInputs: { publicValue: 'publicValue' },
+        inputs: { publicValue: 'value' },
+      },
+    });
+
+    expect(actual.inputs).toEqual(['value:publicValue']);
+    expect(actual.Component.inputs).toEqual(['value : publicValue']);
+  });
+
+  it('prefers an effective compiled field over a stale class input annotation', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = ['original : publicValue'];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Component', inputs }],
+      ɵcmp: {
+        declaredInputs: { publicValue: 'effective' },
+        inputs: { publicValue: 'a' },
+      },
+    });
+
+    expect(actual.inputs).toEqual(['effective:publicValue']);
+    expect(actual.Component.inputs).toEqual([
+      'original : publicValue',
+      'effective:publicValue',
+    ]);
+    expect(inputs).toEqual(['original : publicValue']);
+  });
+
+  it('preserves an unaliased compiled override when the original annotation names another field', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = ['original : publicValue'];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Directive', inputs }],
+      ɵdir: {
+        declaredInputs: { publicValue: 'publicValue' },
+        inputs: { publicValue: 'publicValue' },
+      },
+    });
+
+    expect(actual.inputs).toEqual(['publicValue']);
+    expect(actual.Directive.inputs).toEqual([
+      'original : publicValue',
+      'publicValue',
+    ]);
+    expect(inputs).toEqual(['original : publicValue']);
+  });
+
+  it('uses the compiled field when declared input metadata is absent and the annotation is stale', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const inputs = ['original : publicValue'];
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Directive', inputs }],
+      ɵdir: {
+        inputs: { publicValue: 'effective' },
+      },
+    });
+
+    expect(actual.inputs).toEqual(['effective:publicValue']);
+    expect(actual.Directive.inputs).toEqual([
+      'original : publicValue',
+      'effective:publicValue',
+    ]);
+    expect(inputs).toEqual(['original : publicValue']);
+  });
+
+  it('retains declared input names when a minified field has no explicit class binding', () => {
+    funcGetGlobal().__ngMocksReflectComponentType = false;
+    const actual = collectDeclarations({
+      __annotations__: [{ ngMetadataName: 'Directive' }],
+      ɵdir: {
+        declaredInputs: { publicValue: 'value' },
+        inputs: { publicValue: 'a' },
+      },
+    });
+
+    expect(actual.inputs).toEqual(['value:publicValue']);
+    expect(actual.Directive.inputs).toEqual(['value:publicValue']);
+  });
+});

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.outputs.spec.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.outputs.spec.ts
@@ -1,0 +1,59 @@
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  Output,
+} from '@angular/core';
+
+import collectDeclarations from './collect-declarations';
+
+describe('collect-declarations:outputs', () => {
+  it('deduplicates formatted component aliases without mutating their annotation array', () => {
+    const outputs = ['declared : publicDeclared'];
+
+    @Component({
+      // eslint-disable-next-line @angular-eslint/no-outputs-metadata-property
+      outputs,
+      selector: 'target-output-metadata',
+      standalone: false,
+      template: '',
+    })
+    class TargetComponent {
+      public readonly declared = new EventEmitter<string>();
+      @Output() public readonly changed = new EventEmitter<string>();
+    }
+
+    const actual = collectDeclarations(TargetComponent);
+
+    expect(actual.Component.outputs).toEqual([
+      'declared : publicDeclared',
+      'changed',
+    ]);
+    expect(outputs).toEqual(['declared : publicDeclared']);
+  });
+
+  it('deduplicates formatted directive aliases and preserves distinct aliases of one property', () => {
+    const outputs = ['declared : first', 'declared : second'];
+
+    @Directive({
+      // eslint-disable-next-line @angular-eslint/no-outputs-metadata-property
+      outputs,
+      selector: '[targetOutputMetadata]',
+      standalone: false,
+    })
+    class TargetDirective {
+      public readonly declared = new EventEmitter<string>();
+    }
+
+    const actual = collectDeclarations(TargetDirective);
+
+    expect(actual.Directive.outputs).toEqual([
+      'declared : first',
+      'declared : second',
+    ]);
+    expect(outputs).toEqual([
+      'declared : first',
+      'declared : second',
+    ]);
+  });
+});

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
@@ -396,7 +396,7 @@ describe('collect-declarations', () => {
     expect(actual.inputs).toEqual([
       { name: 'value', isSignal: true, transform: String },
     ]);
-    expect(actual.outputs).toEqual(['valueChange']);
+    expect(actual.outputs).toEqual(['value:valueChange']);
     expect(actual.standalone).toBe(true);
     delete global.__ngMocksReflectComponentType;
   });
@@ -458,7 +458,7 @@ describe('collect-declarations', () => {
     });
 
     expect(actual.inputs).toEqual([]);
-    expect(actual.outputs).toEqual(['valueChange']);
+    expect(actual.outputs).toEqual(['value:valueChange']);
     delete global.__ngMocksReflectComponentType;
   });
 });

--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.ts
@@ -353,15 +353,31 @@ const parseNgDef = (
 
   for (const alias of Object.keys(ngDef.inputs || {})) {
     const input = ngDef.inputs[alias];
+    let annotatedInput: DirectiveIo | undefined;
+    for (const value of declaration.Component?.inputs ?? declaration.Directive?.inputs ?? []) {
+      const parsed = funcDirectiveIoParse(value);
+      if ((parsed.alias || parsed.name) === alias) {
+        annotatedInput = value;
+        break;
+      }
+    }
     const minifiedName = Array.isArray(input) ? input[0] : input;
     const flags = Array.isArray(input) && typeof input[1] === 'number' ? input[1] : 0;
-    const transform = Array.isArray(input) ? input[2] : undefined;
+    const transform = (Array.isArray(input) ? input[2] : undefined) ?? ngDef.inputTransforms?.[minifiedName];
     const {
       name,
       alias: normalizedAlias,
       required,
     } = funcDirectiveIoParse({
-      name: ngDef.declaredInputs?.[alias] ?? minifiedName,
+      // Older JIT compilers use the public alias as declaredInputs for class
+      // metadata arrays. Recover the field only when its annotation still
+      // matches the compiled binding, preserving effective TestBed overrides.
+      name:
+        annotatedInput &&
+        ngDef.declaredInputs?.[alias] === alias &&
+        funcDirectiveIoParse(annotatedInput).name === minifiedName
+          ? minifiedName
+          : (ngDef.declaredInputs?.[alias] ?? minifiedName),
       alias,
       required: undefined,
     });
@@ -542,16 +558,48 @@ const parsePropDecorators = (
 
 const buildDeclaration = (def: any | undefined, declaration: Declaration): void => {
   if (def) {
-    def.inputs = def.inputs || [];
+    def.inputs = [...(def.inputs || [])];
     for (const input of declaration.inputs) {
-      if (def.inputs.indexOf(input) === -1) {
+      const parsed = funcDirectiveIoParse(input);
+      let index = -1;
+      for (let position = 0; position < def.inputs.length; position += 1) {
+        const existing = funcDirectiveIoParse(def.inputs[position]);
+        if (existing.name === parsed.name && existing.alias === parsed.alias) {
+          index = position;
+          break;
+        }
+      }
+      if (index === -1) {
         def.inputs.push(input);
+      } else if (
+        parsed.required !== undefined ||
+        parsed.isSignal !== undefined ||
+        parsed.transform !== undefined ||
+        funcDirectiveIoParse(def.inputs[index]).transform !== undefined
+      ) {
+        const existing = funcDirectiveIoParse(def.inputs[index]);
+        def.inputs[index] = funcDirectiveIoBuild({
+          ...existing,
+          required: existing.required ?? parsed.required,
+          isSignal: existing.isSignal ?? parsed.isSignal,
+          // Reflected bindings follow property decorator precedence, including
+          // decorators that remove a transform declared in the class metadata.
+          transform: parsed.transform,
+        });
       }
     }
 
-    def.outputs = def.outputs || [];
+    // Reflection adds normalized aliases; keep the original annotation array
+    // isolated and compare bindings semantically so formatting cannot duplicate them.
+    def.outputs = [...(def.outputs || [])];
     for (const output of declaration.outputs) {
-      if (def.outputs.indexOf(output) === -1) {
+      const { name, alias } = funcDirectiveIoParse(output);
+      const existing = def.outputs.some((value: DirectiveIo) => {
+        const parsed = funcDirectiveIoParse(value);
+
+        return parsed.name === name && parsed.alias === alias;
+      });
+      if (!existing) {
         def.outputs.push(output);
       }
     }

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -101,5 +101,11 @@ file|tests/issue-11324/module-options.spec.ts|versions=20+
 file|tests/issue-2437/test.spec.ts|versions=14+
 file|examples/TestContentChild/static.spec.ts|versions=8+
 file|examples/TestContentChild/signals.spec.ts|features=signalQueries
+file|tests/mock-render-metadata/host-directives.spec.ts|features=hostDirectives
+file|tests/mock-render-metadata/static-queries.spec.ts|versions=8+
+file|tests/mock-render-metadata/input-transforms.spec.ts|versions=16+
+file|tests/mock-render-metadata/output-model.spec.ts|features=signalInputs,outputFn
+file|tests/mock-render-metadata/output-observable.spec.ts|features=outputFn
+file|tests/mock-render-metadata/query-signals.spec.ts|features=signalQueries
 file|tests/**
 file|examples/**

--- a/tests/mock-render-metadata/decorators.spec.ts
+++ b/tests/mock-render-metadata/decorators.spec.ts
@@ -1,0 +1,454 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ContentChild,
+  ContentChildren,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+  Output,
+  QueryList,
+  TemplateRef,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MockBuilder,
+  MockRender,
+  MockRenderFactory,
+  ngMocks,
+} from 'ng-mocks';
+
+@Directive({
+  selector: '[metadataParent]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ParentDirective {
+  @HostBinding('attr.data-inherited')
+  @Input('publicInherited')
+  public inherited = '';
+
+  @Output('publicInheritedChanged')
+  public readonly inheritedChanged = new EventEmitter<string>();
+
+  public readonly clicks: string[] = [];
+
+  @HostListener('click', ['$event.type'])
+  public onClick(type: string): void {
+    this.clicks.push(type);
+  }
+}
+
+@Component({
+  selector: 'metadata-component[first], metadata-component[second]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  inputs: ['declared: publicDeclared'],
+  outputs: ['declaredChanged: publicDeclaredChanged'],
+  host: {
+    'data-static': 'component',
+    '[attr.data-declared]': 'declared',
+    '(metadata-event)': 'metadataEvents.push($event.type)',
+  },
+  template: '{{ inherited }}:{{ own }}:{{ declared }}',
+})
+class TargetComponent extends ParentDirective {
+  @Input('publicOwn') public own = '';
+  @Output('publicOwnChanged')
+  public readonly ownChanged = new EventEmitter<string>();
+
+  @HostBinding('class.active') public active = true;
+
+  public readonly declaredAssignments: string[] = [];
+  public readonly declaredChanged = new EventEmitter<string>();
+  public readonly metadataEvents: string[] = [];
+  public readonly enters: string[] = [];
+
+  public get declared(): string {
+    return (
+      this.declaredAssignments[this.declaredAssignments.length - 1] ||
+      ''
+    );
+  }
+
+  public set declared(value: string) {
+    this.declaredAssignments.push(value);
+  }
+
+  @HostListener('mouseenter', ['$event.type'])
+  public onEnter(type: string): void {
+    this.enters.push(type);
+  }
+}
+
+@Directive({
+  selector: '[metadataFirst], [metadataSecond]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  inputs: ['declared: publicDeclared'],
+  outputs: ['declaredChanged: publicDeclaredChanged'],
+  host: {
+    'data-static': 'directive',
+    '[attr.data-declared]': 'declared',
+    '(metadata-event)': 'metadataEvents.push($event.type)',
+  },
+})
+class TargetDirective extends ParentDirective {
+  public declared = '';
+  public readonly declaredChanged = new EventEmitter<string>();
+  public readonly metadataEvents: string[] = [];
+}
+
+@Directive({
+  selector: '[metadataItem]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  exportAs: 'metadataItem',
+})
+class ItemDirective {
+  @Input() public metadataItem = '';
+}
+
+@Directive({
+  selector: '[metadataQueries]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class QueryParentDirective {
+  @ContentChild('projected', { read: ItemDirective } as never)
+  public contentChild?: ItemDirective;
+
+  @ContentChildren(ItemDirective, { descendants: true })
+  public contentChildren?: QueryList<ItemDirective>;
+}
+
+@Component({
+  selector: 'metadata-query[first], metadata-query[second]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: `
+    <span
+      *ngIf="visible"
+      metadataItem="view-first"
+      #view="metadataItem"
+    ></span>
+    <span metadataItem="view-second" #view="metadataItem"></span>
+    <ng-template #viewTemplate>view template</ng-template>
+    <ng-content></ng-content>
+  `,
+})
+class QueryComponent extends QueryParentDirective {
+  @Input() public visible = true;
+
+  @ContentChild('projected', { read: ElementRef } as never)
+  public contentElement?: ElementRef;
+
+  @ContentChild('projectedTemplate', {} as never)
+  public contentTemplate?: TemplateRef<any>;
+
+  @ViewChild('view', { read: ItemDirective } as never)
+  public viewChild?: ItemDirective;
+
+  @ViewChildren(ItemDirective)
+  public viewChildren?: QueryList<ItemDirective>;
+
+  @ViewChild('view', { read: ElementRef } as never)
+  public viewElement?: ElementRef;
+
+  @ViewChild('viewTemplate', {} as never)
+  public viewTemplate?: TemplateRef<any>;
+}
+
+// Complex selectors force MockRender to recompile a subclass under a synthetic
+// selector. Its metadata must retain behavior without registering it twice.
+describe('mock-render-metadata:decorators', () => {
+  beforeEach(() =>
+    MockBuilder([
+      CommonModule,
+      ParentDirective,
+      TargetComponent,
+      TargetDirective,
+      ItemDirective,
+      QueryParentDirective,
+      QueryComponent,
+    ]),
+  );
+
+  it('binds inherited, decorated and metadata-array aliases and emits each output once', () => {
+    const inheritedEvents: string[] = [];
+    const ownEvents: string[] = [];
+    const declaredEvents: string[] = [];
+    const fixture = MockRender(TargetComponent, {
+      publicInherited: 'inherited',
+      publicInheritedChanged: (value: string) =>
+        inheritedEvents.push(value),
+      publicOwn: 'own',
+      publicOwnChanged: (value: string) => ownEvents.push(value),
+      publicDeclared: 'declared',
+      publicDeclaredChanged: (value: string) =>
+        declaredEvents.push(value),
+    });
+    const target = fixture.point.componentInstance;
+
+    expect(target.inherited).toBe('inherited');
+    expect(target.own).toBe('own');
+    expect(target.declared).toBe('declared');
+    expect(target.declaredAssignments).toEqual(['declared']);
+    expect(ngMocks.formatText(fixture)).toBe(
+      'inherited:own:declared',
+    );
+    target.inheritedChanged.emit('inherited-first');
+    target.ownChanged.emit('own-first');
+    target.declaredChanged.emit('declared-first');
+
+    fixture.componentInstance.publicInherited = 'updated-inherited';
+    fixture.componentInstance.publicOwn = 'updated-own';
+    fixture.componentInstance.publicDeclared = 'updated-declared';
+    fixture.detectChanges();
+
+    expect(target.inherited).toBe('updated-inherited');
+    expect(target.own).toBe('updated-own');
+    expect(target.declared).toBe('updated-declared');
+    expect(target.declaredAssignments).toEqual([
+      'declared',
+      'updated-declared',
+    ]);
+    expect(ngMocks.formatText(fixture)).toBe(
+      'updated-inherited:updated-own:updated-declared',
+    );
+    target.inheritedChanged.emit('inherited-second');
+    target.ownChanged.emit('own-second');
+    target.declaredChanged.emit('declared-second');
+    expect(inheritedEvents).toEqual([
+      'inherited-first',
+      'inherited-second',
+    ]);
+    expect(ownEvents).toEqual(['own-first', 'own-second']);
+    expect(declaredEvents).toEqual([
+      'declared-first',
+      'declared-second',
+    ]);
+  });
+
+  it('preserves component host bindings and calls each inherited or own listener once', () => {
+    const fixture = MockRender(TargetComponent, {
+      publicInherited: 'inherited',
+      publicDeclared: 'declared',
+    });
+    const target = fixture.point.componentInstance;
+    const element = fixture.point.nativeElement;
+
+    expect(element.dataset.static).toBe('component');
+    expect(element.dataset.inherited).toBe('inherited');
+    expect(element.dataset.declared).toBe('declared');
+    expect(element.classList.contains('active')).toBe(true);
+
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+    fixture.point.triggerEventHandler('mouseenter', {
+      type: 'mouseenter',
+    });
+    fixture.point.triggerEventHandler('metadata-event', {
+      type: 'metadata-event',
+    });
+    expect(target.clicks).toEqual(['click']);
+    expect(target.enters).toEqual(['mouseenter']);
+    expect(target.metadataEvents).toEqual(['metadata-event']);
+
+    fixture.componentInstance.publicInherited = 'updated-inherited';
+    fixture.componentInstance.publicDeclared = 'updated-declared';
+    target.active = false;
+    fixture.detectChanges();
+
+    expect(element.dataset.inherited).toBe('updated-inherited');
+    expect(element.dataset.declared).toBe('updated-declared');
+    expect(element.classList.contains('active')).toBe(false);
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+    fixture.point.triggerEventHandler('mouseenter', {
+      type: 'mouseenter',
+    });
+    fixture.point.triggerEventHandler('metadata-event', {
+      type: 'metadata-event',
+    });
+    expect(target.clicks).toEqual(['click', 'click']);
+    expect(target.enters).toEqual(['mouseenter', 'mouseenter']);
+    expect(target.metadataEvents).toEqual([
+      'metadata-event',
+      'metadata-event',
+    ]);
+  });
+
+  it('preserves directive aliases, host metadata and inherited listeners', () => {
+    const inheritedEvents: string[] = [];
+    const declaredEvents: string[] = [];
+    const fixture = MockRender(TargetDirective, {
+      publicInherited: 'inherited',
+      publicInheritedChanged: (value: string) =>
+        inheritedEvents.push(value),
+      publicDeclared: 'declared',
+      publicDeclaredChanged: (value: string) =>
+        declaredEvents.push(value),
+    });
+    const target = fixture.point.componentInstance;
+    const element = fixture.point.nativeElement;
+
+    expect(target.inherited).toBe('inherited');
+    expect(target.declared).toBe('declared');
+    expect(element.dataset.static).toBe('directive');
+    expect(element.dataset.inherited).toBe('inherited');
+    expect(element.dataset.declared).toBe('declared');
+    target.inheritedChanged.emit('inherited-first');
+    target.declaredChanged.emit('declared-first');
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+    fixture.point.triggerEventHandler('metadata-event', {
+      type: 'metadata-event',
+    });
+
+    fixture.componentInstance.publicInherited = 'updated-inherited';
+    fixture.componentInstance.publicDeclared = 'updated-declared';
+    fixture.detectChanges();
+
+    expect(target.inherited).toBe('updated-inherited');
+    expect(target.declared).toBe('updated-declared');
+    expect(element.dataset.inherited).toBe('updated-inherited');
+    expect(element.dataset.declared).toBe('updated-declared');
+    target.inheritedChanged.emit('inherited-second');
+    target.declaredChanged.emit('declared-second');
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+    fixture.point.triggerEventHandler('metadata-event', {
+      type: 'metadata-event',
+    });
+    expect(inheritedEvents).toEqual([
+      'inherited-first',
+      'inherited-second',
+    ]);
+    expect(declaredEvents).toEqual([
+      'declared-first',
+      'declared-second',
+    ]);
+    expect(target.clicks).toEqual(['click', 'click']);
+    expect(target.metadataEvents).toEqual([
+      'metadata-event',
+      'metadata-event',
+    ]);
+  });
+
+  it('preserves inherited content queries and view queries, read tokens and dynamic collections', () => {
+    const factory = MockRenderFactory(QueryComponent, ['visible']);
+    factory.configureTestBed();
+    // Project content into the actual cloned selector generated by MockRender.
+    TestBed.overrideTemplate(
+      factory.declaration as never,
+      (factory.declaration as any).tpl.replace(
+        '</',
+        `<span *ngIf="visible" metadataItem="content-first" #projected="metadataItem"></span>
+         <div><span metadataItem="content-second" #projected="metadataItem"></span></div>
+         <ng-template #projectedTemplate>content template</ng-template></`,
+      ),
+    );
+    const fixture = factory({ visible: true });
+    const target = fixture.point.componentInstance;
+    const firstContent = ngMocks.findInstance(
+      '[metadataItem="content-first"]',
+      ItemDirective,
+    );
+    const secondContent = ngMocks.findInstance(
+      '[metadataItem="content-second"]',
+      ItemDirective,
+    );
+    const firstView = ngMocks.findInstance(
+      '[metadataItem="view-first"]',
+      ItemDirective,
+    );
+    const secondView = ngMocks.findInstance(
+      '[metadataItem="view-second"]',
+      ItemDirective,
+    );
+
+    expect(target.contentChild).toBe(firstContent);
+    expect(target.viewChild).toBe(firstView);
+    expect(
+      target.contentElement && target.contentElement.nativeElement,
+    ).toBe(
+      ngMocks.find('[metadataItem="content-first"]').nativeElement,
+    );
+    expect(
+      target.viewElement && target.viewElement.nativeElement,
+    ).toBe(ngMocks.find('[metadataItem="view-first"]').nativeElement);
+    expect(
+      target.contentTemplate &&
+        target.contentTemplate.elementRef.nativeElement,
+    ).toBe(
+      ngMocks.findTemplateRef('projectedTemplate').elementRef
+        .nativeElement,
+    );
+    expect(
+      target.viewTemplate &&
+        target.viewTemplate.elementRef.nativeElement,
+    ).toBe(
+      ngMocks.findTemplateRef('viewTemplate').elementRef
+        .nativeElement,
+    );
+    if (!target.contentChildren || !target.viewChildren) {
+      throw new Error(
+        'ContentChildren and ViewChildren were not initialized',
+      );
+    }
+    expect(target.contentChildren.toArray()).toEqual([
+      firstContent,
+      secondContent,
+    ]);
+    expect(target.viewChildren.toArray()).toEqual([
+      firstView,
+      secondView,
+    ]);
+    const contentChanges: number[] = [];
+    const viewChanges: number[] = [];
+    const contentSubscription =
+      target.contentChildren.changes.subscribe(
+        (children: QueryList<ItemDirective>) =>
+          contentChanges.push(children.length),
+      );
+    const viewSubscription = target.viewChildren.changes.subscribe(
+      (children: QueryList<ItemDirective>) =>
+        viewChanges.push(children.length),
+    );
+
+    fixture.componentInstance.visible = false;
+    fixture.detectChanges();
+
+    expect(target.contentChild).toBe(secondContent);
+    expect(target.viewChild).toBe(secondView);
+    expect(target.contentChildren.toArray()).toEqual([secondContent]);
+    expect(target.viewChildren.toArray()).toEqual([secondView]);
+    expect(contentChanges).toEqual([1]);
+    expect(viewChanges).toEqual([1]);
+
+    fixture.componentInstance.visible = true;
+    fixture.detectChanges();
+    const insertedContent = ngMocks.findInstance(
+      '[metadataItem="content-first"]',
+      ItemDirective,
+    );
+    const insertedView = ngMocks.findInstance(
+      '[metadataItem="view-first"]',
+      ItemDirective,
+    );
+
+    expect(insertedContent).not.toBe(firstContent);
+    expect(insertedView).not.toBe(firstView);
+    expect(target.contentChild).toBe(insertedContent);
+    expect(target.viewChild).toBe(insertedView);
+    expect(target.contentChildren.toArray()).toEqual([
+      insertedContent,
+      secondContent,
+    ]);
+    expect(target.viewChildren.toArray()).toEqual([
+      insertedView,
+      secondView,
+    ]);
+    expect(contentChanges).toEqual([1, 2]);
+    expect(viewChanges).toEqual([1, 2]);
+    contentSubscription.unsubscribe();
+    viewSubscription.unsubscribe();
+  });
+});

--- a/tests/mock-render-metadata/host-directives.spec.ts
+++ b/tests/mock-render-metadata/host-directives.spec.ts
@@ -1,0 +1,75 @@
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Directive({
+  selector: '[metadataHost]',
+  standalone: true,
+})
+class HostDirective {
+  @HostBinding('attr.data-value')
+  @Input()
+  public value = 'default';
+
+  @Output() public readonly changed = new EventEmitter<string>();
+
+  @HostListener('click')
+  public click(): void {
+    this.changed.emit(this.value);
+  }
+}
+
+@Component({
+  hostDirectives: [
+    {
+      directive: HostDirective,
+      inputs: ['value: publicValue'],
+      outputs: ['changed: publicChanged'],
+    },
+  ],
+  selector: 'metadata-host[first], metadata-host[second]',
+  standalone: true,
+  template: '',
+})
+class TargetComponent {}
+
+describe('mock-render-metadata:host-directives', () => {
+  beforeEach(() => MockBuilder([TargetComponent, HostDirective]));
+
+  it('registers inherited host directives once and preserves exposed bindings', () => {
+    const changed =
+      typeof jest === 'undefined' ? jasmine.createSpy() : jest.fn();
+    const fixture = MockRender(TargetComponent, {
+      publicChanged: changed,
+      publicValue: 'initial',
+    });
+    const directive = ngMocks.findInstance(HostDirective);
+
+    expect(ngMocks.findInstances(HostDirective)).toEqual([directive]);
+    expect(directive.value).toEqual('initial');
+    expect(fixture.point.nativeElement.dataset.value).toEqual(
+      'initial',
+    );
+    ngMocks.trigger(fixture.point, 'click');
+    expect(changed).toHaveBeenCalledTimes(1);
+    expect(changed).toHaveBeenCalledWith('initial');
+
+    fixture.componentInstance.publicValue = 'updated';
+    fixture.detectChanges();
+    expect(directive.value).toEqual('updated');
+    expect(fixture.point.nativeElement.dataset.value).toEqual(
+      'updated',
+    );
+    ngMocks.trigger(fixture.point, 'click');
+    expect(changed).toHaveBeenCalledTimes(2);
+    expect(changed).toHaveBeenCalledWith('updated');
+  });
+});

--- a/tests/mock-render-metadata/injection.spec.ts
+++ b/tests/mock-render-metadata/injection.spec.ts
@@ -1,0 +1,60 @@
+import {
+  Attribute,
+  Component,
+  Host,
+  Inject,
+  InjectionToken,
+  Optional,
+  Self,
+  SkipSelf,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
+
+const TOKEN = new InjectionToken<string>('metadata-token');
+const MISSING = new InjectionToken<string>('metadata-missing');
+const VIEW = new InjectionToken<string>('metadata-view');
+
+@Component({
+  providers: [{ provide: TOKEN, useValue: 'local' }],
+  viewProviders: [{ provide: VIEW, useValue: 'view' }],
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ local }}:{{ parent }}:{{ view }}',
+})
+class TargetComponent {
+  public constructor(
+    @Self() @Inject(TOKEN) public readonly local: string,
+    @SkipSelf() @Inject(TOKEN) public readonly parent: string,
+    @Host() @Inject(VIEW) public readonly view: string,
+    @Optional()
+    @Self()
+    @Inject(MISSING)
+    public readonly missing: string | null,
+    @Attribute('data-absent') public readonly absent: string,
+  ) {}
+}
+
+describe('mock-render-metadata:injection', () => {
+  beforeEach(() => MockBuilder(TargetComponent));
+
+  it('retains constructor tokens, lookup flags, providers and view providers on selectorless clones', () => {
+    const factory = MockRenderFactory(TargetComponent, []);
+    factory.configureTestBed();
+    // MockRender's providers option also supplies the rendered element. Set a
+    // provider on the wrapper alone to distinguish Self from SkipSelf lookup.
+    TestBed.overrideComponent(factory.declaration as never, {
+      set: { providers: [{ provide: TOKEN, useValue: 'parent' }] },
+    });
+    const fixture = factory();
+    const target = fixture.point.componentInstance;
+
+    expect(target.local).toEqual('local');
+    expect(target.parent).toEqual('parent');
+    expect(target.view).toEqual('view');
+    expect(target.missing).toBeNull();
+    expect(target.absent).toBeNull();
+    expect(ngMocks.formatText(fixture)).toEqual('local:parent:view');
+    expect(ngMocks.findInstance(TargetComponent)).toBe(target);
+  });
+});

--- a/tests/mock-render-metadata/input-transforms.spec.ts
+++ b/tests/mock-render-metadata/input-transforms.spec.ts
@@ -1,0 +1,184 @@
+import { Component, Directive, Input } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  isMockOf,
+  MockBuilder,
+  MockComponent,
+  MockDirective,
+  MockRender,
+  ngMocks,
+} from 'ng-mocks';
+
+const componentInputs = [{ name: 'value', transform: String }];
+const directiveInputs = [
+  { name: 'value', alias: 'publicValue', transform: Number },
+];
+
+@Component({
+  selector: 'target-metadata-transform[value]',
+  standalone: true,
+  inputs: componentInputs,
+  template: '{{ value }}',
+})
+class TargetComponent {
+  @Input({ transform: Number }) public value: number | string = 0;
+}
+
+@Component({
+  selector: 'target-metadata-no-transform[value]',
+  standalone: true,
+  inputs: componentInputs,
+  template: '{{ value }}',
+})
+class UntransformedComponent {
+  @Input() public value: number | string = 0;
+}
+
+@Directive({
+  selector: '[metadataTransformedValue]',
+  standalone: true,
+  inputs: directiveInputs,
+})
+class TargetDirective {
+  public value: number | string = 0;
+}
+
+// Input transforms are available from Angular 16.1. Property decorators take
+// precedence over the same input declared in the component metadata array.
+describe('mock-render-metadata:input-transforms', () => {
+  it('keeps the effective property transform on a real complex-selector clone', async () => {
+    await MockBuilder(TargetComponent);
+    const fixture = MockRender(TargetComponent, { value: '4' });
+    const target = fixture.point.componentInstance;
+
+    expect(isMockOf(target, TargetComponent)).toBe(false);
+    expect(target.value).toBe(4);
+    expect(typeof target.value).toBe('number');
+    expect(fixture.nativeElement.textContent).toContain('4');
+
+    fixture.componentRef.setInput('value', '8');
+    fixture.detectChanges();
+
+    expect(target.value).toBe(8);
+    expect(typeof target.value).toBe('number');
+    expect(fixture.nativeElement.textContent).toContain('8');
+    expect(componentInputs).toEqual([
+      { name: 'value', transform: String },
+    ]);
+  });
+
+  it('keeps the effective property transform when creating a MockComponent', async () => {
+    const mock = MockComponent(TargetComponent);
+    await TestBed.configureTestingModule({
+      imports: [mock],
+    }).compileComponents();
+    const fixture = MockRender(
+      '<target-metadata-transform [value]="value"></target-metadata-transform>',
+      { value: '4' },
+    );
+    const target = ngMocks.findInstance(TargetComponent);
+
+    expect(isMockOf(target, TargetComponent)).toBe(true);
+    expect(target.value).toBe(4);
+    expect(typeof target.value).toBe('number');
+
+    fixture.componentInstance.value = '8';
+    fixture.detectChanges();
+
+    expect(target.value).toBe(8);
+    expect(typeof target.value).toBe('number');
+    expect(componentInputs).toEqual([
+      { name: 'value', transform: String },
+    ]);
+  });
+
+  it('clears the class-array transform when a real cloned property has no transform', async () => {
+    await MockBuilder(UntransformedComponent);
+    const fixture = MockRender(UntransformedComponent, { value: 4 });
+    const target = fixture.point.componentInstance;
+
+    expect(isMockOf(target, UntransformedComponent)).toBe(false);
+    expect(target.value).toBe(4);
+    expect(typeof target.value).toBe('number');
+
+    fixture.componentRef.setInput('value', 8);
+    fixture.detectChanges();
+
+    expect(target.value).toBe(8);
+    expect(typeof target.value).toBe('number');
+    expect(fixture.nativeElement.textContent).toContain('8');
+    expect(componentInputs).toEqual([
+      { name: 'value', transform: String },
+    ]);
+  });
+
+  it('clears the class-array transform when a mocked property has no transform', async () => {
+    const mock = MockComponent(UntransformedComponent);
+    await TestBed.configureTestingModule({
+      imports: [mock],
+    }).compileComponents();
+    const fixture = MockRender(
+      '<target-metadata-no-transform [value]="value"></target-metadata-no-transform>',
+      { value: 4 },
+    );
+    const target = ngMocks.findInstance(UntransformedComponent);
+
+    expect(isMockOf(target, UntransformedComponent)).toBe(true);
+    expect(target.value).toBe(4);
+    expect(typeof target.value).toBe('number');
+
+    fixture.componentInstance.value = 8;
+    fixture.detectChanges();
+
+    expect(target.value).toBe(8);
+    expect(typeof target.value).toBe('number');
+    expect(componentInputs).toEqual([
+      { name: 'value', transform: String },
+    ]);
+  });
+
+  it('preserves a class-array-only transform on a real directive clone', async () => {
+    await MockBuilder(TargetDirective);
+    const fixture = MockRender(TargetDirective, { publicValue: '4' });
+    const target = fixture.point.componentInstance;
+
+    expect(isMockOf(target, TargetDirective)).toBe(false);
+    expect(target.value).toBe(4);
+    expect(typeof target.value).toBe('number');
+
+    fixture.componentRef.setInput('publicValue', '8');
+    fixture.detectChanges();
+
+    expect(target.value).toBe(8);
+    expect(typeof target.value).toBe('number');
+    expect(directiveInputs).toEqual([
+      { name: 'value', alias: 'publicValue', transform: Number },
+    ]);
+  });
+
+  it('preserves a class-array-only transform when creating a MockDirective', async () => {
+    const mock = MockDirective(TargetDirective);
+    await TestBed.configureTestingModule({
+      imports: [mock],
+    }).compileComponents();
+    const fixture = MockRender(
+      '<span metadataTransformedValue [publicValue]="value"></span>',
+      { value: '4' },
+    );
+    const target = ngMocks.findInstance(TargetDirective);
+
+    expect(isMockOf(target, TargetDirective)).toBe(true);
+    expect(target.value).toBe(4);
+    expect(typeof target.value).toBe('number');
+
+    fixture.componentInstance.value = '8';
+    fixture.detectChanges();
+
+    expect(target.value).toBe(8);
+    expect(typeof target.value).toBe('number');
+    expect(directiveInputs).toEqual([
+      { name: 'value', alias: 'publicValue', transform: Number },
+    ]);
+  });
+});

--- a/tests/mock-render-metadata/output-model.spec.ts
+++ b/tests/mock-render-metadata/output-model.spec.ts
@@ -1,0 +1,406 @@
+import {
+  Component,
+  ElementRef,
+  isSignal,
+  model,
+  output,
+  reflectComponentType,
+  ViewChild,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  isMockOf,
+  MockBuilder,
+  MockComponent,
+  MockRender,
+  ngMocks,
+} from 'ng-mocks';
+
+@Component({
+  selector: 'target-metadata-model[requiredLabel]',
+  standalone: true,
+  template: '{{ label() }}:{{ count() }}',
+})
+class TargetComponent {
+  public readonly label = model.required<string>({
+    alias: 'requiredLabel',
+  });
+  public readonly count = model(3, { alias: 'quantity' });
+  public readonly changed = output<string>();
+  public readonly selected = output<string>({ alias: 'chosen' });
+}
+
+@Component({
+  standalone: true,
+  template: '{{ value() }}',
+})
+class SelectorlessComponent {
+  public readonly value = model('default-value');
+}
+
+@Component({
+  selector: 'target-metadata-first, target-metadata-second',
+  standalone: true,
+  template: '{{ value() }}',
+})
+class MultipleSelectorsComponent {
+  public readonly value = model.required<string>();
+  public readonly changed = output<string>({ alias: 'updated' });
+}
+
+@Component({
+  selector: 'target-metadata-collision',
+  standalone: true,
+  template: '{{ valueChange() }}',
+})
+class CollisionComponent {
+  public readonly valueChange = model(0, { alias: 'value' });
+}
+
+@Component({
+  selector: 'target-metadata-model-query',
+  standalone: true,
+  template: '<span #child>query</span>',
+})
+class QueryModelComponent {
+  public readonly count = model(0, { alias: 'quantity' });
+  @ViewChild('child') public quantityChange?: ElementRef;
+}
+
+@Component({
+  selector: 'target-metadata-model-method',
+  standalone: true,
+  template: '',
+})
+class MethodModelComponent {
+  public readonly count = model(0, { alias: 'quantity' });
+
+  public quantityChange(): string {
+    return 'real';
+  }
+}
+
+describe('mock-render-metadata:output-model', () => {
+  // The root TypeScript-only runner does not transform authoring functions.
+  // Angular-compiled spread targets exercise model and output from Angular 17.3.
+  if (
+    !reflectComponentType(TargetComponent)?.outputs.some(
+      metadata => metadata.propName === 'selected',
+    )
+  ) {
+    it('needs compiled model and output metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() =>
+    MockBuilder([
+      TargetComponent,
+      SelectorlessComponent,
+      MultipleSelectorsComponent,
+    ]),
+  );
+
+  it('binds aliased models and subscribes once to each output through a complex selector', () => {
+    const changed: string[] = [];
+    const chosen: string[] = [];
+    const labels: string[] = [];
+    const quantities: number[] = [];
+    const fixture = MockRender(TargetComponent, {
+      changed: (value: string) => changed.push(value),
+      chosen: (value: string) => chosen.push(value),
+      quantity: 4,
+      quantityChange: (value: number) => quantities.push(value),
+      requiredLabel: 'initial',
+      requiredLabelChange: (value: string) => labels.push(value),
+    });
+    const target = fixture.point.componentInstance;
+    const label = target.label;
+    const count = target.count;
+
+    expect(isSignal(label)).toBe(true);
+    expect(isSignal(count)).toBe(true);
+    expect(label()).toEqual('initial');
+    expect(count()).toEqual(4);
+    expect(fixture.nativeElement.textContent).toContain('initial:4');
+    expect(labels).toEqual([]);
+    expect(quantities).toEqual([]);
+
+    target.changed.emit('changed');
+    target.selected.emit('chosen');
+    label.set('child');
+    count.update(value => value + 1);
+
+    expect(changed).toEqual(['changed']);
+    expect(chosen).toEqual(['chosen']);
+    expect(labels).toEqual(['child']);
+    expect(quantities).toEqual([5]);
+
+    // A repeated model value must not emit, and parent writes are inputs only.
+    label.set('child');
+    count.set(5);
+    fixture.componentRef.setInput('requiredLabel', 'parent');
+    fixture.componentRef.setInput('quantity', 8);
+    fixture.detectChanges();
+
+    expect(target.label).toBe(label);
+    expect(target.count).toBe(count);
+    expect(label()).toEqual('parent');
+    expect(count()).toEqual(8);
+    expect(fixture.nativeElement.textContent).toContain('parent:8');
+    expect(labels).toEqual(['child']);
+    expect(quantities).toEqual([5]);
+
+    target.changed.emit('again');
+    target.selected.emit('again');
+    expect(changed).toEqual(['changed', 'again']);
+    expect(chosen).toEqual(['chosen', 'again']);
+  });
+
+  it('retains an unbound selectorless model default with empty params', () => {
+    const fixture = MockRender(SelectorlessComponent, {});
+    const value = fixture.point.componentInstance.value;
+
+    expect(isSignal(value)).toBe(true);
+    expect(value()).toEqual('default-value');
+    expect(fixture.nativeElement.textContent).toContain(
+      'default-value',
+    );
+
+    value.update(current => `${current}-updated`);
+    fixture.detectChanges();
+
+    expect(fixture.point.componentInstance.value).toBe(value);
+    expect(value()).toEqual('default-value-updated');
+    expect(fixture.nativeElement.textContent).toContain(
+      'default-value-updated',
+    );
+  });
+
+  it('retains a selectorless model default without params and accepts later wrapper writes', () => {
+    const fixture = MockRender(SelectorlessComponent);
+    const value = fixture.point.componentInstance.value;
+
+    expect(isSignal(value)).toBe(true);
+    expect(value()).toEqual('default-value');
+    expect(fixture.nativeElement.textContent).toContain(
+      'default-value',
+    );
+
+    fixture.componentInstance.value = 'parent';
+    fixture.detectChanges();
+
+    expect(fixture.point.componentInstance.value).toBe(value);
+    expect(value()).toEqual('parent');
+    expect(fixture.nativeElement.textContent).toContain('parent');
+  });
+
+  it('retains model input and implicit output metadata through multiple selectors', () => {
+    const values: string[] = [];
+    const updated: string[] = [];
+    const fixture = MockRender(MultipleSelectorsComponent, {
+      updated: (value: string) => updated.push(value),
+      value: 'initial',
+      valueChange: (value: string) => values.push(value),
+    });
+    const target = fixture.point.componentInstance;
+    const value = target.value;
+
+    expect(isSignal(value)).toBe(true);
+    expect(value()).toEqual('initial');
+    expect(values).toEqual([]);
+
+    value.set('child');
+    target.changed.emit('selected');
+    fixture.detectChanges();
+
+    expect(target.value).toBe(value);
+    expect(value()).toEqual('child');
+    expect(fixture.nativeElement.textContent).toContain('child');
+    expect(values).toEqual(['child']);
+    expect(updated).toEqual(['selected']);
+  });
+
+  it('keeps aliased model inputs callable and provides separate output emitters on a mock', async () => {
+    TestBed.resetTestingModule();
+    await MockBuilder().mock(TargetComponent);
+    const labels: string[] = [];
+    const quantities: number[] = [];
+    const changed: string[] = [];
+    const chosen: string[] = [];
+    const fixture = MockRender(
+      `<target-metadata-model
+        [requiredLabel]="label"
+        [quantity]="quantity"
+        (requiredLabelChange)="labels.push($event)"
+        (quantityChange)="quantities.push($event)"
+        (changed)="changed.push($event)"
+        (chosen)="chosen.push($event)"
+      ></target-metadata-model>`,
+      {
+        label: 'initial',
+        quantity: 4,
+        labels,
+        quantities,
+        changed,
+        chosen,
+      },
+    );
+    const targetElement = ngMocks.find(TargetComponent);
+    const target = targetElement.componentInstance;
+    const label = target.label;
+    const count = target.count;
+
+    expect(isMockOf(target, TargetComponent)).toBe(true);
+    expect(isSignal(label)).toBe(true);
+    expect(isSignal(count)).toBe(true);
+    expect(label()).toEqual('initial');
+    expect(count()).toEqual(4);
+
+    ngMocks
+      .output(targetElement, 'requiredLabelChange')
+      .emit('child');
+    ngMocks.output(targetElement, 'quantityChange').emit(5);
+    target.changed.emit('changed');
+    target.selected.emit('chosen');
+
+    expect(labels).toEqual(['child']);
+    expect(quantities).toEqual([5]);
+    expect(changed).toEqual(['changed']);
+    expect(chosen).toEqual(['chosen']);
+
+    fixture.componentInstance.label = 'parent';
+    fixture.componentInstance.quantity = 8;
+    fixture.detectChanges();
+
+    expect(target.label).toBe(label);
+    expect(target.count).toBe(count);
+    expect(label()).toEqual('parent');
+    expect(count()).toEqual(8);
+    expect(labels).toEqual(['child']);
+    expect(quantities).toEqual([5]);
+  });
+
+  it('renders a real model whose public output name is also its signal property name', async () => {
+    TestBed.resetTestingModule();
+    await MockBuilder(CollisionComponent);
+    const changes: number[] = [];
+    const fixture = MockRender(CollisionComponent, {
+      value: 1,
+      valueChange: (value: number) => changes.push(value),
+    });
+    const value = fixture.point.componentInstance.valueChange;
+
+    expect(isSignal(value)).toBe(true);
+    expect(value()).toBe(1);
+
+    value.set(2);
+    fixture.detectChanges();
+
+    expect(changes).toEqual([2]);
+    expect(fixture.point.componentInstance.valueChange).toBe(value);
+    expect(fixture.nativeElement.textContent).toContain('2');
+  });
+
+  it('mocks a model with a colliding public output name without replacing its input signal', async () => {
+    TestBed.resetTestingModule();
+    await MockBuilder().mock(CollisionComponent);
+    const changes: number[] = [];
+    const fixture = MockRender(
+      `<target-metadata-collision
+        [value]="value"
+        (valueChange)="value = $event; changes.push($event)"
+      ></target-metadata-collision>`,
+      { value: 1, changes },
+    );
+    const target = ngMocks.find(CollisionComponent);
+    const value = target.componentInstance.valueChange;
+    const emitter = ngMocks.output(target, 'valueChange');
+
+    expect(
+      isMockOf(target.componentInstance, CollisionComponent),
+    ).toBe(true);
+    expect(isSignal(value)).toBe(true);
+    expect(value()).toBe(1);
+    expect(emitter).not.toBe(value as never);
+
+    emitter.emit(2);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.value).toBe(2);
+    expect(value()).toBe(2);
+    expect(changes).toEqual([2]);
+
+    fixture.componentInstance.value = 3;
+    fixture.detectChanges();
+
+    expect(target.componentInstance.valueChange).toBe(value);
+    expect(value()).toBe(3);
+    expect(changes).toEqual([2]);
+  });
+
+  it('keeps a view query separate from a model output with the same public name on a mock', async () => {
+    TestBed.resetTestingModule();
+    const mock = MockComponent(QueryModelComponent);
+    TestBed.configureTestingModule({ imports: [mock] });
+    TestBed.overrideTemplate(mock, '<span #child>query</span>');
+    await TestBed.compileComponents();
+    const changes: number[] = [];
+    const fixture = MockRender(
+      `<target-metadata-model-query
+        [quantity]="quantity"
+        (quantityChange)="changes.push($event)"
+      ></target-metadata-model-query>`,
+      { quantity: 1, changes },
+    );
+    const target = ngMocks.find(QueryModelComponent);
+    const query = target.componentInstance.quantityChange;
+    const emitter = ngMocks.output(target, 'quantityChange');
+
+    expect(query?.nativeElement).toBe(
+      ngMocks.find('span').nativeElement,
+    );
+    expect(emitter).not.toBe(query as never);
+
+    emitter.emit(2);
+    fixture.componentInstance.quantity = 3;
+    fixture.detectChanges();
+
+    expect(changes).toEqual([2]);
+    expect(target.componentInstance.count()).toBe(3);
+    expect(target.componentInstance.quantityChange).toBe(query);
+  });
+
+  it('keeps a method callable beside a model output with the same public name on a mock', async () => {
+    TestBed.resetTestingModule();
+    await MockBuilder().mock(MethodModelComponent);
+    const changes: number[] = [];
+    const fixture = MockRender(
+      `<target-metadata-model-method
+        [quantity]="quantity"
+        (quantityChange)="changes.push($event)"
+      ></target-metadata-model-method>`,
+      { quantity: 1, changes },
+    );
+    const target = ngMocks.find(MethodModelComponent);
+    const method = target.componentInstance.quantityChange;
+    const emitter = ngMocks.output(target, 'quantityChange');
+
+    expect(typeof method).toBe('function');
+    expect(emitter).not.toBe(method as never);
+    expect(() =>
+      target.componentInstance.quantityChange(),
+    ).not.toThrow();
+
+    emitter.emit(2);
+    fixture.componentInstance.quantity = 3;
+    fixture.detectChanges();
+
+    expect(changes).toEqual([2]);
+    expect(target.componentInstance.count()).toBe(3);
+    expect(target.componentInstance.quantityChange).toBe(method);
+  });
+});

--- a/tests/mock-render-metadata/output-observable.spec.ts
+++ b/tests/mock-render-metadata/output-observable.spec.ts
@@ -1,0 +1,64 @@
+import { Component, reflectComponentType } from '@angular/core';
+import { outputFromObservable } from '@angular/core/rxjs-interop';
+import { Subject } from 'rxjs';
+
+import { MockBuilder, MockRender } from 'ng-mocks';
+
+@Component({
+  selector: 'target-metadata-observable[events]',
+  standalone: true,
+  template: '',
+})
+class TargetComponent {
+  public readonly events = new Subject<string>();
+  public readonly changed = outputFromObservable(this.events);
+  public readonly selected = outputFromObservable(this.events, {
+    alias: 'chosen',
+  });
+}
+
+describe('mock-render-metadata:output-observable', () => {
+  // The root TypeScript-only runner does not transform authoring functions.
+  // Angular-compiled spread targets exercise these outputs from Angular 17.3.
+  if (
+    !reflectComponentType(TargetComponent)?.outputs.some(
+      metadata => metadata.propName === 'selected',
+    )
+  ) {
+    it('needs compiled observable output metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder(TargetComponent));
+
+  it('binds observable outputs and aliases once and unsubscribes when the clone is destroyed', () => {
+    const changed: string[] = [];
+    const chosen: string[] = [];
+    const fixture = MockRender(TargetComponent, {
+      changed: (value: string) => changed.push(value),
+      chosen: (value: string) => chosen.push(value),
+    });
+    const events = fixture.point.componentInstance.events;
+
+    expect(events.observed).toBe(true);
+    expect(changed).toEqual([]);
+    expect(chosen).toEqual([]);
+
+    events.next('first');
+    fixture.detectChanges();
+    events.next('second');
+
+    expect(changed).toEqual(['first', 'second']);
+    expect(chosen).toEqual(['first', 'second']);
+
+    fixture.destroy();
+
+    expect(events.observed).toBe(false);
+    events.next('after-destroy');
+    expect(changed).toEqual(['first', 'second']);
+    expect(chosen).toEqual(['first', 'second']);
+  });
+});

--- a/tests/mock-render-metadata/query-signals.spec.ts
+++ b/tests/mock-render-metadata/query-signals.spec.ts
@@ -1,0 +1,258 @@
+import {
+  Component,
+  contentChild,
+  contentChildren,
+  Directive,
+  ElementRef,
+  Input,
+  signal,
+  viewChild,
+  viewChildren,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MockBuilder,
+  MockRender,
+  MockRenderFactory,
+  ngMocks,
+} from 'ng-mocks';
+
+@Directive({
+  selector: '[metadataQueryItem]',
+  standalone: true,
+})
+class ItemDirective {
+  @Input() public metadataQueryItem = '';
+}
+
+@Component({
+  selector: 'target-metadata-queries[queries]',
+  standalone: true,
+  imports: [ItemDirective],
+  template: `
+    <ng-content></ng-content>
+    @if (showViews()) {
+      @if (showFirst()) {
+        <span
+          metadataQueryItem="view-first"
+          class="view-first"
+        ></span>
+      }
+      <div>
+        <span
+          metadataQueryItem="view-nested"
+          class="view-nested"
+        ></span>
+      </div>
+    }
+  `,
+})
+class TargetComponent {
+  public readonly showViews = signal(true);
+  public readonly showFirst = signal(true);
+  public readonly content = contentChild(ItemDirective);
+  public readonly requiredContent =
+    contentChild.required(ItemDirective);
+  public readonly contentElement = contentChild(ItemDirective, {
+    read: ElementRef,
+  });
+  public readonly directContent = contentChildren(ItemDirective);
+  public readonly allContent = contentChildren(ItemDirective, {
+    descendants: true,
+  });
+  public readonly contentElements = contentChildren(ItemDirective, {
+    descendants: true,
+    read: ElementRef,
+  });
+  public readonly view = viewChild(ItemDirective);
+  public readonly requiredView = viewChild.required(ItemDirective);
+  public readonly viewElement = viewChild(ItemDirective, {
+    read: ElementRef,
+  });
+  public readonly views = viewChildren(ItemDirective);
+  public readonly viewElements = viewChildren(ItemDirective, {
+    read: ElementRef,
+  });
+}
+
+describe('mock-render-metadata:query-signals', () => {
+  // The root TypeScript-only runner does not transform signal queries.
+  // Angular-compiled spread targets execute these cases from Angular 17.2.
+  if (
+    !(TargetComponent as any).ɵcmp.contentQueries ||
+    !(TargetComponent as any).ɵcmp.viewQuery
+  ) {
+    it('needs compiled signal query metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => MockBuilder([TargetComponent, ItemDirective]));
+
+  it('retains viewChild and viewChildren metadata and updates read tokens after view changes', () => {
+    const fixture = MockRender(TargetComponent, {});
+    const target = fixture.point.componentInstance;
+    const firstElement = ngMocks.find('.view-first');
+    const nestedElement = ngMocks.find('.view-nested');
+    const first = ngMocks.get(firstElement, ItemDirective);
+    const nested = ngMocks.get(nestedElement, ItemDirective);
+    const view = target.view;
+    const views = target.views;
+
+    expect(view()).toBe(first);
+    expect(target.requiredView()).toBe(first);
+    expect(target.viewElement()?.nativeElement).toBe(
+      firstElement.nativeElement,
+    );
+    expect(views()).toEqual([first, nested]);
+    expect(
+      target.viewElements().map(element => element.nativeElement),
+    ).toEqual([
+      firstElement.nativeElement,
+      nestedElement.nativeElement,
+    ]);
+
+    target.showFirst.set(false);
+    fixture.detectChanges();
+
+    expect(target.view).toBe(view);
+    expect(target.views).toBe(views);
+    expect(view()).toBe(nested);
+    expect(target.requiredView()).toBe(nested);
+    expect(target.viewElement()?.nativeElement).toBe(
+      nestedElement.nativeElement,
+    );
+    expect(views()).toEqual([nested]);
+    expect(
+      target.viewElements().map(element => element.nativeElement),
+    ).toEqual([nestedElement.nativeElement]);
+
+    target.showFirst.set(true);
+    fixture.detectChanges();
+    const restoredElement = ngMocks.find('.view-first');
+    const restored = ngMocks.get(restoredElement, ItemDirective);
+
+    expect(restored).not.toBe(first);
+    expect(view()).toBe(restored);
+    expect(target.requiredView()).toBe(restored);
+    expect(views()).toEqual([restored, nested]);
+    expect(
+      target.viewElements().map(element => element.nativeElement),
+    ).toEqual([
+      restoredElement.nativeElement,
+      nestedElement.nativeElement,
+    ]);
+
+    target.showViews.set(false);
+    fixture.detectChanges();
+
+    expect(view()).toBeUndefined();
+    expect(target.viewElement()).toBeUndefined();
+    expect(views()).toEqual([]);
+    expect(target.viewElements()).toEqual([]);
+    let message: string | undefined;
+    try {
+      target.requiredView();
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('NG0951');
+  });
+
+  it('retains contentChild and contentChildren metadata through the cloned component', () => {
+    // Configure a class-based render first so the complex-selector middleware
+    // is exercised, then project children through its generated wrapper.
+    const factory = MockRenderFactory(TargetComponent, ['show']);
+    factory.configureTestBed();
+    TestBed.overrideTemplate(
+      factory.declaration as never,
+      (factory.declaration as any).tpl.replace(
+        '</',
+        `@if (show) {
+           <span metadataQueryItem="content-first" class="content-first"></span>
+         }
+         <div><span metadataQueryItem="content-nested" class="content-nested"></span></div></`,
+      ),
+    );
+    const fixture = factory({ show: true });
+    const target = fixture.point.componentInstance;
+    const firstElement = ngMocks.find('.content-first');
+    const nestedElement = ngMocks.find('.content-nested');
+    const first = ngMocks.get(firstElement, ItemDirective);
+    const nested = ngMocks.get(nestedElement, ItemDirective);
+    const content = target.content;
+    const allContent = target.allContent;
+
+    expect(content()).toBe(first);
+    expect(target.requiredContent()).toBe(first);
+    expect(target.contentElement()?.nativeElement).toBe(
+      firstElement.nativeElement,
+    );
+    expect(target.directContent()).toEqual([first]);
+    expect(allContent()).toEqual([first, nested]);
+    expect(
+      target.contentElements().map(element => element.nativeElement),
+    ).toEqual([
+      firstElement.nativeElement,
+      nestedElement.nativeElement,
+    ]);
+
+    // Projected queries must exclude the owner's private view directives.
+    expect(
+      target.views().map(item => item.metadataQueryItem),
+    ).toEqual(['view-first', 'view-nested']);
+    fixture.componentInstance.show = false;
+    fixture.detectChanges();
+
+    expect(target.content).toBe(content);
+    expect(target.allContent).toBe(allContent);
+    expect(content()).toBe(nested);
+    expect(target.requiredContent()).toBe(nested);
+    expect(target.contentElement()?.nativeElement).toBe(
+      nestedElement.nativeElement,
+    );
+    expect(target.directContent()).toEqual([]);
+    expect(allContent()).toEqual([nested]);
+    expect(
+      target.contentElements().map(element => element.nativeElement),
+    ).toEqual([nestedElement.nativeElement]);
+
+    fixture.componentInstance.show = true;
+    fixture.detectChanges();
+    const restoredElement = ngMocks.find('.content-first');
+    const restored = ngMocks.get(restoredElement, ItemDirective);
+
+    expect(restored).not.toBe(first);
+    expect(content()).toBe(restored);
+    expect(target.requiredContent()).toBe(restored);
+    expect(target.directContent()).toEqual([restored]);
+    expect(allContent()).toEqual([restored, nested]);
+    expect(
+      target.contentElements().map(element => element.nativeElement),
+    ).toEqual([
+      restoredElement.nativeElement,
+      nestedElement.nativeElement,
+    ]);
+  });
+
+  it('retains empty content query results and required-query errors without projection', () => {
+    const fixture = MockRender(TargetComponent, {});
+    const target = fixture.point.componentInstance;
+
+    expect(target.content()).toBeUndefined();
+    expect(target.contentElement()).toBeUndefined();
+    expect(target.directContent()).toEqual([]);
+    expect(target.allContent()).toEqual([]);
+    expect(target.contentElements()).toEqual([]);
+    let message: string | undefined;
+    try {
+      target.requiredContent();
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('NG0951');
+  });
+});

--- a/tests/mock-render-metadata/static-queries.spec.ts
+++ b/tests/mock-render-metadata/static-queries.spec.ts
@@ -1,0 +1,164 @@
+import { CommonModule } from '@angular/common';
+import {
+  AfterContentInit,
+  AfterViewInit,
+  Component,
+  ContentChild,
+  Directive,
+  Input,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
+
+@Directive({
+  selector: '[metadataStaticItem]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ItemDirective {}
+
+@Component({
+  selector: 'metadata-static[first], metadata-static[second]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: `
+    <span *ngIf="visible" metadataStaticItem="inserted-view"></span>
+    <span metadataStaticItem="initial-view"></span>
+    <ng-content></ng-content>
+  `,
+})
+class TargetComponent
+  implements OnInit, AfterContentInit, AfterViewInit
+{
+  @Input() public visible = false;
+
+  @ContentChild(ItemDirective, { static: true })
+  public staticContent?: ItemDirective;
+
+  @ViewChild(ItemDirective, { static: true })
+  public staticView?: ItemDirective;
+
+  public readonly contentAssignments: Array<
+    ItemDirective | undefined
+  > = [];
+  public readonly viewAssignments: Array<ItemDirective | undefined> =
+    [];
+  public contentAtInit: Array<ItemDirective | undefined> = [];
+  public viewAtInit: Array<ItemDirective | undefined> = [];
+  public contentAfterInit?: ItemDirective;
+  public viewAfterInit?: ItemDirective;
+
+  public get dynamicContent(): ItemDirective | undefined {
+    return this.contentAssignments[
+      this.contentAssignments.length - 1
+    ];
+  }
+
+  @ContentChild(ItemDirective, { static: false })
+  public set dynamicContent(value: ItemDirective | undefined) {
+    this.contentAssignments.push(value);
+  }
+
+  public get dynamicView(): ItemDirective | undefined {
+    return this.viewAssignments[this.viewAssignments.length - 1];
+  }
+
+  @ViewChild(ItemDirective, { static: false })
+  public set dynamicView(value: ItemDirective | undefined) {
+    this.viewAssignments.push(value);
+  }
+
+  public ngOnInit(): void {
+    this.contentAtInit = [this.staticContent, this.dynamicContent];
+    this.viewAtInit = [this.staticView, this.dynamicView];
+  }
+
+  public ngAfterContentInit(): void {
+    this.contentAfterInit = this.dynamicContent;
+  }
+
+  public ngAfterViewInit(): void {
+    this.viewAfterInit = this.dynamicView;
+  }
+}
+
+// Explicit static query options require Angular 8. Recompiling the complex
+// selector must retain query timing without assigning the same result twice.
+describe('mock-render-metadata:static-queries', () => {
+  beforeEach(() =>
+    MockBuilder([CommonModule, ItemDirective, TargetComponent]),
+  );
+
+  it('preserves lifecycle timing and updates only dynamic query results', () => {
+    const factory = MockRenderFactory(TargetComponent, ['visible']);
+    factory.configureTestBed();
+    TestBed.overrideTemplate(
+      factory.declaration as never,
+      (factory.declaration as any).tpl.replace(
+        '</',
+        `<span *ngIf="visible" metadataStaticItem="inserted-content"></span>
+         <span metadataStaticItem="initial-content"></span></`,
+      ),
+    );
+    const fixture = factory({ visible: false });
+    const target = fixture.point.componentInstance;
+    const initialContent = ngMocks.findInstance(
+      '[metadataStaticItem="initial-content"]',
+      ItemDirective,
+    );
+    const initialView = ngMocks.findInstance(
+      '[metadataStaticItem="initial-view"]',
+      ItemDirective,
+    );
+
+    expect(target.contentAtInit).toEqual([initialContent, undefined]);
+    expect(target.viewAtInit).toEqual([initialView, undefined]);
+    expect(target.contentAfterInit).toBe(initialContent);
+    expect(target.viewAfterInit).toBe(initialView);
+    expect(target.contentAssignments).toEqual([initialContent]);
+    expect(target.viewAssignments).toEqual([initialView]);
+
+    fixture.componentInstance.visible = true;
+    fixture.detectChanges();
+    const insertedContent = ngMocks.findInstance(
+      '[metadataStaticItem="inserted-content"]',
+      ItemDirective,
+    );
+    const insertedView = ngMocks.findInstance(
+      '[metadataStaticItem="inserted-view"]',
+      ItemDirective,
+    );
+
+    expect(target.staticContent).toBe(initialContent);
+    expect(target.staticView).toBe(initialView);
+    expect(target.dynamicContent).toBe(insertedContent);
+    expect(target.dynamicView).toBe(insertedView);
+    expect(target.contentAssignments).toEqual([
+      initialContent,
+      insertedContent,
+    ]);
+    expect(target.viewAssignments).toEqual([
+      initialView,
+      insertedView,
+    ]);
+
+    fixture.componentInstance.visible = false;
+    fixture.detectChanges();
+
+    expect(target.staticContent).toBe(initialContent);
+    expect(target.staticView).toBe(initialView);
+    expect(target.dynamicContent).toBe(initialContent);
+    expect(target.dynamicView).toBe(initialView);
+    expect(target.contentAssignments).toEqual([
+      initialContent,
+      insertedContent,
+      initialContent,
+    ]);
+    expect(target.viewAssignments).toEqual([
+      initialView,
+      insertedView,
+      initialView,
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #14853 for the metadata issue reported in #14839.

`MockRender` recompiles declarations with missing or complex selectors under a generated selector. Copying metadata onto an inherited subclass can register class host handlers, host directives, animation definitions, and output bindings twice. Model output normalization can also confuse the real signal property with its change emitter or overwrite another member on a mock.

## What

- Reuse the original effective host and animation definitions for middleware declarations, preserving TestBed overrides without mutating the original metadata.
- Isolate input/output metadata arrays and deduplicate equivalent bindings while preserving effective input names, flags, transform precedence, and older Angular transform metadata.
- Preserve real input/output property names and allocate separate mock model emitters without colliding with other bindings, queries, host members, methods, or accessors. Resolve those emitters through their public output aliases.
- Add source and version-gated Angular regressions for decorated inputs/outputs, all four content/view query decorators and signal queries, static query timing, host bindings/listeners/directives, injection metadata, providers/view providers, animations, standalone metadata, model/output functions, and observable outputs.

## Impact

Rendered declarations retain their effective metadata and run inherited behavior once. Mock model outputs remain addressable by their public aliases while preserving unrelated members. This restores the documented contract, so public documentation and migration guidance do not change.

Fixes #14839
