### PR TITLE
build(docker): share one browser cache across worktrees

### DIFF
--- a/.agents/skills/update-package-locks/SKILL.md
+++ b/.agents/skills/update-package-locks/SKILL.md
@@ -54,11 +54,11 @@ For a repo-wide refresh, the affected command lines are all service command entr
 
 For repo-wide refreshes, derive targets from the current `compose.sh` and `compose.yml`; do not hardcode target names or rely on bare `sh compose.sh`. Run each target once per pass in batches of 2-4, with a unique `COMPOSE_PROJECT_NAME` per concurrent command. Clean each batch with `docker compose down -v` before starting the next one.
 
-Browser volumes are external and shared across these namespaces. Before placing targets that use the same
+The browser volume is external and shared across these namespaces. Before placing targets that use the same
 browser build in a parallel batch, complete one target's wrapper run to populate that build. If cache state
 or the build selected by an update is uncertain, run those targets sequentially. Apply this rule in both
-passes and coordinate with other worktrees. Batch cleanup retains the external browser volumes; do not
-remove them while another worktree may be using them. See `CONTRIBUTING.md` for cache revision mappings.
+passes and coordinate with other worktrees. Batch cleanup retains the external browser volume; do not
+remove it while another worktree may be using it. See `CONTRIBUTING.md` for cache revision mappings.
 
 If a wrapper target fails, including Docker address-pool or Puppeteer cache errors, report the command, error, and remaining work to the user and discuss the solution before cleanup, retries, or other recovery steps. Do not switch to local runtimes or create a workaround.
 

--- a/.agents/skills/update-package-locks/SKILL.md
+++ b/.agents/skills/update-package-locks/SKILL.md
@@ -18,7 +18,7 @@ Create a plain Markdown checklist that any AI agent can follow:
 - [ ] Create an isolated worktree from `upstream/main` or the existing PR branch
 - [ ] For a PR conflict, merge `upstream/main` and keep the dependency PR's lockfile side as the regeneration base
 - [ ] Temporarily change the relevant `compose.yml` service command line(s) from `npm install` to `npm update`
-- [ ] Run the update wrapper pass with wrapper targets in batches of 2-4
+- [ ] Run the update wrapper pass, serializing cold browser installs before batches of 2-4
 - [ ] Restore `compose.yml` back to `npm install`
 - [ ] Run the install wrapper pass with wrapper targets in batches of 2-4
 - [ ] Commit the refreshed lockfiles with only the dependency or merge changes already in scope
@@ -35,7 +35,7 @@ Create a plain Markdown checklist that any AI agent can follow:
    - For an existing dependency PR conflict, fetch that PR branch into an isolated worktree, merge `upstream/main` without rewriting history, and keep the dependency PR's lockfile side as the regeneration base.
 2. In that new worktree, inspect `compose.yml`.
 3. Temporarily change only the affected `compose.yml` service command line(s) from `npm install` to `npm update`.
-4. For a repo-wide refresh, derive the current wrapper targets from `compose.sh` and `compose.yml`, then run them in batches of 2-4 concurrent commands. If the user explicitly named one target, run only that target.
+4. For a repo-wide refresh, derive the current wrapper targets from `compose.sh` and `compose.yml`, then run them in batches of 2-4 concurrent commands. Serialize targets that may download the same uncached browser build, as described below. If the user explicitly named one target, run only that target.
 5. Restore the same service command line(s) back to `npm install`.
 6. Run the same target set again in batches of 2-4 so the resulting lockfiles match the normal CI install flow.
 7. Commit the refreshed `package-lock.json` files with only the dependency or merge changes already in scope, plus `.agents/skills/update-package-locks/SKILL.md` if this skill was intentionally edited.
@@ -53,6 +53,12 @@ Do not use the current active worktree. A fresh refresh needs a new branch; an e
 For a repo-wide refresh, the affected command lines are all service command entries in `compose.yml` that currently read `- install`. Change only those entries to `- update`, run the wrapper, then change those same entries back to `- install`. Do not edit `package.json`, shell scripts, or lockfiles by hand.
 
 For repo-wide refreshes, derive targets from the current `compose.sh` and `compose.yml`; do not hardcode target names or rely on bare `sh compose.sh`. Run each target once per pass in batches of 2-4, with a unique `COMPOSE_PROJECT_NAME` per concurrent command. Clean each batch with `docker compose down -v` before starting the next one.
