### PR TITLE
test(TestBed): cover nested mock module boundaries #14895

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.extract-deps.spec.ts
+++ b/libs/ng-mocks/src/lib/common/func.extract-deps.spec.ts
@@ -21,6 +21,11 @@ class Issue7490Level2Module {}
 })
 class Issue7490Level1Module {}
 
+@NgModule({
+  imports: [Issue7490Level3Module],
+})
+class Issue14895RealRootModule {}
+
 describe('funcExtractDeps', () => {
   it('collects recursive dependencies to their full depth', () => {
     const result = funcExtractDeps(
@@ -60,5 +65,89 @@ describe('funcExtractDeps', () => {
 
     expect(result.size).toBe(3);
     expect(visited.size).toBe(4);
+  });
+
+  // @see https://github.com/help-me-mom/ng-mocks/issues/14895
+  it('collects a blocked dependency without visiting its descendants', () => {
+    const visited = new Set<AnyDeclaration<any>>();
+    const result = funcExtractDeps(
+      Issue7490Level1Module,
+      new Set(),
+      true,
+      visited,
+      dependency => dependency !== Issue7490Level2Module,
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.has(Issue7490Level2Module)).toBe(true);
+    expect(result.has(Issue7490Level3Module)).toBe(false);
+    expect(result.has(Issue7490Level4Module)).toBe(false);
+    expect(visited.size).toBe(1);
+    expect(visited.has(Issue7490Level1Module)).toBe(true);
+    expect(visited.has(Issue7490Level2Module)).toBe(false);
+  });
+
+  it('reaches shared descendants through a later independent root', () => {
+    const visited = new Set<AnyDeclaration<any>>();
+    const result = funcExtractDeps(
+      Issue7490Level1Module,
+      new Set(),
+      true,
+      visited,
+      dependency => dependency !== Issue7490Level2Module,
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.has(Issue7490Level3Module)).toBe(false);
+    expect(visited.has(Issue7490Level3Module)).toBe(false);
+
+    funcExtractDeps(
+      Issue14895RealRootModule,
+      result,
+      true,
+      visited,
+      dependency => dependency !== Issue7490Level2Module,
+    );
+
+    expect(result.size).toBe(3);
+    expect(result.has(Issue7490Level2Module)).toBe(true);
+    expect(result.has(Issue7490Level3Module)).toBe(true);
+    expect(result.has(Issue7490Level4Module)).toBe(true);
+    expect(visited.size).toBe(4);
+    expect(visited.has(Issue7490Level2Module)).toBe(false);
+    expect(visited.has(Issue7490Level3Module)).toBe(true);
+    expect(visited.has(Issue7490Level4Module)).toBe(true);
+  });
+
+  it('preserves shared descendants reached before a blocked dependency', () => {
+    const visited = new Set<AnyDeclaration<any>>();
+    const result = funcExtractDeps(
+      Issue14895RealRootModule,
+      new Set(),
+      true,
+      visited,
+      dependency => dependency !== Issue7490Level2Module,
+    );
+
+    expect(result.size).toBe(2);
+    expect(result.has(Issue7490Level3Module)).toBe(true);
+    expect(result.has(Issue7490Level4Module)).toBe(true);
+
+    funcExtractDeps(
+      Issue7490Level1Module,
+      result,
+      true,
+      visited,
+      dependency => dependency !== Issue7490Level2Module,
+    );
+
+    expect(result.size).toBe(3);
+    expect(result.has(Issue7490Level2Module)).toBe(true);
+    expect(result.has(Issue7490Level3Module)).toBe(true);
+    expect(result.has(Issue7490Level4Module)).toBe(true);
+    expect(visited.size).toBe(4);
+    expect(visited.has(Issue7490Level2Module)).toBe(false);
+    expect(visited.has(Issue7490Level3Module)).toBe(true);
+    expect(visited.has(Issue7490Level4Module)).toBe(true);
   });
 });

--- a/tests/issue-14895/test.spec.ts
+++ b/tests/issue-14895/test.spec.ts
@@ -1,0 +1,359 @@
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  HostListener,
+  Inject,
+  InjectionToken,
+  Input,
+  NgModule,
+  Output,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+const PRIVATE_VALUE = new InjectionToken<object>(
+  'PRIVATE_VALUE_14895',
+);
+const SHARED_VALUE = new InjectionToken<object>('SHARED_VALUE_14895');
+const privateValue = { name: 'real-private-provider' };
+const sharedValue = { name: 'real-shared-provider' };
+let privateConstructors: string[] = [];
+let privateFactoryCalls = 0;
+let sharedFactoryCalls = 0;
+let sharedConstructorCalls = 0;
+let listenerCalls = 0;
+let transformCalls = 0;
+
+@Component({
+  selector: 'private-14895',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'real-private:{{ value }}',
+})
+class PrivateComponent {
+  @Input() public value = '';
+  @Output() public readonly changed = new EventEmitter<string>();
+
+  public constructor() {
+    privateConstructors.push('component');
+  }
+}
+
+@Directive({
+  selector: '[private14895]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class PrivateDirective {
+  public constructor() {
+    privateConstructors.push('directive');
+  }
+
+  @HostListener('click')
+  public onClick(): void {
+    listenerCalls += 1;
+  }
+}
+
+@Pipe({
+  name: 'private14895',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class PrivatePipe implements PipeTransform {
+  public constructor() {
+    privateConstructors.push('pipe');
+  }
+
+  public transform(value: string): string {
+    transformCalls += 1;
+
+    return `real-pipe:${value}`;
+  }
+}
+
+@Component({
+  selector: 'shared-14895',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'real-shared:{{ value }}',
+})
+class SharedComponent {
+  @Input() public value = '';
+
+  public constructor() {
+    sharedConstructorCalls += 1;
+  }
+}
+
+@NgModule({
+  declarations: [SharedComponent],
+  exports: [SharedComponent],
+  providers: [
+    {
+      provide: SHARED_VALUE,
+      useFactory: () => {
+        sharedFactoryCalls += 1;
+
+        return sharedValue;
+      },
+    },
+  ],
+})
+class SharedModule {}
+
+@NgModule({
+  declarations: [PrivateComponent, PrivateDirective, PrivatePipe],
+  imports: [SharedModule],
+  exports: [
+    PrivateComponent,
+    PrivateDirective,
+    PrivatePipe,
+    SharedModule,
+  ],
+  providers: [
+    {
+      provide: PRIVATE_VALUE,
+      useFactory: () => {
+        privateFactoryCalls += 1;
+
+        return privateValue;
+      },
+    },
+  ],
+})
+class NestedModule {
+  public constructor() {
+    privateConstructors.push('nested-module');
+  }
+}
+
+@NgModule({
+  imports: [NestedModule],
+  exports: [NestedModule],
+})
+class BoundaryModule {
+  public constructor() {
+    privateConstructors.push('boundary-module');
+  }
+}
+
+@Component({
+  selector: 'host-14895',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: `
+    <section>host:{{ value }}:{{ clicks }}</section>
+    <button private14895 (click)="onClick()">toggle</button>
+    <private-14895
+      [value]="value"
+      (changed)="value = $event"
+    ></private-14895>
+    <shared-14895 [value]="value"></shared-14895>
+    <span>{{ value | private14895 }}</span>
+  `,
+})
+class HostComponent {
+  public value = 'initial';
+  public clicks = 0;
+
+  public constructor(
+    @Inject(PRIVATE_VALUE) public readonly privateProvider: object,
+    @Inject(SHARED_VALUE) public readonly sharedProvider: object,
+  ) {}
+
+  public onClick(): void {
+    this.clicks += 1;
+  }
+}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [BoundaryModule],
+})
+class HostModule {}
+
+@NgModule({
+  imports: [SharedModule],
+  exports: [SharedModule],
+})
+class IndependentModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14895
+// The mixed TestBed bridge must stop inferred keeps at the explicit mock
+// boundary, while a separate real import path can still keep shared children.
+describe('issue-14895', () => {
+  beforeEach(() => {
+    privateConstructors = [];
+    privateFactoryCalls = 0;
+    sharedFactoryCalls = 0;
+    sharedConstructorCalls = 0;
+    listenerCalls = 0;
+    transformCalls = 0;
+  });
+
+  it('mocks nested declarations and providers while preserving the real host', async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostModule, MockModule(BoundaryModule)],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const component = ngMocks.findInstance(fixture, PrivateComponent);
+    const directive = ngMocks.findInstance(fixture, PrivateDirective);
+    const pipe = ngMocks.findInstance(fixture, PrivatePipe);
+    const shared = ngMocks.findInstance(fixture, SharedComponent);
+
+    expect(isMockOf(fixture.componentInstance, HostComponent)).toBe(
+      false,
+    );
+    expect(isMockOf(component, PrivateComponent)).toBe(true);
+    expect(isMockOf(directive, PrivateDirective)).toBe(true);
+    expect(isMockOf(pipe, PrivatePipe)).toBe(true);
+    expect(isMockOf(shared, SharedComponent)).toBe(true);
+    expect(component.value).toEqual('initial');
+    expect(fixture.componentInstance.privateProvider).not.toBe(
+      privateValue,
+    );
+    expect(fixture.componentInstance.sharedProvider).not.toBe(
+      sharedValue,
+    );
+    expect(privateFactoryCalls).toEqual(0);
+    expect(sharedFactoryCalls).toEqual(0);
+    expect(privateConstructors).toEqual([]);
+    expect(sharedConstructorCalls).toEqual(0);
+    expect(transformCalls).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toContain('host:initial:0');
+    expect(ngMocks.formatText(fixture)).not.toContain(
+      'real-private:',
+    );
+    expect(ngMocks.formatText(fixture)).not.toContain('real-shared:');
+    expect(ngMocks.formatText(fixture)).not.toContain('real-pipe:');
+
+    ngMocks.find(fixture, 'button').triggerEventHandler('click', {});
+    component.changed.emit('updated');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.clicks).toEqual(1);
+    expect(fixture.componentInstance.value).toEqual('updated');
+    expect(component.value).toEqual('updated');
+    expect(listenerCalls).toEqual(0);
+    expect(transformCalls).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toContain('host:updated:1');
+  });
+
+  it('keeps a shared descendant reached through an independent real module', async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HostModule,
+        MockModule(BoundaryModule),
+        IndependentModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const component = ngMocks.findInstance(fixture, PrivateComponent);
+    const directive = ngMocks.findInstance(fixture, PrivateDirective);
+    const pipe = ngMocks.findInstance(fixture, PrivatePipe);
+    const shared = ngMocks.findInstance(fixture, SharedComponent);
+
+    expect(isMockOf(fixture.componentInstance, HostComponent)).toBe(
+      false,
+    );
+    expect(isMockOf(component, PrivateComponent)).toBe(true);
+    expect(isMockOf(directive, PrivateDirective)).toBe(true);
+    expect(isMockOf(pipe, PrivatePipe)).toBe(true);
+    expect(isMockOf(shared, SharedComponent)).toBe(false);
+    expect(shared.value).toEqual('initial');
+    expect(fixture.componentInstance.privateProvider).not.toBe(
+      privateValue,
+    );
+    expect(fixture.componentInstance.sharedProvider).toBe(
+      sharedValue,
+    );
+    expect(privateFactoryCalls).toEqual(0);
+    expect(sharedFactoryCalls).toEqual(1);
+    expect(privateConstructors).toEqual([]);
+    expect(sharedConstructorCalls).toEqual(1);
+    expect(transformCalls).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toContain(
+      'real-shared:initial',
+    );
+    expect(ngMocks.formatText(fixture)).not.toContain(
+      'real-private:',
+    );
+    expect(ngMocks.formatText(fixture)).not.toContain('real-pipe:');
+
+    ngMocks.find(fixture, 'button').triggerEventHandler('click', {});
+    component.changed.emit('updated');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.clicks).toEqual(1);
+    expect(component.value).toEqual('updated');
+    expect(shared.value).toEqual('updated');
+    expect(listenerCalls).toEqual(0);
+    expect(transformCalls).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toContain('host:updated:1');
+    expect(ngMocks.formatText(fixture)).toContain(
+      'real-shared:updated',
+    );
+  });
+
+  it('preserves shared real dependencies when top-level imports are reversed', async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        IndependentModule,
+        MockModule(BoundaryModule),
+        HostModule,
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const component = ngMocks.findInstance(fixture, PrivateComponent);
+    const directive = ngMocks.findInstance(fixture, PrivateDirective);
+    const pipe = ngMocks.findInstance(fixture, PrivatePipe);
+    const shared = ngMocks.findInstance(fixture, SharedComponent);
+
+    expect(isMockOf(fixture.componentInstance, HostComponent)).toBe(
+      false,
+    );
+    expect(isMockOf(component, PrivateComponent)).toBe(true);
+    expect(isMockOf(directive, PrivateDirective)).toBe(true);
+    expect(isMockOf(pipe, PrivatePipe)).toBe(true);
+    expect(isMockOf(shared, SharedComponent)).toBe(false);
+    expect(shared.value).toEqual('initial');
+    expect(fixture.componentInstance.privateProvider).not.toBe(
+      privateValue,
+    );
+    expect(fixture.componentInstance.sharedProvider).toBe(
+      sharedValue,
+    );
+    expect(privateFactoryCalls).toEqual(0);
+    expect(sharedFactoryCalls).toEqual(1);
+    expect(privateConstructors).toEqual([]);
+    expect(sharedConstructorCalls).toEqual(1);
+    expect(transformCalls).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toContain(
+      'real-shared:initial',
+    );
+    expect(ngMocks.formatText(fixture)).not.toContain(
+      'real-private:',
+    );
+    expect(ngMocks.formatText(fixture)).not.toContain('real-pipe:');
+
+    ngMocks.find(fixture, 'button').triggerEventHandler('click', {});
+    component.changed.emit('updated');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.clicks).toEqual(1);
+    expect(component.value).toEqual('updated');
+    expect(shared.value).toEqual('updated');
+    expect(listenerCalls).toEqual(0);
+    expect(transformCalls).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toContain('host:updated:1');
+    expect(ngMocks.formatText(fixture)).toContain(
+      'real-shared:updated',
+    );
+  });
+});

