### PR TITLE
test: cover unaliased directive metadata parsing

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.directive-io-parse.spec.ts
@@ -1,6 +1,90 @@
 import funcDirectiveIoParse from './func.directive-io-parse';
 
 describe('funcDirectiveIoParse', () => {
+  it('keeps names without aliases from strings', () => {
+    expect(funcDirectiveIoParse('value')).toEqual({
+      name: 'value',
+    });
+    expect(funcDirectiveIoParse('valueChange')).toEqual({
+      name: 'valueChange',
+    });
+  });
+
+  it('keeps names without aliases from objects', () => {
+    expect(funcDirectiveIoParse({ name: 'value' })).toEqual({
+      name: 'value',
+    });
+    expect(funcDirectiveIoParse({ name: 'valueChange' })).toEqual({
+      name: 'valueChange',
+    });
+  });
+
+  it('keeps required metadata without an alias', () => {
+    expect(
+      funcDirectiveIoParse({ name: 'value', required: true }),
+    ).toEqual({ name: 'value', required: true });
+    expect(
+      funcDirectiveIoParse({ name: 'value', required: false }),
+    ).toEqual({ name: 'value', required: false });
+  });
+
+  it('keeps signal flags and transforms without an alias', () => {
+    expect(
+      funcDirectiveIoParse({
+        isSignal: true,
+        name: 'value',
+        transform: String,
+      }),
+    ).toEqual({ isSignal: true, name: 'value', transform: String });
+    expect(
+      funcDirectiveIoParse({
+        isSignal: false,
+        name: 'value',
+        transform: Number,
+      }),
+    ).toEqual({ isSignal: false, name: 'value', transform: Number });
+  });
+
+  it('omits redundant aliases while preserving metadata', () => {
+    expect(funcDirectiveIoParse('value:value')).toEqual({
+      name: 'value',
+    });
+    expect(
+      funcDirectiveIoParse({
+        alias: 'value',
+        isSignal: true,
+        name: 'value',
+        required: true,
+        transform: String,
+      }),
+    ).toEqual({
+      isSignal: true,
+      name: 'value',
+      required: true,
+      transform: String,
+    });
+  });
+
+  it('omits empty aliases while preserving metadata', () => {
+    expect(funcDirectiveIoParse('value:')).toEqual({
+      name: 'value',
+    });
+    expect(
+      funcDirectiveIoParse({
+        alias: '',
+        isSignal: true,
+        name: 'value',
+        required: true,
+        transform: String,
+      }),
+    ).toEqual({
+      isSignal: true,
+      name: 'value',
+      required: true,
+      transform: String,
+    });
+  });
+
   it('keeps regular aliases', () => {
     expect(funcDirectiveIoParse('prop:alias')).toEqual({
       alias: 'alias',


### PR DESCRIPTION
## Why

The parser-specific tests in #14880 all used aliases. Unaliased bindings were exercised indirectly by declaration collection and mock tests, leaving their parser behavior without direct regression coverage.

## What

- Add string and object cases without aliases, including names ending in `Change`.
- Assert that required flags, signal flags, and transforms are preserved, including explicit `false` flags.
- Cover removal of empty and same-name aliases while retaining metadata.

## Impact

This makes the existing unaliased parser contract explicit. The change is limited to regression tests; runtime behavior and public documentation remain unchanged.

Follow-up to #14880. Related to #14839.