+
+Browser volumes are external and shared across these namespaces. Before placing targets that use the same
+browser build in a parallel batch, complete one target's wrapper run to populate that build. If cache state
+or the build selected by an update is uncertain, run those targets sequentially. Apply this rule in both
+passes and coordinate with other worktrees. Batch cleanup retains the external browser volumes; do not
+remove them while another worktree may be using them. See `CONTRIBUTING.md` for cache revision mappings.
 
 If a wrapper target fails, including Docker address-pool or Puppeteer cache errors, report the command, error, and remaining work to the user and discuss the solution before cleanup, retries, or other recovery steps. Do not switch to local runtimes or create a workaround.
 
@@ -110,7 +116,7 @@ git push
 - The required validation for this skill is a successful wrapper-based update pass followed by a successful wrapper-based install pass.
 - For a single target, run `sh compose.sh <target>` once while the service command is temporarily `npm update`, then run `sh compose.sh <target>` again after restoring `npm install`.
 - For a repo-wide lock refresh, run every relevant wrapper target once with all relevant service commands temporarily set to `npm update`, then run every same target again after restoring all service commands to `npm install`.
-- Repo-wide target runs may be concurrent in batches of 2-4. A batch is successful only when every target command exits successfully.
+- Repo-wide target runs may be concurrent in batches of 2-4 after shared browser builds are populated; serialize uncertain or cold installs of the same build. A batch is successful only when every target command exits successfully.
 - After the final push, the hosting provider must report a definitive conflict-free PR state. A local clean merge is not sufficient, and CI status is a separate signal.
 - Do not run `sh test.sh`, `npm test`, lint, or TypeScript checks as part of this skill's default validation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@
 - If multiple worktrees or agent sessions run in parallel, set a unique compose namespace:
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh compose.sh <target>`
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh test.sh <target>`
-- Browser downloads use external volumes shared across compose namespaces. Follow `CONTRIBUTING.md` for
+- Services with configurable browser caches use one external volume shared across compose namespaces. Follow `CONTRIBUTING.md` for
   first-time volume creation and legacy revision mappings. Serialize cold installs of the same browser build;
   populated browser caches may serve concurrent test containers. Keep build caches and dependencies isolated.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@
 - If multiple worktrees or agent sessions run in parallel, set a unique compose namespace:
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh compose.sh <target>`
   - `COMPOSE_PROJECT_NAME=ngmocks_<unique> sh test.sh <target>`
+- Browser downloads use external volumes shared across compose namespaces. Follow `CONTRIBUTING.md` for
+  first-time volume creation and legacy revision mappings. Serialize cold installs of the same browser build;
+  populated browser caches may serve concurrent test containers. Keep build caches and dependencies isolated.
 
 ## Worktree Isolation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,46 @@ To avoid collisions when multiple worktrees run docker compose in parallel, set 
 Use your own unique string for each task/worktree.
 Reuse the same value for every `docker compose`, `sh ./compose.sh`, and `sh ./test.sh` command you run in that worktree.
 With a unique project name, Compose keeps the worktree resources separate, including the default network and the named `cache`, `gyp`, and `npm` volumes.
+Browser downloads use separate external volumes shared by all worktrees on the same Docker engine.
 
 ```shell
 COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> sh ./compose.sh e2e
 COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> sh ./test.sh e2e
 COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> docker compose run --rm ng-mocks npm run lint
 ```
+
+### Shared browser downloads
+
+`compose.sh` creates the browser volumes automatically. They have fixed names so the browser targets reuse
+downloads across services and `COMPOSE_PROJECT_NAME` values. For direct Compose commands on a fresh Docker
+engine, create them first:
+
+```shell
+docker volume create ngmocks-puppeteer-cache
+docker volume create ngmocks-chromium-686378-cache
+docker volume create ngmocks-chromium-722234-cache
+```
+
+Root, `tests-e2e`, Angular 16 and newer, Jasmine, and min share Puppeteer's browser cache at
+`/root/.cache/puppeteer`. Each browser build keeps its own directory. Angular 8 through 15 use revision-specific
+directories under that volume because their older installers remove other revisions from the download directory.
+Angular 5 through 7 use dedicated revision volumes: Puppeteer 1.20.0 needs Chromium 686378, and Puppeteer 2.1.1
+needs Chromium 722234. For these targets, `compose.sh` mounts the cache into `node_modules` only while running
+the browser installer. Package installation skips Chromium, and tests select the executable from the normal
+cache mount outside `node_modules`.
+
+When updating a legacy Puppeteer dependency, keep its cache revision and executable path in `compose.yml`,
+the volume creation and installer mounts in `compose.sh`, and this section aligned with its default Chromium
+revision. Do not force a different revision to keep an old cache path working.
+
+Finish the first installation of each browser build before starting another installation of that build in a
+parallel worktree. Once populated, the cache can serve concurrent test containers. External browser volumes
+survive `docker compose down --volumes`; remove them explicitly only when no worktree is using them.
+Existing project-scoped caches are left in place; the shared volumes populate on their first use.
+
+The host installation in `compose.sh` remains separate: macOS and Linux need different browser binaries.
+The Jest-only project uses jsdom and does not download Chrome. Angular build caches and `node_modules` stay
+inside each worktree.
 
 ### Automated dependency updates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To avoid collisions when multiple worktrees run docker compose in parallel, set 
 Use your own unique string for each task/worktree.
 Reuse the same value for every `docker compose`, `sh ./compose.sh`, and `sh ./test.sh` command you run in that worktree.
 With a unique project name, Compose keeps the worktree resources separate, including the default network and the named `cache`, `gyp`, and `npm` volumes.
-Browser downloads use separate external volumes shared by all worktrees on the same Docker engine.
+Services with configurable browser caches mount one external volume shared by all worktrees on the same Docker engine.
 
 ```shell
 COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> sh ./compose.sh e2e