--- a/tests/ng-mocks-global-exclude-modules/mixed.spec.ts
+++ b/tests/ng-mocks-global-exclude-modules/mixed.spec.ts
@@ -1,0 +1,122 @@
+import {
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+const calls: string[] = [];
+
+@Component({
+  selector: 'child-global-exclude-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'excluded child',
+})
+class ExcludedChildComponent {
+  public constructor() {
+    calls.push('excluded child');
+  }
+}
+
+@NgModule({
+  declarations: [ExcludedChildComponent],
+  exports: [ExcludedChildComponent],
+})
+class SharedModule {}
+
+@Component({
+  selector: 'excluded-global-exclude-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template:
+    '<child-global-exclude-mixed></child-global-exclude-mixed>',
+})
+class ExcludedComponent {
+  public constructor() {
+    calls.push('excluded');
+  }
+}
+
+@NgModule({
+  declarations: [ExcludedComponent],
+  exports: [ExcludedComponent],
+  imports: [SharedModule],
+})
+class ExcludedModule {}
+
+@Component({
+  selector: 'mocked-global-exclude-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'real mocked',
+})
+class MockedComponent {
+  public constructor() {
+    calls.push('mocked');
+  }
+}
+
+@NgModule({
+  declarations: [MockedComponent],
+  exports: [MockedComponent, SharedModule],
+  imports: [SharedModule],
+})
+class MockedModule {}
+
+@Component({
+  selector: 'host-global-exclude-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: `
+    host
+    <excluded-global-exclude-mixed></excluded-global-exclude-mixed>
+    <child-global-exclude-mixed></child-global-exclude-mixed>
+    <mocked-global-exclude-mixed></mocked-global-exclude-mixed>
+  `,
+})
+class HostComponent {}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [ExcludedModule, MockedModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+class HostModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14895
+describe('ng-mocks-global-exclude-modules:mixed', () => {
+  beforeAll(() => ngMocks.globalExclude(ExcludedModule));
+  afterAll(() => ngMocks.globalWipe(ExcludedModule));
+
+  beforeEach(() => {
+    calls.length = 0;
+
+    return TestBed.configureTestingModule({
+      imports: [HostModule, MockModule(MockedModule)],
+    });
+  });
+
+  it('excludes the module without keeping its shared descendant real through a mock', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    expect(
+      ngMocks.findInstance(fixture, ExcludedComponent, null),
+    ).toBeNull();
+    // The excluded path must not infer a keep for a child that is still
+    // rendered through the explicitly mocked module.
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, ExcludedChildComponent),
+        ExcludedChildComponent,
+      ),
+    ).toBe(true);
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, MockedComponent),
+        MockedComponent,
+      ),
+    ).toBe(true);
+    expect(ngMocks.formatText(fixture)).toEqual('host');
+    expect(calls).toEqual([]);
+  });
+});

--- a/tests/ng-mocks-global-keep-modules/mixed.spec.ts
+++ b/tests/ng-mocks-global-keep-modules/mixed.spec.ts
@@ -1,0 +1,122 @@
+import { Component, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+const calls: string[] = [];
+
+@Component({
+  selector: 'child-global-keep-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'real child',
+})
+class ChildComponent {
+  public constructor() {
+    calls.push('child');
+  }
+}
+
+@NgModule({
+  declarations: [ChildComponent],
+  exports: [ChildComponent],
+})
+class ChildModule {}
+
+@Component({
+  selector: 'kept-global-keep-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template:
+    'kept <child-global-keep-mixed></child-global-keep-mixed>',
+})
+class KeptComponent {
+  public constructor() {
+    calls.push('kept');
+  }
+}
+
+@NgModule({
+  declarations: [KeptComponent],
+  exports: [KeptComponent],
+  imports: [ChildModule],
+})
+class KeptModule {}
+
+@Component({
+  selector: 'mocked-global-keep-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'real mocked',
+})
+class MockedComponent {
+  public constructor() {
+    calls.push('mocked');
+  }
+}
+
+@NgModule({
+  declarations: [MockedComponent],
+  exports: [MockedComponent],
+})
+class MockedModule {}
+
+@Component({
+  selector: 'host-global-keep-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: `
+    host
+    <kept-global-keep-mixed></kept-global-keep-mixed>
+    <mocked-global-keep-mixed></mocked-global-keep-mixed>
+  `,
+})
+class HostComponent {}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [KeptModule, MockedModule],
+})
+class HostModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14895
+describe('ng-mocks-global-keep-modules:mixed', () => {
+  beforeAll(() => {
+    ngMocks.globalKeep(KeptModule);
+    ngMocks.globalMock(ChildModule);
+  });
+  afterAll(() => {
+    ngMocks.globalWipe(KeptModule);
+    ngMocks.globalWipe(ChildModule);
+  });
+
+  beforeEach(() => {
+    calls.length = 0;
+
+    return TestBed.configureTestingModule({
+      imports: [HostModule, MockModule(MockedModule)],
+    });
+  });
+
+  it('keeps the module without overriding a global child-module mock or an explicit module mock', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, KeptComponent),
+        KeptComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, ChildComponent),
+        ChildComponent,
+      ),
+    ).toBe(true);
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, MockedComponent),
+        MockedComponent,
+      ),
+    ).toBe(true);
+    expect(ngMocks.formatText(fixture)).toEqual('host kept');
+    expect(calls).toEqual(['kept']);
+  });
+});

--- a/tests/ng-mocks-global-replace-modules/mixed.spec.ts
+++ b/tests/ng-mocks-global-replace-modules/mixed.spec.ts
@@ -1,0 +1,164 @@
+import { Component, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+const calls: string[] = [];
+
+@Component({
+  selector: 'original-child-global-replace-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'original child',
+})
+class OriginalChildComponent {
+  public constructor() {
+    calls.push('original child');
+  }
+}
+
+@NgModule({
+  declarations: [OriginalChildComponent],
+  exports: [OriginalChildComponent],
+})
+class SharedModule {}
+
+@Component({
+  selector: 'target-global-replace-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template:
+    '<original-child-global-replace-mixed></original-child-global-replace-mixed>',
+})
+class OriginalComponent {
+  public constructor() {
+    calls.push('original');
+  }
+}
+
+@NgModule({
+  declarations: [OriginalComponent],
+  exports: [OriginalComponent],
+  imports: [SharedModule],
+})
+class OriginalModule {}
+
+@Component({
+  selector: 'replacement-child-global-replace-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'replacement child',
+})
+class ReplacementChildComponent {
+  public constructor() {
+    calls.push('replacement child');
+  }
+}
+
+@Component({
+  selector: 'target-global-replace-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  // The replacement shares a selector but needs a distinct Angular component ID.
+  host: { 'data-replacement': 'true' },
+  template:
+    '<replacement-child-global-replace-mixed></replacement-child-global-replace-mixed>',
+})
+class ReplacementComponent {
+  public constructor() {
+    calls.push('replacement');
+  }
+}
+
+@NgModule({
+  declarations: [ReplacementComponent, ReplacementChildComponent],
+  exports: [ReplacementComponent],
+})
+class ReplacementModule {}
+
+@Component({
+  selector: 'mocked-global-replace-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'real mocked',
+})
+class MockedComponent {
+  public constructor() {
+    calls.push('mocked');
+  }
+}
+
+@NgModule({
+  declarations: [MockedComponent],
+  exports: [MockedComponent, SharedModule],
+  imports: [SharedModule],
+})
+class MockedModule {}
+
+@Component({
+  selector: 'host-global-replace-mixed',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: `
+    host
+    <target-global-replace-mixed></target-global-replace-mixed>
+    <original-child-global-replace-mixed></original-child-global-replace-mixed>
+    <mocked-global-replace-mixed></mocked-global-replace-mixed>
+  `,
+})
+class HostComponent {}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [OriginalModule, MockedModule],
+})
+class HostModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14895
+describe('ng-mocks-global-replace-modules:mixed', () => {
+  beforeAll(() =>
+    ngMocks.globalReplace(OriginalModule, ReplacementModule),
+  );
+  afterAll(() => ngMocks.globalWipe(OriginalModule));
+
+  beforeEach(() => {
+    calls.length = 0;
+
+    return TestBed.configureTestingModule({
+      imports: [HostModule, MockModule(MockedModule)],
+    });
+  });
+
+  it('replaces the real import graph without restoring original descendants', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, ReplacementComponent),
+        ReplacementComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, ReplacementChildComponent),
+        ReplacementChildComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, MockedComponent),
+        MockedComponent,
+      ),
+    ).toBe(true);
+    expect(
+      ngMocks.findInstance(fixture, OriginalComponent, null),
+    ).toBeNull();
+    // Traversing the replaced module must not keep this shared child real
+    // when it is also reachable through the explicitly mocked module.
+    expect(
+      isMockOf(
+        ngMocks.findInstance(fixture, OriginalChildComponent),
+        OriginalChildComponent,
+      ),
+    ).toBe(true);
+    expect(ngMocks.formatText(fixture)).toEqual(
+      'host replacement child',
+    );
+    expect(calls).toEqual(['replacement', 'replacement child']);
+  });
+});


### PR DESCRIPTION
## Why

The mixed TestBed fix in #14654 stopped inferred real dependencies at explicitly mocked module boundaries. Its original host-listener regression did not directly cover nested modules, shared descendants reached through an independent real import, or global module resolutions.

Follow-up to #14653 and #14654. Fixes #14895.

## What

Add real-Angular regressions for nested mocked declarations and providers, preserved real host behavior, shared real descendants, and reversed TestBed import order. Check declaration identities and the absence of real constructor, listener, and provider-factory side effects below mock boundaries.

Extend the global module feature suites with mixed-TestBed cases for mock, keep, replace, and exclude, including a globally mocked child module inside a globally kept parent. Add focused dependency-traversal cases showing that blocked nodes are collected without visiting their descendants and that independent real roots still reach shared descendants in either root order.

## Impact

The broader boundary and precedence contracts now have regression coverage alongside the original issue tests. Existing behavior is preserved, so no public API or documentation change is required.
