### PR TITLE
docs(migrations): clarify mocked signal input behavior #14897

### DIFF
--- a/docs/articles/api/MockComponent.md
+++ b/docs/articles/api/MockComponent.md
@@ -26,7 +26,7 @@ The class of a mock component has:
 
 - the same `selector`
 - the same inputs and outputs with alias support
-- signal inputs which stay callable and keep their required and transform metadata
+- signal inputs which stay callable when declared with `input()` or `input.required()`
 - templates with pure `<ng-content>` tags to allow transclusion
 - support for `@ContentChild` and `@ContentChildren`
 - support for `ControlValueAccessor`, `Validator` and `AsyncValidator`
@@ -101,8 +101,8 @@ describe('Test', () => {
 
 Starting with Angular 17, inputs can be declared with `input()` and
 `input.required()`. `MockComponent` preserves them as signals instead of
-replacing them with ordinary properties. Angular can therefore bind aliases
-and run input transforms in the same way as it does for the real component.
+replacing them with ordinary properties. Angular updates their values through
+template bindings, including bindings that use input aliases.
 
 ```ts
 @Component({
@@ -134,9 +134,15 @@ expect(child.name()).toEqual(fixture.point.componentInstance.name);
 ```
 
 The template uses the input alias, while the mock instance is read through the
-original property name. Required signal inputs remain required in Angular's
-metadata. For details about binding signal inputs on the component rendered by
+original property name. For details about binding signal inputs on the component rendered by
 `MockRender`, see [ComponentRef.setInput and signal inputs](MockRender.md#componentrefsetinput-and-signal-inputs).
+
+Mocks do not run the original component's constructor or field initializers.
+Angular stores transforms supplied to `input()` or `input.required()` on the initialized signal,
+without exposing them in reflected input metadata. A mock therefore receives the raw bound value
+without running that transform; for example, a bound string `'2'` remains a string.
+Decorator-based `@Input({ transform: ... })` transforms are preserved through their reflected metadata.
+Use `.keep(ChildComponent)` when the test needs the real component's initialization or signal-input transform.
 
 ## Standalone components
 

--- a/docs/articles/migrations.md
+++ b/docs/articles/migrations.md
@@ -13,13 +13,14 @@ If you are facing an issue, despite the instructions, please, feel free to [cont
 
 ## From ng-mocks 14.15 to 14.16
 
-### Signal inputs of mocked components
+### Signal inputs of mocked components and directives {#signal-inputs-of-mocked-components}
 
-Starting with `14.16.0`, [`MockComponent`](api/MockComponent.md) and component mocks created by
-[`MockBuilder`](api/MockBuilder.md) preserve inputs declared with `input()` or `input.required()` as Angular signals.
-Previously, a bound signal input on a mocked component was incorrectly replaced with its plain value. The change fixes
-[#13671](https://github.com/help-me-mom/ng-mocks/issues/13671) and makes mocked and kept components expose the same
-input interface. Input aliases, required-input metadata and transforms are preserved too.
+Starting with `14.16.0`, [`MockComponent`](api/MockComponent.md) and [`MockDirective`](api/MockDirective.md) preserve
+inputs declared with `input()` or `input.required()` as Angular signals. This also applies to components and directives
+mocked by [`MockBuilder`](api/MockBuilder.md), including dependencies mocked indirectly through their modules.
+Previously, a bound signal input on a mocked declaration was incorrectly replaced with its plain value. The change
+fixes [#13671](https://github.com/help-me-mom/ng-mocks/issues/13671) and makes mocked and kept declarations expose the
+same input interface. Input aliases are preserved too.
 
 This is an observable behavior change for Angular 17+ tests which relied on the old mock-only behavior. For example,
 this assertion could pass before `14.16.0` even though `name` is declared as a signal:
@@ -30,7 +31,7 @@ const child = ngMocks.findInstance(ChildComponent);
 expect(child.name).toEqual('test');
 ```
 
-Since `14.16.0`, read the signal as you would on the real component:
+Since `14.16.0`, read the signal as you would on the real component or directive:
 
 ```ts
 const child = ngMocks.findInstance(ChildComponent);
@@ -38,13 +39,43 @@ const child = ngMocks.findInstance(ChildComponent);
 expect(child.name()).toEqual('test');
 ```
 
-Before updating, check tests which access a mocked component through `componentInstance` or `ngMocks.findInstance`.
-If a property is declared with `input()` or `input.required()`, update direct reads to call the signal. Do not assign a
-value directly to the property. Change its parent binding and run change detection, or use Angular's
-[`ComponentRef.setInput`](api/MockRender.md#componentrefsetinput-and-signal-inputs) when the component is rendered
-directly.
+Before updating, check tests which access mocked components through `componentInstance` and mocked components or
+directives through `ngMocks.findInstance` or `ngMocks.get`. If a property is declared with `input()` or
+`input.required()`, update direct reads to call the signal. Do not assign a value directly to the signal property.
+Change the value bound by the parent or host template and run change detection.
 
-For value-oriented assertions which should work both before and after `14.16.0`, use [`ngMocks.input`](api/ngMocks/input.md):
+For example, suppose `HostModule` imports a module declaring `DependencyDirective`, and the host's `span` binds
+`[publicLabel]="label"` to the directive's aliased `label` signal. `MockBuilder` mocks that directive as a dependency:
+
+```ts
+beforeEach(() => MockBuilder(HostComponent, HostModule));
+
+it('updates the mocked directive input through the host binding', () => {
+  const fixture = MockRender(HostComponent);
+  const host = fixture.point.componentInstance;
+  const element = ngMocks.find('span');
+  const directive = ngMocks.get(element, DependencyDirective);
+
+  host.label = 'label-second';
+  fixture.detectChanges();
+
+  expect(directive.label()).toEqual('label-second');
+  expect(ngMocks.input(element, 'publicLabel')).toEqual('label-second');
+});
+```
+
+The same reads and host-binding updates work with a directive created directly by `MockDirective`.
+For a host created with `TestBed.createComponent` in a zoneless test, call
+`fixture.changeDetectorRef.markForCheck()` after direct property writes and before `fixture.detectChanges()`.
+See Angular's [zoneless testing guidance](https://angular.dev/guide/zoneless#using-zoneless-in-testbed).
+
+For components rendered directly, Angular's
+[`ComponentRef.setInput`](api/MockRender.md#componentrefsetinput-and-signal-inputs) is another way to update an input;
+run change detection afterwards. Directives do not have a `ComponentRef`, so update their host bindings instead.
+
+For value-oriented assertions which should work both before and after `14.16.0`, use
+[`ngMocks.input`](api/ngMocks/input.md). It returns the input's value for both components and directives. Use the
+public binding alias when an input has one, as with `publicLabel` above:
 
 ```ts
 const child = ngMocks.find(ChildComponent);
@@ -52,8 +83,28 @@ const child = ngMocks.find(ChildComponent);
 expect(ngMocks.input(child, 'name')).toEqual('test');
 ```
 
-No changes are needed for decorator-based `@Input()` properties. Kept components already exposed signal inputs as
-signals, so this migration applies only when the declaration is replaced with a mock.
+No changes are needed for decorator-based `@Input()` properties; they remain ordinary properties. Kept components
+and directives already exposed signal inputs as signals, so this migration applies only when the declaration is
+replaced with a mock.
+
+Preserving the signal interface does not preserve the original constructor or field initializers. For example,
+do not expect a mocked `input('default')` to retain that initial value. Supply the values needed by the test through
+its bindings.
+
+This also affects transforms defined in an `input()` or `input.required()` initializer. Angular does not expose
+those transform functions in reflected input metadata, so ng-mocks cannot recover them without running the original
+initialization. A mocked component or directive therefore receives the raw bound value: a bound string such as
+`'2'` remains a string, even if the original signal input transforms strings into numbers.
+Decorator-based `@Input({ transform: ... })` transforms are preserved through their reflected metadata.
+
+When a test needs the original signal-input transform or initialization, keep that component or directive.
+For the directive example above, replace the setup with:
+
+```ts
+beforeEach(() =>
+  MockBuilder(HostComponent, HostModule).keep(DependencyDirective),
+);
+```
 
 ## From 21 to 22
 

--- a/libs/ng-mocks/src/lib/common/mock.spec.ts
+++ b/libs/ng-mocks/src/lib/common/mock.spec.ts
@@ -418,6 +418,8 @@ describe('definitions', () => {
     expect(instance.regular).toBeUndefined();
     expect(isSignal(instance.value)).toBe(true);
     expect(isSignal(instance.required)).toBe(true);
+    expect(instance.value()).toBeUndefined();
+    expect(() => instance.required()).toThrowError(/NG0950/);
     expect(instance.__ngMocks).toBe(true);
   });
 

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -86,6 +86,7 @@ file|tests/issue-12725/test.spec.ts|versions=21+
 file|tests/issue-13671/test.spec.ts|features=signalInputs
 file|tests/issue-14003/test.spec.ts|features=signalInputs
 file|tests/issue-14692/test.spec.ts|features=signalInputs
+file|tests/issue-14897/*.ts|features=signalInputs
 file|tests/issue-14839/test.spec.ts|features=signalInputs
 file|tests/issue-7976/test.spec.ts|features=signalInputs
 file|tests/issue-8887/test.spec.ts|features=signalInputs

--- a/tests/issue-14897/builder.spec.ts
+++ b/tests/issue-14897/builder.spec.ts
@@ -1,0 +1,374 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  Input,
+  input,
+  isSignal,
+  NgModule,
+} from '@angular/core';
+
+import { isMockOf, MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+let constructorCalls = 0;
+let initializerCalls = 0;
+let transformations = 0;
+
+@Directive({
+  exportAs: 'dependency14897Builder',
+  selector: '[dependency-14897-builder]',
+  standalone: false,
+})
+class DependencyDirective {
+  public readonly initialized = ++initializerCalls;
+  public readonly plain = input('original plain');
+  public readonly label = input('original label', {
+    alias: 'publicLabel',
+  });
+  public readonly requiredName = input.required<string>({
+    alias: 'requiredLabel',
+  });
+  public readonly amount = input(0, {
+    alias: 'publicAmount',
+    transform: (value: string | number) => {
+      transformations += 1;
+
+      return Number(value) * 2;
+    },
+  });
+  @Input() public legacy = 'original legacy';
+
+  public constructor() {
+    constructorCalls += 1;
+  }
+}
+
+@NgModule({
+  declarations: [DependencyDirective],
+  exports: [DependencyDirective],
+})
+class DependencyModule {}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'host-14897-builder',
+  standalone: false,
+  template: `
+    <span
+      dependency-14897-builder
+      [plain]="plain"
+      [publicLabel]="label"
+      [requiredLabel]="requiredName"
+      [publicAmount]="amount"
+      [legacy]="legacy"
+      #dependency="dependency14897Builder"
+      >{{ dependency.plain() }}:{{ dependency.label() }}:{{
+        dependency.requiredName()
+      }}:{{ dependency.amount() }}:{{ dependency.legacy }}</span
+    >
+  `,
+})
+class HostComponent {
+  public plain = 'first';
+  public label = 'label-first';
+  public requiredName = 'required-first';
+  public amount: string | number = '2';
+  public legacy = 'legacy-first';
+}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [DependencyModule],
+})
+class HostModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14897
+describe('issue-14897:builder', () => {
+  // The root TypeScript-only runner does not compile directive signal inputs.
+  if (!(DependencyDirective as any).ɵdir?.inputs?.plain) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => {
+    constructorCalls = 0;
+    initializerCalls = 0;
+    transformations = 0;
+  });
+
+  describe('mocked through a dependency module', () => {
+    beforeEach(() => MockBuilder(HostComponent, HostModule));
+
+    it('updates callable signal inputs without running initializer transform logic', () => {
+      const fixture = MockRender(HostComponent);
+      const host = fixture.point.componentInstance;
+      const element = ngMocks.find('span');
+      const directive = ngMocks.get(element, DependencyDirective);
+      const plain = directive.plain;
+      const label = directive.label;
+      const requiredName = directive.requiredName;
+      const amount = directive.amount;
+
+      expect(isMockOf(directive, DependencyDirective)).toBe(true);
+      expect(isSignal(plain)).toBe(true);
+      expect(isSignal(label)).toBe(true);
+      expect(isSignal(requiredName)).toBe(true);
+      expect(isSignal(amount)).toBe(true);
+      expect(isSignal(directive.legacy)).toBe(false);
+      // Mock directives retain raw bindings without running input initializer transforms.
+      expect([
+        plain(),
+        label(),
+        requiredName(),
+        amount(),
+        directive.legacy,
+      ]).toEqual([
+        'first',
+        'label-first',
+        'required-first',
+        '2',
+        'legacy-first',
+      ]);
+      expect([
+        ngMocks.input(element, 'plain'),
+        ngMocks.input(element, 'publicLabel'),
+        ngMocks.input(element, 'requiredLabel'),
+        ngMocks.input(element, 'publicAmount'),
+        ngMocks.input(element, 'legacy'),
+      ]).toEqual([
+        'first',
+        'label-first',
+        'required-first',
+        '2',
+        'legacy-first',
+      ]);
+      expect(ngMocks.formatText(fixture)).toEqual(
+        'first:label-first:required-first:2:legacy-first',
+      );
+      expect(directive.initialized).toBeUndefined();
+      expect(constructorCalls).toBe(0);
+      expect(initializerCalls).toBe(0);
+      expect(transformations).toBe(0);
+
+      host.plain = 'second';
+      host.label = 'label-second';
+      host.requiredName = 'required-second';
+      host.amount = 3;
+      host.legacy = 'legacy-second';
+      fixture.detectChanges();
+
+      expect(directive.plain).toBe(plain);
+      expect(directive.label).toBe(label);
+      expect(directive.requiredName).toBe(requiredName);
+      expect(directive.amount).toBe(amount);
+      expect([
+        plain(),
+        label(),
+        requiredName(),
+        amount(),
+        directive.legacy,
+      ]).toEqual([
+        'second',
+        'label-second',
+        'required-second',
+        3,
+        'legacy-second',
+      ]);
+      expect([
+        ngMocks.input(element, 'plain'),
+        ngMocks.input(element, 'publicLabel'),
+        ngMocks.input(element, 'requiredLabel'),
+        ngMocks.input(element, 'publicAmount'),
+        ngMocks.input(element, 'legacy'),
+      ]).toEqual([
+        'second',
+        'label-second',
+        'required-second',
+        3,
+        'legacy-second',
+      ]);
+      expect(ngMocks.formatText(fixture)).toEqual(
+        'second:label-second:required-second:3:legacy-second',
+      );
+      expect(constructorCalls).toBe(0);
+      expect(initializerCalls).toBe(0);
+      expect(transformations).toBe(0);
+
+      host.plain = 'third';
+      host.label = 'label-third';
+      host.requiredName = 'required-third';
+      host.amount = '4';
+      host.legacy = 'legacy-third';
+      fixture.detectChanges();
+
+      expect(directive.plain).toBe(plain);
+      expect(directive.label).toBe(label);
+      expect(directive.requiredName).toBe(requiredName);
+      expect(directive.amount).toBe(amount);
+      expect([
+        plain(),
+        label(),
+        requiredName(),
+        amount(),
+        directive.legacy,
+      ]).toEqual([
+        'third',
+        'label-third',
+        'required-third',
+        '4',
+        'legacy-third',
+      ]);
+      expect([
+        ngMocks.input(element, 'plain'),
+        ngMocks.input(element, 'publicLabel'),
+        ngMocks.input(element, 'requiredLabel'),
+        ngMocks.input(element, 'publicAmount'),
+        ngMocks.input(element, 'legacy'),
+      ]).toEqual([
+        'third',
+        'label-third',
+        'required-third',
+        '4',
+        'legacy-third',
+      ]);
+      expect(ngMocks.formatText(fixture)).toEqual(
+        'third:label-third:required-third:4:legacy-third',
+      );
+      expect(constructorCalls).toBe(0);
+      expect(initializerCalls).toBe(0);
+      expect(transformations).toBe(0);
+    });
+  });
+
+  describe('kept through a dependency module', () => {
+    beforeEach(() =>
+      MockBuilder(HostComponent, HostModule).keep(
+        DependencyDirective,
+      ),
+    );
+
+    it('preserves real signal inputs and initialization when the directive is kept', () => {
+      const fixture = MockRender(HostComponent);
+      const host = fixture.point.componentInstance;
+      const element = ngMocks.find('span');
+      const directive = ngMocks.get(element, DependencyDirective);
+      const plain = directive.plain;
+      const label = directive.label;
+      const requiredName = directive.requiredName;
+      const amount = directive.amount;
+
+      expect(isMockOf(directive, DependencyDirective)).toBe(false);
+      expect(isSignal(plain)).toBe(true);
+      expect(isSignal(label)).toBe(true);
+      expect(isSignal(requiredName)).toBe(true);
+      expect(isSignal(amount)).toBe(true);
+      expect(isSignal(directive.legacy)).toBe(false);
+      expect([
+        plain(),
+        label(),
+        requiredName(),
+        amount(),
+        directive.legacy,
+      ]).toEqual([
+        'first',
+        'label-first',
+        'required-first',
+        4,
+        'legacy-first',
+      ]);
+      expect(ngMocks.input(element, 'plain')).toEqual('first');
+      expect(ngMocks.input(element, 'publicLabel')).toEqual(
+        'label-first',
+      );
+      expect(ngMocks.input(element, 'requiredLabel')).toEqual(
+        'required-first',
+      );
+      expect(ngMocks.input(element, 'publicAmount')).toEqual(4);
+      expect(ngMocks.input(element, 'legacy')).toEqual(
+        'legacy-first',
+      );
+      expect(ngMocks.formatText(fixture)).toEqual(
+        'first:label-first:required-first:4:legacy-first',
+      );
+      expect(directive.initialized).toBe(1);
+      expect(constructorCalls).toBe(1);
+      expect(initializerCalls).toBe(1);
+      expect(transformations).toBe(1);
+
+      host.plain = 'second';
+      host.label = 'label-second';
+      host.requiredName = 'required-second';
+      host.amount = 3;
+      host.legacy = 'legacy-second';
+      fixture.detectChanges();
+
+      expect(directive.plain).toBe(plain);
+      expect(directive.label).toBe(label);
+      expect(directive.requiredName).toBe(requiredName);
+      expect(directive.amount).toBe(amount);
+      expect([
+        plain(),
+        label(),
+        requiredName(),
+        amount(),
+        directive.legacy,
+      ]).toEqual([
+        'second',
+        'label-second',
+        'required-second',
+        6,
+        'legacy-second',
+      ]);
+      expect(ngMocks.formatText(fixture)).toEqual(
+        'second:label-second:required-second:6:legacy-second',
+      );
+      expect(transformations).toBe(2);
+
+      host.plain = 'third';
+      host.label = 'label-third';
+      host.requiredName = 'required-third';
+      host.amount = '4';
+      host.legacy = 'legacy-third';
+      fixture.detectChanges();
+
+      expect(directive.plain).toBe(plain);
+      expect(directive.label).toBe(label);
+      expect(directive.requiredName).toBe(requiredName);
+      expect(directive.amount).toBe(amount);
+      expect([
+        plain(),
+        label(),
+        requiredName(),
+        amount(),
+        directive.legacy,
+      ]).toEqual([
+        'third',
+        'label-third',
+        'required-third',
+        8,
+        'legacy-third',
+      ]);
+      expect(ngMocks.input(element, 'plain')).toEqual('third');
+      expect(ngMocks.input(element, 'publicLabel')).toEqual(
+        'label-third',
+      );
+      expect(ngMocks.input(element, 'requiredLabel')).toEqual(
+        'required-third',
+      );
+      expect(ngMocks.input(element, 'publicAmount')).toEqual(8);
+      expect(ngMocks.input(element, 'legacy')).toEqual(
+        'legacy-third',
+      );
+      expect(ngMocks.formatText(fixture)).toEqual(
+        'third:label-third:required-third:8:legacy-third',
+      );
+      expect(directive.initialized).toBe(1);
+      expect(constructorCalls).toBe(1);
+      expect(initializerCalls).toBe(1);
+      expect(transformations).toBe(3);
+    });
+  });
+});

--- a/tests/issue-14897/component.spec.ts
+++ b/tests/issue-14897/component.spec.ts
@@ -1,0 +1,111 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  isSignal,
+  reflectComponentType,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockComponent, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'target-14897-component',
+  standalone: false,
+  template: '',
+})
+class TargetComponent {
+  public static constructed = 0;
+  public static transformed = 0;
+
+  public readonly value = input(0, {
+    alias: 'publicValue',
+    transform: (value: string | number) => {
+      TargetComponent.transformed += 1;
+
+      return Number(value) * 2;
+    },
+  });
+
+  public constructor() {
+    TargetComponent.constructed += 1;
+  }
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'host-14897-component',
+  standalone: false,
+  template: `
+    <target-14897-component
+      [publicValue]="value"
+    ></target-14897-component>
+  `,
+})
+class HostComponent {
+  public value: string | number = '2';
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14897
+describe('issue-14897:component', () => {
+  // The root TypeScript-only runner does not transform signal declarations.
+  if (
+    !reflectComponentType(TargetComponent)?.inputs.some(
+      inputMetadata => inputMetadata.propName === 'value',
+    )
+  ) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => {
+    TargetComponent.constructed = 0;
+    TargetComponent.transformed = 0;
+
+    return TestBed.configureTestingModule({
+      declarations: [HostComponent, MockComponent(TargetComponent)],
+    }).compileComponents();
+  });
+
+  it('updates an aliased signal input without executing its original transform', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const element = ngMocks.find(fixture, TargetComponent);
+    const component = element.componentInstance;
+    const value = component.value;
+
+    expect(isMockOf(component, TargetComponent)).toBe(true);
+    expect(isSignal(value)).toBe(true);
+    // Angular does not expose the signal transform in compiled input metadata.
+    // MockComponent skips original field initializers, so the signal receives
+    // raw bound values without executing the original transform.
+    expect(value() as unknown).toEqual('2');
+    expect(ngMocks.input(element, 'publicValue')).toEqual('2');
+    expect(TargetComponent.constructed).toEqual(0);
+    expect(TargetComponent.transformed).toEqual(0);
+
+    fixture.componentInstance.value = 3;
+    // Direct TestBed fixtures need notification after plain property updates in zoneless mode.
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    expect(component.value).toBe(value);
+    expect(value()).toEqual(3);
+    expect(ngMocks.input(element, 'publicValue')).toEqual(3);
+    expect(TargetComponent.constructed).toEqual(0);
+    expect(TargetComponent.transformed).toEqual(0);
+
+    fixture.componentInstance.value = '4';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    expect(component.value).toBe(value);
+    expect(value() as unknown).toEqual('4');
+    expect(ngMocks.input(element, 'publicValue')).toEqual('4');
+    expect(TargetComponent.constructed).toEqual(0);
+    expect(TargetComponent.transformed).toEqual(0);
+  });
+});

--- a/tests/issue-14897/direct.spec.ts
+++ b/tests/issue-14897/direct.spec.ts
@@ -1,0 +1,184 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  Input,
+  input,
+  isSignal,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockDirective, ngMocks } from 'ng-mocks';
+
+@Directive({
+  selector: '[dependency14897]',
+  standalone: true,
+})
+class DependencyDirective {
+  public static constructed = 0;
+  public static transformed = 0;
+
+  public readonly plain = input('plain-default');
+  public readonly label = input('label-default', {
+    alias: 'publicLabel',
+  });
+  public readonly requiredName = input.required<string>({
+    alias: 'requiredLabel',
+  });
+  public readonly amount = input(0, {
+    alias: 'publicAmount',
+    transform: (value: string | number) => {
+      DependencyDirective.transformed += 1;
+
+      return Number(value);
+    },
+  });
+  @Input() public legacy = 'legacy-default';
+
+  public constructor() {
+    DependencyDirective.constructed += 1;
+  }
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'host-14897-direct',
+  standalone: false,
+  template: `
+    <span
+      dependency14897
+      [plain]="plain"
+      [publicLabel]="label"
+      [requiredLabel]="requiredName"
+      [publicAmount]="amount"
+      [legacy]="legacy"
+      >{{ plain }}:{{ label }}:{{ requiredName }}:{{ amount }}:{{
+        legacy
+      }}</span
+    >
+  `,
+})
+class HostComponent {
+  public plain = 'plain-1';
+  public label = 'label-1';
+  public requiredName = 'required-1';
+  public amount: string | number = '1';
+  public legacy = 'legacy-1';
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14897
+describe('issue-14897:direct', () => {
+  // The root TypeScript-only runner does not transform signal declarations.
+  // Directives expose their compiled inputs through ɵdir, not reflectComponentType.
+  if (!(DependencyDirective as any).ɵdir?.inputs?.plain) {
+    it('needs compiled signal input metadata', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return;
+  }
+
+  beforeEach(() => {
+    DependencyDirective.constructed = 0;
+    DependencyDirective.transformed = 0;
+
+    return TestBed.configureTestingModule({
+      declarations: [HostComponent],
+      imports: [MockDirective(DependencyDirective)],
+    }).compileComponents();
+  });
+
+  it('updates signal inputs and aliases without executing original transforms', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const host = fixture.componentInstance;
+    const element = ngMocks.find(fixture, 'span');
+    const directive = ngMocks.get(element, DependencyDirective);
+    const plain = directive.plain;
+    const label = directive.label;
+    const requiredName = directive.requiredName;
+    const amount = directive.amount;
+
+    expect(isMockOf(directive, DependencyDirective)).toBe(true);
+    expect(isSignal(plain)).toBe(true);
+    expect(isSignal(label)).toBe(true);
+    expect(isSignal(requiredName)).toBe(true);
+    expect(isSignal(amount)).toBe(true);
+    expect(isSignal(directive.legacy)).toBe(false);
+    expect(plain()).toEqual('plain-1');
+    expect(label()).toEqual('label-1');
+    expect(requiredName()).toEqual('required-1');
+    // Angular does not expose the signal transform in compiled input metadata.
+    // MockDirective skips original field initializers, so this signal receives
+    // raw bound values without executing the original transform.
+    expect(amount() as unknown).toEqual('1');
+    expect(directive.legacy).toEqual('legacy-1');
+    expect(ngMocks.input(element, 'plain')).toEqual('plain-1');
+    expect(ngMocks.input(element, 'publicLabel')).toEqual('label-1');
+    expect(ngMocks.input(element, 'requiredLabel')).toEqual(
+      'required-1',
+    );
+    expect(ngMocks.input(element, 'publicAmount')).toEqual('1');
+    expect(ngMocks.input(element, 'legacy')).toEqual('legacy-1');
+    expect(DependencyDirective.constructed).toEqual(0);
+    expect(DependencyDirective.transformed).toEqual(0);
+
+    host.plain = 'plain-2';
+    host.label = 'label-2';
+    host.requiredName = 'required-2';
+    host.amount = 2;
+    host.legacy = 'legacy-2';
+    // Direct TestBed fixtures need notification after plain property updates in zoneless mode.
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    expect(directive.plain).toBe(plain);
+    expect(directive.label).toBe(label);
+    expect(directive.requiredName).toBe(requiredName);
+    expect(directive.amount).toBe(amount);
+    expect(plain()).toEqual('plain-2');
+    expect(label()).toEqual('label-2');
+    expect(requiredName()).toEqual('required-2');
+    expect(amount()).toEqual(2);
+    expect(directive.legacy).toEqual('legacy-2');
+    expect(ngMocks.input(element, 'plain')).toEqual('plain-2');
+    expect(ngMocks.input(element, 'publicLabel')).toEqual('label-2');
+    expect(ngMocks.input(element, 'requiredLabel')).toEqual(
+      'required-2',
+    );
+    expect(ngMocks.input(element, 'publicAmount')).toEqual(2);
+    expect(ngMocks.input(element, 'legacy')).toEqual('legacy-2');
+    expect(DependencyDirective.constructed).toEqual(0);
+    expect(DependencyDirective.transformed).toEqual(0);
+
+    host.plain = 'plain-3';
+    host.label = 'label-3';
+    host.requiredName = 'required-3';
+    host.amount = '3';
+    host.legacy = 'legacy-3';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    expect(directive.plain).toBe(plain);
+    expect(directive.label).toBe(label);
+    expect(directive.requiredName).toBe(requiredName);
+    expect(directive.amount).toBe(amount);
+    expect(plain()).toEqual('plain-3');
+    expect(label()).toEqual('label-3');
+    expect(requiredName()).toEqual('required-3');
+    expect(amount() as unknown).toEqual('3');
+    expect(directive.legacy).toEqual('legacy-3');
+    expect(ngMocks.input(element, 'plain')).toEqual('plain-3');
+    expect(ngMocks.input(element, 'publicLabel')).toEqual('label-3');
+    expect(ngMocks.input(element, 'requiredLabel')).toEqual(
+      'required-3',
+    );
+    expect(ngMocks.input(element, 'publicAmount')).toEqual('3');
+    expect(ngMocks.input(element, 'legacy')).toEqual('legacy-3');
+    expect(DependencyDirective.constructed).toEqual(0);
+    expect(DependencyDirective.transformed).toEqual(0);
+    expect(ngMocks.formatText(fixture)).toEqual(
+      'plain-3:label-3:required-3:3:legacy-3',
+    );
+  });
+});


### PR DESCRIPTION
## Why

The 14.15-to-14.16 migration guide describes the signal-input change only for component mocks, although the same initialization code is used by directive mocks, including directives mocked through modules.

The migration guide and MockComponent API article also promise preservation of signal-input transforms. Angular does not include transforms declared inside `input()` initializers in reflected input metadata. Since mocks skip original initialization, they receive raw binding values instead: a bound string `'2'` stays a string even when the original declaration transforms it into a number.

Fixes #14897. Follow-up to #14565, #14584, and #13671.

## What

Extend the migration guidance to components and directives, direct mocks and module-based mocking, callable reads, public aliases, and host-binding updates. Clarify that `ComponentRef.setInput` applies to components and that kept declarations are the path for testing original signal transforms or initialization.

Add compiled regressions for direct MockDirective use, MockBuilder module mocking, a kept directive, and direct MockComponent use. Cover ordinary, aliased and required signal inputs, stable signal identity across repeated updates, value lookup, ordinary decorator inputs, and absence of original initialization or transform side effects on mocks. The kept control retains its real transform behavior. Extend the signal-initialization unit coverage to check missing required values, and document change notifications for plain TestBed hosts in zoneless tests.

Correct both documentation pages to distinguish signal initializer transforms from reflected decorator-input transforms. Preserve the existing migration heading anchor.

## Impact

The guides now describe the behavior users can rely on when upgrading and show how to retain real transform logic where needed. The change updates documentation and regression coverage without altering runtime behavior or public APIs.