@@ -77,32 +77,30 @@ COMPOSE_PROJECT_NAME=ngmocks_<your-unique-string> docker compose run --rm ng-moc
 
 ### Shared browser downloads
 
-`compose.sh` creates the browser volumes automatically. They have fixed names so the browser targets reuse
-downloads across services and `COMPOSE_PROJECT_NAME` values. For direct Compose commands on a fresh Docker
-engine, create them first:
+`compose.sh` creates the single `ngmocks-puppeteer-cache` volume automatically. Its fixed name lets supported
+services reuse downloads across `COMPOSE_PROJECT_NAME` values. For direct Compose commands on a fresh Docker
+engine, create it first:
 
 ```shell
 docker volume create ngmocks-puppeteer-cache
-docker volume create ngmocks-chromium-686378-cache
-docker volume create ngmocks-chromium-722234-cache
 ```
 
-Root, `tests-e2e`, Angular 16 and newer, Jasmine, and min share Puppeteer's browser cache at
-`/root/.cache/puppeteer`. Each browser build keeps its own directory. Angular 8 through 15 use revision-specific
-directories under that volume because their older installers remove other revisions from the download directory.
-Angular 5 through 7 use dedicated revision volumes: Puppeteer 1.20.0 needs Chromium 686378, and Puppeteer 2.1.1
-needs Chromium 722234. For these targets, `compose.sh` mounts the cache into `node_modules` only while running
-the browser installer. Package installation skips Chromium, and tests select the executable from the normal
-cache mount outside `node_modules`.
+Supported services mount that volume at `/root/.cache/puppeteer`. Modern Puppeteer keeps each browser build in its
+own directory. Angular 8 through 15 use revision-specific directories inside the same volume because their
+older installers remove other revisions from the download directory.
 
-When updating a legacy Puppeteer dependency, keep its cache revision and executable path in `compose.yml`,
-the volume creation and installer mounts in `compose.sh`, and this section aligned with its default Chromium
-revision. Do not force a different revision to keep an old cache path working.
+Angular 5 through 7 retain their existing local browser installation because Puppeteer 1.20.0 and 2.1.1 do
+not support a configurable download directory. Normal npm lifecycle scripts and the explicit browser
+installation in `compose.sh` remain enabled for every target.
+
+When updating a legacy Puppeteer dependency with a configured download path, keep its cache revision in
+`compose.yml` aligned with its default Chromium revision. Do not force a different revision to keep an old
+cache path working.
 
 Finish the first installation of each browser build before starting another installation of that build in a
-parallel worktree. Once populated, the cache can serve concurrent test containers. External browser volumes
-survive `docker compose down --volumes`; remove them explicitly only when no worktree is using them.
-Existing project-scoped caches are left in place; the shared volumes populate on their first use.
+parallel worktree. Once populated, the cache can serve concurrent test containers. The external browser volume
+survives `docker compose down --volumes`; remove it explicitly only when no worktree is using it.
+Existing project-scoped caches are left in place; the shared volume populates on its first use.
 
 The host installation in `compose.sh` remains separate: macOS and Linux need different browser binaries.
 The Jest-only project uses jsdom and does not download Chrome. Angular build caches and `node_modules` stay

--- a/compose.sh
+++ b/compose.sh
@@ -2,8 +2,6 @@
 set -e
 
 docker volume create ngmocks-puppeteer-cache > /dev/null
-docker volume create ngmocks-chromium-686378-cache > /dev/null
-docker volume create ngmocks-chromium-722234-cache > /dev/null
 
 export NVM_DIR="$HOME/.nvm" && \. "$NVM_DIR/nvm.sh"
 
@@ -35,9 +33,7 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a5" ] || [ "$1" = "a5es5" ]; then
   docker compose up --build -- a5es5 && \
-    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
-      --volume ngmocks-chromium-686378-cache:/app/node_modules/puppeteer/.local-chromium \
-      a5es5 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm a5es5 node ./node_modules/puppeteer/install.js && \
     docker compose run --rm a5es5 node ./node_modules/node-sass/scripts/install.js && \
     cd ./e2e/a5es5 && \
     nvm install && \
@@ -49,9 +45,7 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a5" ] || [ "$1" = "a5es2015" ]; then
   docker compose up --build -- a5es2015 && \
-    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
-      --volume ngmocks-chromium-686378-cache:/app/node_modules/puppeteer/.local-chromium \
-      a5es2015 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm a5es2015 node ./node_modules/puppeteer/install.js && \
     docker compose run --rm a5es2015 node ./node_modules/node-sass/scripts/install.js && \
     cd ./e2e/a5es2015 && \
     nvm install && \
@@ -63,9 +57,7 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a6" ]; then
   docker compose up --build -- a6 && \
-    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
-      --volume ngmocks-chromium-722234-cache:/app/node_modules/puppeteer/.local-chromium \
-      a6 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm a6 node ./node_modules/puppeteer/install.js && \
     docker compose run --rm a6 node ./node_modules/node-sass/scripts/install.js && \
     cd ./e2e/a6 && \
     nvm install && \
@@ -77,9 +69,7 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a7" ]; then
   docker compose up --build -- a7 && \
-    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
-      --volume ngmocks-chromium-722234-cache:/app/node_modules/puppeteer/.local-chromium \
-      a7 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm a7 node ./node_modules/puppeteer/install.js && \
     cd ./e2e/a7 && \
     nvm install && \
     nvm use && \

--- a/compose.sh
+++ b/compose.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+docker volume create ngmocks-puppeteer-cache > /dev/null
+docker volume create ngmocks-chromium-686378-cache > /dev/null
+docker volume create ngmocks-chromium-722234-cache > /dev/null
+
 export NVM_DIR="$HOME/.nvm" && \. "$NVM_DIR/nvm.sh"
 
 if [ "$1" = "" ] || [ "$1" = "root" ]; then
@@ -31,7 +35,9 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a5" ] || [ "$1" = "a5es5" ]; then
   docker compose up --build -- a5es5 && \
-    docker compose run --rm a5es5 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
+      --volume ngmocks-chromium-686378-cache:/app/node_modules/puppeteer/.local-chromium \
+      a5es5 node ./node_modules/puppeteer/install.js && \
     docker compose run --rm a5es5 node ./node_modules/node-sass/scripts/install.js && \
     cd ./e2e/a5es5 && \
     nvm install && \
@@ -43,7 +49,9 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a5" ] || [ "$1" = "a5es2015" ]; then
   docker compose up --build -- a5es2015 && \
-    docker compose run --rm a5es2015 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
+      --volume ngmocks-chromium-686378-cache:/app/node_modules/puppeteer/.local-chromium \
+      a5es2015 node ./node_modules/puppeteer/install.js && \
     docker compose run --rm a5es2015 node ./node_modules/node-sass/scripts/install.js && \
     cd ./e2e/a5es2015 && \
     nvm install && \
@@ -55,7 +63,9 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a6" ]; then
   docker compose up --build -- a6 && \
-    docker compose run --rm a6 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
+      --volume ngmocks-chromium-722234-cache:/app/node_modules/puppeteer/.local-chromium \
+      a6 node ./node_modules/puppeteer/install.js && \
     docker compose run --rm a6 node ./node_modules/node-sass/scripts/install.js && \
     cd ./e2e/a6 && \
     nvm install && \
@@ -67,7 +77,9 @@ fi
 
 if [ "$1" = "" ] || [ "$1" = "a7" ]; then
   docker compose up --build -- a7 && \
-    docker compose run --rm a7 node ./node_modules/puppeteer/install.js && \
+    docker compose run --rm -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= \
+      --volume ngmocks-chromium-722234-cache:/app/node_modules/puppeteer/.local-chromium \
+      a7 node ./node_modules/puppeteer/install.js && \
     cd ./e2e/a7 && \
     nvm install && \
     nvm use && \

--- a/compose.yml
+++ b/compose.yml
@@ -24,6 +24,7 @@ services:
     volumes:
       - ./docs:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -53,14 +54,9 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
-    environment:
-      # Keep the Chromium revision aligned with Puppeteer 1.20.0.
-      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-686378/chrome-linux/chrome
     volumes:
       - ./e2e/a5es5:/app
       - cache:/root/.cache
-      - chromium-686378:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -73,14 +69,9 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
-    environment:
-      # Keep the Chromium revision aligned with Puppeteer 1.20.0.
-      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-686378/chrome-linux/chrome
     volumes:
       - ./e2e/a5es2015:/app
       - cache:/root/.cache
-      - chromium-686378:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -93,14 +84,9 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
-    environment:
-      # Keep the Chromium revision aligned with Puppeteer 2.1.1.
-      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-722234/chrome-linux/chrome
     volumes:
       - ./e2e/a6:/app
       - cache:/root/.cache
-      - chromium-722234:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -113,14 +99,9 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
-    environment:
-      # Keep the Chromium revision aligned with Puppeteer 2.1.1.
-      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-722234/chrome-linux/chrome
     volumes:
       - ./e2e/a7:/app
       - cache:/root/.cache
-      - chromium-722234:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -422,6 +403,7 @@ services:
     volumes:
       - ./e2e/jest:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -436,6 +418,7 @@ services:
     volumes:
       - ./e2e/vitest:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -470,6 +453,7 @@ services:
     volumes:
       - ./e2e/nx:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -484,10 +468,4 @@ volumes:
   # Shared across Compose projects and retained when a worktree's volumes are removed.
   puppeteer:
     name: ngmocks-puppeteer-cache
-    external: true
-  chromium-686378:
-    name: ngmocks-chromium-686378-cache
-    external: true
-  chromium-722234:
-    name: ngmocks-chromium-722234-cache
     external: true

--- a/compose.yml
+++ b/compose.yml
@@ -5,9 +5,11 @@ services:
     working_dir: /app
     environment:
       - NODE_OPTIONS=--max-old-space-size=8192
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - .:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -35,9 +37,11 @@ services:
     working_dir: /app
     environment:
       - NODE_OPTIONS=--max-old-space-size=8192
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./tests-e2e:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -49,9 +53,14 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Keep the Chromium revision aligned with Puppeteer 1.20.0.
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-686378/chrome-linux/chrome
     volumes:
       - ./e2e/a5es5:/app
       - cache:/root/.cache
+      - chromium-686378:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -64,9 +73,14 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Keep the Chromium revision aligned with Puppeteer 1.20.0.
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-686378/chrome-linux/chrome
     volumes:
       - ./e2e/a5es2015:/app
       - cache:/root/.cache
+      - chromium-686378:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -79,9 +93,14 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Keep the Chromium revision aligned with Puppeteer 2.1.1.
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-722234/chrome-linux/chrome
     volumes:
       - ./e2e/a6:/app
       - cache:/root/.cache
+      - chromium-722234:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -94,9 +113,14 @@ services:
     image: satantime/puppeteer-node:8.17.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Keep the Chromium revision aligned with Puppeteer 2.1.1.
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+      - PUPPETEER_EXECUTABLE_PATH=/root/.cache/puppeteer/linux-722234/chrome-linux/chrome
     volumes:
       - ./e2e/a7:/app
       - cache:/root/.cache
+      - chromium-722234:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -109,9 +133,13 @@ services:
     image: satantime/puppeteer-node:10.24.1
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 5.5.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-818858
     volumes:
       - ./e2e/a8:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -124,9 +152,13 @@ services:
     image: satantime/puppeteer-node:12.22.12
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 10.4.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-901912
     volumes:
       - ./e2e/a9:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -139,9 +171,13 @@ services:
     image: satantime/puppeteer-node:12.22.12
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 10.4.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-901912
     volumes:
       - ./e2e/a10:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -154,9 +190,13 @@ services:
     image: satantime/puppeteer-node:12.22.12
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 10.4.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-901912
     volumes:
       - ./e2e/a11:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -169,9 +209,13 @@ services:
     image: satantime/puppeteer-node:12.22.12
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 10.4.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-901912
     volumes:
       - ./e2e/a12:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -184,9 +228,13 @@ services:
     image: satantime/puppeteer-node:12.22.12
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 10.4.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-901912
     volumes:
       - ./e2e/a13:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -199,9 +247,13 @@ services:
     image: satantime/puppeteer-node:16.20.2
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 13.7.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-982053
     volumes:
       - ./e2e/a14:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -213,9 +265,13 @@ services:
     image: satantime/puppeteer-node:16.20.2
     platform: linux/amd64
     working_dir: /app
+    environment:
+      # Isolate the revision expected by Puppeteer 13.7.0 from legacy installer cleanup.
+      - PUPPETEER_DOWNLOAD_PATH=/root/.cache/puppeteer/legacy-982053
     volumes:
       - ./e2e/a15:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -227,9 +283,12 @@ services:
     image: satantime/puppeteer-node:18.20.8
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a16:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -241,9 +300,12 @@ services:
     image: satantime/puppeteer-node:20.20.2
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a17:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -255,9 +317,12 @@ services:
     image: satantime/puppeteer-node:20.20.2
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a18:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -269,9 +334,12 @@ services:
     image: satantime/puppeteer-node:22.23.2
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a19:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -283,9 +351,12 @@ services:
     image: satantime/puppeteer-node:22.23.2
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a20:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -297,9 +368,12 @@ services:
     image: satantime/puppeteer-node:24.19.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a21:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -311,9 +385,12 @@ services:
     image: satantime/puppeteer-node:24.19.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/a22:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -325,9 +402,12 @@ services:
     image: satantime/puppeteer-node:24.19.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/jasmine:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -367,9 +447,12 @@ services:
     image: satantime/puppeteer-node:24.19.0
     platform: linux/amd64
     working_dir: /app
+    environment:
+      - PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
     volumes:
       - ./e2e/min:/app
       - cache:/root/.cache
+      - puppeteer:/root/.cache/puppeteer
       - gyp:/root/.node-gyp
       - npm:/root/.npm
     command:
@@ -398,3 +481,13 @@ volumes:
   cache:
   gyp:
   npm:
+  # Shared across Compose projects and retained when a worktree's volumes are removed.
+  puppeteer:
+    name: ngmocks-puppeteer-cache
+    external: true
+  chromium-686378:
+    name: ngmocks-chromium-686378-cache
+    external: true
+  chromium-722234:
+    name: ngmocks-chromium-722234-cache
+    external: true


### PR DESCRIPTION
## Why

Each isolated Compose project currently creates its own Puppeteer cache, so worktrees download the same browser builds repeatedly. Legacy targets that support a configurable download directory also keep duplicate Chromium downloads in individual dependency directories.

## What

Share browser downloads through one external Docker volume named `ngmocks-puppeteer-cache`. Modern Puppeteer consumers use their native cache layout, and Angular 8–15 select revision-specific directories inside the same volume so legacy installer cleanup cannot remove another target's browser.

Create the volume from the existing install wrapper and document its lifecycle, legacy revision mappings, and the need to finish cold downloads before parallel installations. Align the lockfile-refresh workflow with those shared-cache requirements.

## Impact

Targets with configurable browser caches reuse downloads across services and worktrees. Browser installation remains enabled, without added skip flags or adapters. Angular 5–7 retain their existing installation because their Puppeteer versions lack a configurable download directory. Dependencies, Angular build caches, other Compose resources, and host browser installation retain their existing behavior. This changes development tooling and contributor guidance without changing the published library.
