### PR TITLE
fix(TestBed): complete teardown cleanup after errors #14912

### DIFF
--- a/libs/ng-mocks/src/lib/common/func.apply-test-bed-override.ts
+++ b/libs/ng-mocks/src/lib/common/func.apply-test-bed-override.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+
+import { isNgDef } from './func.is-ng-def';
+
+export default (def: any, override: any): void => {
+  if (isNgDef(def, 'c')) {
+    TestBed.overrideComponent(def, override);
+  } else if (isNgDef(def, 'd')) {
+    TestBed.overrideDirective(def, override);
+  } else if (isNgDef(def, 'm')) {
+    TestBed.overrideModule(def, override);
+  }
+  if (isNgDef(def, 't')) {
+    TestBed.overrideProvider(def, override);
+  } else if (isNgDef(def, 'i')) {
+    TestBed.overrideProvider(def, override);
+  }
+};

--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.cleanup.spec.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.cleanup.spec.ts
@@ -1,0 +1,264 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ngMocks } from '../mock-helper/mock-helper';
+import mockHelperFasterInstall from '../mock-helper/mock-helper.faster-install';
+
+import ngMocksUniverse from './ng-mocks-universe';
+
+import './ng-mocks-global-overrides';
+
+@Component({
+  selector: 'target',
+  standalone: false,
+  template: '',
+})
+class TargetComponent {}
+
+@Component({
+  selector: 'other',
+  standalone: false,
+  template: '',
+})
+class OtherComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14912
+describe('ng-mocks-global-overrides:cleanup', () => {
+  const globalKeys = [
+    'builder:config',
+    'builder:module',
+    'builder:promise',
+    'test-bed:module-options',
+  ];
+  let originalGlobal: Map<string, any>;
+  let descriptors: Map<string, PropertyDescriptor | undefined>;
+  let flush: jasmine.Spy;
+  let restore: jasmine.Spy;
+
+  beforeEach(() => {
+    originalGlobal = new Map();
+    for (const key of globalKeys) {
+      if (ngMocksUniverse.global.has(key)) {
+        originalGlobal.set(key, ngMocksUniverse.global.get(key));
+      }
+    }
+    descriptors = new Map();
+    for (const key of [
+      'ngMocksOverrides',
+      'ngMocksSelectors',
+      'ngMocksInjectedDeclarations',
+      'ngMocksMockDeclarations',
+    ]) {
+      descriptors.set(
+        key,
+        Object.getOwnPropertyDescriptor(TestBed, key),
+      );
+    }
+    (TestBed as any).ngMocksOverrides = undefined;
+    flush = spyOn(ngMocks, 'flushTestBed');
+    restore = spyOn(TestBed, 'overrideComponent').and.returnValue(
+      TestBed,
+    );
+    expect(mockHelperFasterInstall().after.length).toBe(1);
+  });
+
+  afterEach(() => {
+    for (const [key, descriptor] of descriptors) {
+      if (descriptor) {
+        Object.defineProperty(TestBed, key, descriptor);
+      } else {
+        delete (TestBed as any)[key];
+      }
+    }
+    for (const key of globalKeys) {
+      ngMocksUniverse.global.delete(key);
+      if (originalGlobal.has(key)) {
+        ngMocksUniverse.global.set(key, originalGlobal.get(key));
+      }
+    }
+  });
+
+  it('restores pending overrides and resets Angular when the preliminary flush throws', () => {
+    const failure = new Error('flush failed');
+    flush.and.callFake(() => {
+      throw failure;
+    });
+    const target = { set: { template: 'original target' } };
+    const other = { set: { template: 'original other' } };
+    (TestBed as any).ngMocksOverrides = new Map([
+      [TargetComponent, target],
+      [OtherComponent, other],
+    ]);
+    const instance = {};
+    const nativeReset = jasmine
+      .createSpy('nativeReset')
+      .and.returnValue(instance);
+    const reset = mockHelperFasterInstall().after[0](
+      nativeReset,
+      instance as never,
+    );
+    let actual: unknown;
+
+    try {
+      reset();
+    } catch (error) {
+      actual = error;
+    }
+
+    expect(actual).toBe(failure);
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(restore.calls.allArgs()).toEqual([
+      [TargetComponent, target],
+      [OtherComponent, other],
+    ]);
+    expect((TestBed as any).ngMocksOverrides).toBeUndefined();
+    expect(nativeReset).toHaveBeenCalledTimes(1);
+    expect(nativeReset.calls.mostRecent()?.object).toBe(instance);
+  });
+
+  it('continues restoring later overrides and resets Angular when one restoration throws', () => {
+    const failure = new Error('restoration failed');
+    restore.and.callFake((declaration: any) => {
+      if (declaration === TargetComponent) {
+        throw failure;
+      }
+
+      return TestBed;
+    });
+    const target = { set: { template: 'original target' } };
+    const other = { set: { template: 'original other' } };
+    (TestBed as any).ngMocksOverrides = new Map([
+      [TargetComponent, target],
+      [OtherComponent, other],
+    ]);
+    const instance = {};
+    const nativeReset = jasmine
+      .createSpy('nativeReset')
+      .and.returnValue(instance);
+    const reset = mockHelperFasterInstall().after[0](
+      nativeReset,
+      instance as never,
+    );
+    let actual: unknown;
+
+    try {
+      reset();
+    } catch (error) {
+      actual = error;
+    }
+
+    expect(actual).toBe(failure);
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(restore.calls.allArgs()).toEqual([
+      [TargetComponent, target],
+      [OtherComponent, other],
+    ]);
+    expect((TestBed as any).ngMocksOverrides).toBeUndefined();
+    expect(nativeReset).toHaveBeenCalledTimes(1);
+  });
+
+  for (const failure of [new Error('flush failed'), undefined]) {
+    it(`preserves the first ${failure === undefined ? 'undefined' : 'Error'} failure when native reset also throws`, () => {
+      flush.and.callFake(() => {
+        throw failure;
+      });
+      const original = { set: { template: 'original target' } };
+      (TestBed as any).ngMocksOverrides = new Map([
+        [TargetComponent, original],
+      ]);
+      const nativeFailure = new Error('native reset failed');
+      const nativeReset = jasmine
+        .createSpy('nativeReset')
+        .and.callFake(() => {
+          throw nativeFailure;
+        });
+      const reset = mockHelperFasterInstall().after[0](
+        nativeReset,
+        {} as never,
+      );
+      let actual: unknown;
+      let didThrow = false;
+
+      try {
+        reset();
+      } catch (error) {
+        actual = error;
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+      expect(actual).toBe(failure);
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(restore.calls.allArgs()).toEqual([
+        [TargetComponent, original],
+      ]);
+      expect((TestBed as any).ngMocksOverrides).toBeUndefined();
+      expect(nativeReset).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it('propagates a native reset failure when no override cleanup fails', () => {
+    const failure = new Error('native reset failed');
+    const nativeReset = jasmine
+      .createSpy('nativeReset')
+      .and.callFake(() => {
+        throw failure;
+      });
+    const reset = mockHelperFasterInstall().after[0](
+      nativeReset,
+      {} as never,
+    );
+    let actual: unknown;
+
+    try {
+      reset();
+    } catch (error) {
+      actual = error;
+    }
+
+    expect(actual).toBe(failure);
+    expect(flush).not.toHaveBeenCalled();
+    expect(restore).not.toHaveBeenCalled();
+    expect((TestBed as any).ngMocksOverrides).toBeUndefined();
+    expect(nativeReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the native reset return value and receiver after successful cleanup', () => {
+    const calls: string[] = [];
+    flush.and.callFake(() => {
+      calls.push('flush');
+    });
+    restore.and.callFake(() => {
+      calls.push('restore');
+
+      return TestBed;
+    });
+    const original = { set: { template: 'original target' } };
+    (TestBed as any).ngMocksOverrides = new Map([
+      [TargetComponent, original],
+    ]);
+    const instance = {};
+    const result = {};
+    const nativeReset = jasmine
+      .createSpy('nativeReset')
+      .and.callFake(() => {
+        calls.push('reset');
+        expect((TestBed as any).ngMocksOverrides).toBeUndefined();
+
+        return result;
+      });
+    const reset = mockHelperFasterInstall().after[0](
+      nativeReset,
+      instance as never,
+    );
+
+    expect(reset()).toBe(result as never);
+    expect(calls).toEqual(['flush', 'restore', 'reset']);
+    expect(restore.calls.allArgs()).toEqual([
+      [TargetComponent, original],
+    ]);
+    expect((TestBed as any).ngMocksOverrides).toBeUndefined();
+    expect(nativeReset).toHaveBeenCalledTimes(1);
+    expect(nativeReset.calls.mostRecent()?.object).toBe(instance);
+  });
+});

--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -17,6 +17,7 @@ import coreReflectMeta from './core.reflect.meta';
 import coreReflectProvidedIn from './core.reflect.provided-in';
 import { NG_MOCKS, NG_MOCKS_ROOT_PROVIDERS, NG_MOCKS_TOUCHES } from './core.tokens';
 import { AnyDeclaration, AnyType, dependencyKeys } from './core.types';
+import funcApplyTestBedOverride from './func.apply-test-bed-override';
 import { funcExtractDeps } from './func.extract-deps';
 import { getSourceOfMock } from './func.get-source-of-mock';
 import funcGetType from './func.get-type';
@@ -54,21 +55,6 @@ const installTestBedInjection = (instance: NgMocksTestBed): void => {
     coreDefineProperty(instance, 'ngMocksGetInstalled', true);
   }
 };
-const applyOverride = (def: any, override: any) => {
-  if (isNgDef(def, 'c')) {
-    TestBed.overrideComponent(def, override);
-  } else if (isNgDef(def, 'd')) {
-    TestBed.overrideDirective(def, override);
-  } else if (isNgDef(def, 'm')) {
-    TestBed.overrideModule(def, override);
-  }
-  if (isNgDef(def, 't')) {
-    TestBed.overrideProvider(def, override);
-  } else if (isNgDef(def, 'i')) {
-    TestBed.overrideProvider(def, override);
-  }
-};
-
 const applyOverrides = (overrides: Map<AnyType<any>, [MetadataOverride<any>, MetadataOverride<any>]>): void => {
   // eslint-disable-next-line unicorn/no-useless-spread -- Keep the pending list stable across TestBed override calls.
   for (const [def, [override, original]] of [...overrides]) {
@@ -76,20 +62,35 @@ const applyOverrides = (overrides: Map<AnyType<any>, [MetadataOverride<any>, Met
       ...original,
       override,
     });
-    applyOverride(def, override);
+    funcApplyTestBedOverride(def, override);
   }
 };
 
 // Thanks Ivy and its TestBed.override - it does not clean up leftovers.
 const applyNgMocksOverrides = (testBed: TestBedStatic & { ngMocksOverrides?: Map<any, any> }): void => {
-  if (testBed.ngMocksOverrides?.size) {
-    ngMocks.flushTestBed();
-    // eslint-disable-next-line unicorn/no-useless-spread -- TestBed override calls can update the shared registry.
-    for (const [def, original] of [...testBed.ngMocksOverrides]) {
-      applyOverride(def, original);
+  const errors: unknown[] = [];
+  try {
+    if (testBed.ngMocksOverrides?.size) {
+      try {
+        ngMocks.flushTestBed();
+      } catch (error) {
+        errors.push(error);
+      }
+      // eslint-disable-next-line unicorn/no-useless-spread -- TestBed override calls can update the shared registry.
+      for (const [def, original] of [...testBed.ngMocksOverrides]) {
+        try {
+          funcApplyTestBedOverride(def, original);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
     }
+  } finally {
+    testBed.ngMocksOverrides = undefined;
   }
-  testBed.ngMocksOverrides = undefined;
+  if (errors.length > 0) {
+    throw errors[0];
+  }
 };
 
 const initTestBed = () => {
@@ -373,9 +374,24 @@ const resetTestingModule =
     resetTestModuleOptions();
     (TestBed as any).ngMocksSelectors = undefined;
     resetInjectedDeclarations();
-    applyNgMocksOverrides(TestBed);
+    const errors: unknown[] = [];
+    try {
+      applyNgMocksOverrides(TestBed);
+    } catch (error) {
+      errors.push(error);
+    }
 
-    return original.call(instance);
+    let result: ReturnType<TestBedStatic['resetTestingModule']> = instance;
+    try {
+      result = original.call(instance);
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0) {
+      throw errors[0];
+    }
+
+    return result;
   };
 
 // Monkey-patching ViewContainerRef.createComponent to replace dynamic imports with mocked declarations.

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.faster.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.faster.spec.ts
@@ -1,0 +1,377 @@
+import { Injectable, InjectionToken, OnDestroy } from '@angular/core';
+import { getTestBed, TestBed } from '@angular/core/testing';
+
+import funcGetGlobal from '../common/func.get-global';
+import ngMocksUniverse from '../common/ng-mocks-universe';
+
+import mockHelperFaster from './mock-helper.faster';
+
+describe('mock-helper.faster', () => {
+  const globalKeys = [
+    'bullet',
+    'bullet:stack',
+    'bullet:stack:id',
+    'bullet:customized',
+    'bullet:reset',
+  ];
+  let originalGlobal: Map<string, any>;
+  let originalTestBed: Record<string, any>;
+  let beforeAllSpy: jasmine.Spy;
+  let beforeEachSpy: jasmine.Spy;
+  let afterEachSpy: jasmine.Spy;
+  let afterAllSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    originalGlobal = new Map();
+    for (const key of globalKeys) {
+      if (ngMocksUniverse.global.has(key)) {
+        originalGlobal.set(key, ngMocksUniverse.global.get(key));
+      }
+      ngMocksUniverse.global.delete(key);
+    }
+    const testBed = getTestBed() as any;
+    originalTestBed = {
+      _activeFixtures: testBed._activeFixtures,
+      _instantiated: testBed._instantiated,
+      _moduleFactory: testBed._moduleFactory,
+      _testModuleRef: testBed._testModuleRef,
+    };
+
+    // Capture the actual lifecycle closures without registering hooks inside a running spec.
+    const global = funcGetGlobal();
+    beforeAllSpy = spyOn(global, 'beforeAll');
+    beforeEachSpy = spyOn(global, 'beforeEach');
+    afterEachSpy = spyOn(global, 'afterEach');
+    afterAllSpy = spyOn(global, 'afterAll');
+    mockHelperFaster();
+  });
+
+  afterEach(() => {
+    const testBed = getTestBed() as any;
+    for (const key of Object.keys(originalTestBed)) {
+      testBed[key] = originalTestBed[key];
+    }
+    for (const key of globalKeys) {
+      ngMocksUniverse.global.delete(key);
+      if (originalGlobal.has(key)) {
+        ngMocksUniverse.global.set(key, originalGlobal.get(key));
+      }
+    }
+  });
+
+  it('removes failed per-test fixtures and preserves beforeAll fixtures', () => {
+    beforeAllSpy.calls.first().args[0]();
+    const idAll = ngMocksUniverse.global.get('bullet:stack:id');
+    beforeEachSpy.calls.first().args[0]();
+    const idEach = ngMocksUniverse.global.get('bullet:stack:id');
+    const error = new Error('fixture destruction');
+    const retained = {
+      destroy: jasmine.createSpy('retained'),
+      ngMocksStackId: idAll,
+    };
+    const current = {
+      destroy: jasmine.createSpy('current'),
+      ngMocksStackId: idEach,
+    };
+    const failing = {
+      destroy: jasmine.createSpy('failing').and.callFake(() => {
+        throw error;
+      }),
+      ngMocksStackId: undefined,
+    };
+    const activeFixtures = [retained, current, failing];
+    const moduleRef = {};
+    const testBed = getTestBed() as any;
+    testBed._activeFixtures = activeFixtures;
+    testBed._testModuleRef = moduleRef;
+    spyOn(testBed, 'shouldTearDownTestingModule').and.returnValue(
+      false,
+    );
+
+    let actualError: unknown;
+    try {
+      afterEachSpy.calls.first().args[0]();
+    } catch (error_) {
+      actualError = error_;
+    }
+
+    expect(actualError).toBe(error);
+    expect(failing.destroy).toHaveBeenCalledTimes(1);
+    expect(current.destroy).toHaveBeenCalledTimes(1);
+    expect(retained.destroy).not.toHaveBeenCalled();
+    expect(activeFixtures).toEqual([retained]);
+    expect(current.ngMocksStackId).toBeUndefined();
+    expect(testBed._testModuleRef).toBe(moduleRef);
+    expect(ngMocksUniverse.global.get('bullet:stack')).toEqual([
+      idAll,
+    ]);
+    expect(ngMocksUniverse.global.get('bullet:stack:id')).toBe(idAll);
+    expect(ngMocksUniverse.global.has('bullet')).toBe(true);
+  });
+
+  it('flushes the module after the last per-test fixture fails to destroy', () => {
+    beforeAllSpy.calls.first().args[0]();
+    beforeEachSpy.calls.first().args[0]();
+    const error = new Error('last fixture destruction');
+    const failing = {
+      destroy: jasmine.createSpy('failing').and.callFake(() => {
+        throw error;
+      }),
+      ngMocksStackId: ngMocksUniverse.global.get('bullet:stack:id'),
+    };
+    const activeFixtures = [failing];
+    const testBed = getTestBed() as any;
+    testBed._activeFixtures = activeFixtures;
+    testBed._instantiated = true;
+    testBed._moduleFactory = {};
+    testBed._testModuleRef = {};
+    spyOn(testBed, 'shouldTearDownTestingModule').and.returnValue(
+      false,
+    );
+
+    let actualError: unknown;
+    try {
+      afterEachSpy.calls.first().args[0]();
+    } catch (error_) {
+      actualError = error_;
+    }
+
+    expect(actualError).toBe(error);
+    expect(activeFixtures).toEqual([]);
+    expect(failing.destroy).toHaveBeenCalledTimes(1);
+    expect(failing.ngMocksStackId).toBeUndefined();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect(ngMocksUniverse.global.has('bullet')).toBe(true);
+  });
+
+  it('preserves an undefined fixture error when module teardown also fails', () => {
+    beforeAllSpy.calls.first().args[0]();
+    const idAll = ngMocksUniverse.global.get('bullet:stack:id');
+    beforeEachSpy.calls.first().args[0]();
+    const idEach = ngMocksUniverse.global.get('bullet:stack:id');
+    const current = {
+      destroy: jasmine.createSpy('current'),
+      ngMocksStackId: idEach,
+    };
+    const failing = {
+      destroy: jasmine.createSpy('failing').and.callFake(() => {
+        // An undefined thrown value must remain distinguishable from no error.
+        throw undefined;
+      }),
+      ngMocksStackId: idEach,
+    };
+    const activeFixtures = [current, failing];
+    const testBed = getTestBed() as any;
+    testBed._activeFixtures = activeFixtures;
+    testBed._instantiated = true;
+    testBed._moduleFactory = {};
+    testBed._testModuleRef = {};
+    spyOn(testBed, 'shouldTearDownTestingModule').and.returnValue(
+      true,
+    );
+    const teardown = spyOn(
+      testBed,
+      'tearDownTestingModule',
+    ).and.throwError(new Error('module teardown'));
+
+    let caughtError = false;
+    let actualError: unknown;
+    try {
+      afterEachSpy.calls.first().args[0]();
+    } catch (error) {
+      caughtError = true;
+      actualError = error;
+    }
+    teardown.and.stub();
+
+    expect(caughtError).toBe(true);
+    expect(actualError).toBeUndefined();
+    expect(failing.destroy).toHaveBeenCalledTimes(1);
+    expect(current.destroy).toHaveBeenCalledTimes(1);
+    expect(teardown).toHaveBeenCalledTimes(1);
+    expect(activeFixtures).toEqual([]);
+    expect(failing.ngMocksStackId).toBeUndefined();
+    expect(current.ngMocksStackId).toBeUndefined();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect(ngMocksUniverse.global.get('bullet:stack')).toEqual([
+      idAll,
+    ]);
+    expect(ngMocksUniverse.global.get('bullet:stack:id')).toBe(idAll);
+    expect(ngMocksUniverse.global.has('bullet')).toBe(true);
+  });
+
+  it('preserves the fixture error when the deferred reset also fails', () => {
+    beforeAllSpy.calls.first().args[0]();
+    const error = new Error('fixture destruction');
+    const failing = {
+      destroy: jasmine.createSpy('failing').and.throwError(error),
+      ngMocksStackId: ngMocksUniverse.global.get('bullet:stack:id'),
+    };
+    const activeFixtures = [failing];
+    const testBed = getTestBed() as any;
+    testBed._activeFixtures = activeFixtures;
+    testBed._instantiated = true;
+    testBed._moduleFactory = {};
+    testBed._testModuleRef = {};
+    spyOn(testBed, 'shouldTearDownTestingModule').and.returnValue(
+      false,
+    );
+    ngMocksUniverse.global.set('bullet:reset', true);
+    const reset = spyOn(TestBed, 'resetTestingModule').and.throwError(
+      new Error('deferred reset'),
+    );
+
+    let caughtError = false;
+    let actualError: unknown;
+    try {
+      afterAllSpy.calls.first().args[0]();
+    } catch (error_) {
+      caughtError = true;
+      actualError = error_;
+    }
+    reset.and.callThrough();
+
+    expect(caughtError).toBe(true);
+    expect(actualError).toBe(error);
+    expect(failing.destroy).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(activeFixtures).toEqual([]);
+    expect(failing.ngMocksStackId).toBeUndefined();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect(ngMocksUniverse.global.get('bullet:stack')).toEqual([]);
+    expect(ngMocksUniverse.global.has('bullet:stack:id')).toBe(false);
+    expect(ngMocksUniverse.global.has('bullet')).toBe(false);
+  });
+
+  it('propagates a deferred reset error after successful fixture cleanup', () => {
+    beforeAllSpy.calls.first().args[0]();
+    const current = {
+      destroy: jasmine.createSpy('current'),
+      ngMocksStackId: ngMocksUniverse.global.get('bullet:stack:id'),
+    };
+    const activeFixtures = [current];
+    const testBed = getTestBed() as any;
+    testBed._activeFixtures = activeFixtures;
+    testBed._instantiated = true;
+    testBed._moduleFactory = {};
+    testBed._testModuleRef = {};
+    spyOn(testBed, 'shouldTearDownTestingModule').and.returnValue(
+      false,
+    );
+    ngMocksUniverse.global.set('bullet:reset', true);
+    const error = new Error('deferred reset');
+    const reset = spyOn(TestBed, 'resetTestingModule').and.throwError(
+      error,
+    );
+
+    let caughtError = false;
+    let actualError: unknown;
+    try {
+      afterAllSpy.calls.first().args[0]();
+    } catch (error_) {
+      caughtError = true;
+      actualError = error_;
+    }
+    reset.and.callThrough();
+
+    expect(caughtError).toBe(true);
+    expect(actualError).toBe(error);
+    expect(current.destroy).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(activeFixtures).toEqual([]);
+    expect(current.ngMocksStackId).toBeUndefined();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect(ngMocksUniverse.global.get('bullet:stack')).toEqual([]);
+    expect(ngMocksUniverse.global.has('bullet:stack:id')).toBe(false);
+    expect(ngMocksUniverse.global.has('bullet')).toBe(false);
+  });
+
+  it('finishes the outer scope and its deferred reset when a real provider teardown throws', () => {
+    const error = new Error('provider destruction');
+    let destroyed = 0;
+    @Injectable()
+    class TargetService implements OnDestroy {
+      public ngOnDestroy(): void {
+        destroyed += 1;
+        throw error;
+      }
+    }
+    const token = new InjectionToken<string>('faster recovery');
+
+    beforeAllSpy.calls.first().args[0]();
+    TestBed.configureTestingModule({
+      providers: [TargetService],
+      teardown: { destroyAfterEach: true, rethrowErrors: true },
+    });
+    TestBed.inject(TargetService);
+    TestBed.resetTestingModule();
+    expect(ngMocksUniverse.global.has('bullet:reset')).toBe(true);
+    const reset = spyOn(
+      TestBed,
+      'resetTestingModule',
+    ).and.callThrough();
+
+    let actualError: unknown;
+    try {
+      afterAllSpy.calls.first().args[0]();
+    } catch (error_) {
+      actualError = error_;
+    }
+
+    expect(actualError).toBe(error);
+    expect(destroyed).toBe(1);
+    expect(ngMocksUniverse.global.get('bullet:stack')).toEqual([]);
+    expect(ngMocksUniverse.global.has('bullet:stack:id')).toBe(false);
+    expect(ngMocksUniverse.global.has('bullet')).toBe(false);
+    expect(ngMocksUniverse.global.has('bullet:reset')).toBe(false);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(() => {
+      TestBed.configureTestingModule({
+        providers: [{ provide: token, useValue: 'recovered' }],
+      });
+      expect(TestBed.inject(token)).toEqual('recovered');
+    }).not.toThrow();
+  });
+
+  it('preserves the outer faster scope when an inner scope finishes', () => {
+    beforeAllSpy.calls.first().args[0]();
+    const idAll = ngMocksUniverse.global.get('bullet:stack:id');
+    const retained = {
+      destroy: jasmine.createSpy('retained'),
+      ngMocksStackId: idAll,
+    };
+    const activeFixtures = [retained];
+    const testBed = getTestBed() as any;
+    testBed._activeFixtures = activeFixtures;
+    spyOn(testBed, 'shouldTearDownTestingModule').and.returnValue(
+      false,
+    );
+
+    mockHelperFaster();
+    beforeAllSpy.calls.mostRecent().args[0]();
+    beforeEachSpy.calls.mostRecent().args[0]();
+    afterEachSpy.calls.mostRecent().args[0]();
+    afterAllSpy.calls.mostRecent().args[0]();
+
+    expect(ngMocksUniverse.global.has('bullet')).toBe(true);
+    expect(ngMocksUniverse.global.get('bullet:stack')).toEqual([
+      idAll,
+    ]);
+    expect(ngMocksUniverse.global.get('bullet:stack:id')).toBe(idAll);
+    expect(activeFixtures).toEqual([retained]);
+    expect(retained.destroy).not.toHaveBeenCalled();
+
+    afterAllSpy.calls.first().args[0]();
+    expect(ngMocksUniverse.global.has('bullet')).toBe(false);
+    expect(activeFixtures).toEqual([]);
+    expect(retained.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.faster.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.faster.ts
@@ -9,18 +9,30 @@ const resetFixtures = (id: never) => {
   const activeFixtures: Array<ComponentFixture<any> & { ngMocksStackId?: any }> =
     (getTestBed() as any)._activeFixtures || /* istanbul ignore next */ [];
 
+  const errors: unknown[] = [];
   let active = 0;
   for (let i = activeFixtures.length - 1; i >= 0; i -= 1) {
     if (!activeFixtures[i].ngMocksStackId || activeFixtures[i].ngMocksStackId === id) {
       activeFixtures[i].ngMocksStackId = undefined;
-      activeFixtures[i].destroy();
+      try {
+        activeFixtures[i].destroy();
+      } catch (error) {
+        errors.push(error);
+      }
       activeFixtures.splice(i, 1);
     } else {
       active += 1;
     }
   }
   if (active === 0) {
-    mockHelperFlushTestBed();
+    try {
+      mockHelperFlushTestBed();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw errors[0];
   }
 };
 
@@ -64,10 +76,25 @@ export default () => {
   });
 
   afterAll(() => {
-    idRemove(idAll);
-    ngMocksUniverse.global.delete('bullet');
-    if (ngMocksUniverse.global.has('bullet:reset')) {
-      TestBed.resetTestingModule();
+    const errors: unknown[] = [];
+    try {
+      idRemove(idAll);
+    } catch (error) {
+      errors.push(error);
+    }
+    // A completed inner suite must leave its outer suite's fixture and module alive.
+    if (!ngMocksUniverse.global.has('bullet:stack:id')) {
+      ngMocksUniverse.global.delete('bullet');
+      if (ngMocksUniverse.global.has('bullet:reset')) {
+        try {
+          TestBed.resetTestingModule();
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+    }
+    if (errors.length > 0) {
+      throw errors[0];
     }
   });
 };

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.flush-test-bed.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.flush-test-bed.spec.ts
@@ -1,0 +1,213 @@
+import { Directive } from '@angular/core';
+import { getTestBed, TestBed } from '@angular/core/testing';
+
+import {
+  rememberInjectedDeclaration,
+  rememberMockDeclarations,
+  resetInjectedDeclarations,
+} from '../common/ng-mocks-injected-declarations';
+
+import flushTestBed from './mock-helper.flush-test-bed';
+
+@Directive({
+  selector: '[target]',
+  standalone: false,
+})
+class TargetDirective {}
+
+class MockTargetDirective {}
+(MockTargetDirective as any).mockOf = TargetDirective;
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14912
+describe('mock-helper.flush-test-bed', () => {
+  let testBed: any;
+  let moduleFactory: object;
+  let moduleRef: object;
+  let originals: Array<[any, string, PropertyDescriptor | undefined]>;
+
+  beforeEach(() => {
+    testBed = getTestBed();
+    originals = [];
+    for (const key of [
+      '_instantiated',
+      '_moduleFactory',
+      '_testModuleRef',
+      'shouldTearDownTestingModule',
+      'tearDownTestingModule',
+    ]) {
+      originals.push([
+        testBed,
+        key,
+        Object.getOwnPropertyDescriptor(testBed, key),
+      ]);
+    }
+    for (const key of [
+      'ngMocksInjectedDeclarations',
+      'ngMocksMockDeclarations',
+    ]) {
+      originals.push([
+        TestBed,
+        key,
+        Object.getOwnPropertyDescriptor(TestBed, key),
+      ]);
+    }
+
+    // Stub teardown so the live TestBed never destroys the sentinel module ref.
+    testBed.shouldTearDownTestingModule = jasmine
+      .createSpy('shouldTearDownTestingModule')
+      .and.returnValue(true);
+    testBed.tearDownTestingModule = jasmine.createSpy(
+      'tearDownTestingModule',
+    );
+    moduleFactory = {};
+    moduleRef = {};
+    testBed._instantiated = true;
+    testBed._moduleFactory = moduleFactory;
+    testBed._testModuleRef = moduleRef;
+
+    resetInjectedDeclarations();
+    rememberMockDeclarations(
+      new Map([[TargetDirective, MockTargetDirective]]),
+    );
+    const seed = {};
+    rememberInjectedDeclaration(TargetDirective, seed);
+    expect(
+      (TestBed as any).ngMocksInjectedDeclarations.get(
+        TargetDirective,
+      ).seed,
+    ).toBe(seed);
+  });
+
+  afterEach(() => {
+    // Restore exact own descriptors, including fields absent in this Angular version.
+    for (const [target, key, descriptor] of originals) {
+      if (descriptor) {
+        Object.defineProperty(target, key, descriptor);
+      } else {
+        delete target[key];
+      }
+    }
+  });
+
+  it('clears initialization and seeds when teardown throws the original error', () => {
+    const failure = new Error('teardown failed');
+    testBed.tearDownTestingModule.and.callFake(() => {
+      expect(testBed._instantiated).toBe(true);
+      expect(testBed._moduleFactory).toBe(moduleFactory);
+      expect(testBed._testModuleRef).toBe(moduleRef);
+      throw failure;
+    });
+    let caught: unknown;
+
+    try {
+      flushTestBed();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(failure);
+    expect(testBed.shouldTearDownTestingModule).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(testBed.tearDownTestingModule).toHaveBeenCalledTimes(1);
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect((TestBed as any).ngMocksMockDeclarations).toBeUndefined();
+    expect(
+      (TestBed as any).ngMocksInjectedDeclarations,
+    ).toBeUndefined();
+  });
+
+  it('clears initialization and seeds when the teardown predicate throws', () => {
+    const failure = new Error('teardown predicate failed');
+    testBed.shouldTearDownTestingModule.and.callFake(() => {
+      expect(testBed._instantiated).toBe(true);
+      expect(testBed._moduleFactory).toBe(moduleFactory);
+      expect(testBed._testModuleRef).toBe(moduleRef);
+      throw failure;
+    });
+    let caught: unknown;
+
+    try {
+      flushTestBed();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(failure);
+    expect(testBed.shouldTearDownTestingModule).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(testBed.tearDownTestingModule).not.toHaveBeenCalled();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect((TestBed as any).ngMocksMockDeclarations).toBeUndefined();
+    expect(
+      (TestBed as any).ngMocksInjectedDeclarations,
+    ).toBeUndefined();
+  });
+
+  it('preserves module visibility until successful teardown finishes', () => {
+    testBed.shouldTearDownTestingModule.and.callFake(() => {
+      expect(testBed._instantiated).toBe(true);
+      expect(testBed._moduleFactory).toBe(moduleFactory);
+      expect(testBed._testModuleRef).toBe(moduleRef);
+
+      return true;
+    });
+    testBed.tearDownTestingModule.and.callFake(() => {
+      expect(testBed._instantiated).toBe(true);
+      expect(testBed._moduleFactory).toBe(moduleFactory);
+      expect(testBed._testModuleRef).toBe(moduleRef);
+    });
+
+    flushTestBed();
+
+    expect(testBed.shouldTearDownTestingModule).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(testBed.tearDownTestingModule).toHaveBeenCalledTimes(1);
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect((TestBed as any).ngMocksMockDeclarations).toBeUndefined();
+    expect(
+      (TestBed as any).ngMocksInjectedDeclarations,
+    ).toBeUndefined();
+  });
+
+  it('clears initialization and seeds without teardown when its predicate is missing', () => {
+    testBed.shouldTearDownTestingModule = undefined;
+
+    flushTestBed();
+
+    expect(testBed.tearDownTestingModule).not.toHaveBeenCalled();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect((TestBed as any).ngMocksMockDeclarations).toBeUndefined();
+    expect(
+      (TestBed as any).ngMocksInjectedDeclarations,
+    ).toBeUndefined();
+  });
+
+  it('clears initialization and seeds without teardown when its predicate is false', () => {
+    testBed.shouldTearDownTestingModule.and.returnValue(false);
+
+    flushTestBed();
+
+    expect(testBed.shouldTearDownTestingModule).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(testBed.tearDownTestingModule).not.toHaveBeenCalled();
+    expect(testBed._instantiated).toBe(false);
+    expect(testBed._moduleFactory).toBeUndefined();
+    expect(testBed._testModuleRef).toBeNull();
+    expect((TestBed as any).ngMocksMockDeclarations).toBeUndefined();
+    expect(
+      (TestBed as any).ngMocksInjectedDeclarations,
+    ).toBeUndefined();
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.flush-test-bed.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.flush-test-bed.ts
@@ -6,10 +6,13 @@ export default (): void => {
   const testBed: any = getTestBed();
   // TestBed.inject seeds are scoped to the current testing module and must not leak after a flush.
   resetInjectedDeclarations();
-  if (testBed.shouldTearDownTestingModule !== undefined && testBed.shouldTearDownTestingModule()) {
-    testBed.tearDownTestingModule();
+  try {
+    if (testBed.shouldTearDownTestingModule !== undefined && testBed.shouldTearDownTestingModule()) {
+      testBed.tearDownTestingModule();
+    }
+  } finally {
+    testBed._instantiated = false;
+    testBed._moduleFactory = undefined;
+    testBed._testModuleRef = null;
   }
-  testBed._instantiated = false;
-  testBed._moduleFactory = undefined;
-  testBed._testModuleRef = null;
 };

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -82,6 +82,7 @@ file|tests/issue-296/test.spec.ts|versions=5-21
 file|tests/issue-736/test.spec.ts|versions=5-21
 file|tests/issue-7490/*.ts|versions=17+
 file|tests/issue-5437/*.ts|versions=13+
+file|tests/issue-14912/*.ts|versions=12+
 file|tests/issue-10942/test.spec.ts|features=signalInputs
 file|tests/issue-11001/test.spec.ts|features=signalInputs
 file|tests/issue-11101/test.spec.ts|features=signalInputs

--- a/tests/issue-14912/overrides.spec.ts
+++ b/tests/issue-14912/overrides.spec.ts
@@ -1,0 +1,84 @@
+import {
+  Component,
+  Injectable,
+  NgModule,
+  OnDestroy,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Injectable()
+class LocalService {
+  public value = 'original local provider';
+}
+
+@Injectable()
+class ModuleService implements OnDestroy {
+  public destroyCalls = 0;
+  public error?: Error;
+
+  public ngOnDestroy(): void {
+    this.destroyCalls += 1;
+    if (this.error) {
+      throw this.error;
+    }
+  }
+}
+
+@Component({
+  selector: 'issue-14912-overrides',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  providers: [LocalService],
+  template: '{{ local.value }}',
+})
+class TargetComponent {
+  public constructor(
+    public readonly local: LocalService,
+    public readonly module: ModuleService,
+  ) {}
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+  exports: [TargetComponent],
+  providers: [ModuleService],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14912
+describe('issue-14912: pending overrides', () => {
+  it('restores declaration metadata and Angular compiler state after teardown throws during reset', () => {
+    TestBed.configureTestingModule({
+      ...MockBuilder(TargetComponent, TargetModule)
+        .keep(ModuleService)
+        .mock(LocalService, { value: 'mocked local provider' })
+        .build(),
+      teardown: { destroyAfterEach: true, rethrowErrors: true },
+    });
+    const first = MockRender(TargetComponent);
+    expect(ngMocks.formatText(first)).toBe('mocked local provider');
+    const original = first.point.componentInstance.module;
+    const error = new Error('module provider destruction failed');
+    original.error = error;
+
+    let actual: unknown;
+    try {
+      TestBed.resetTestingModule();
+    } catch (error_) {
+      actual = error_;
+    }
+    expect(actual).toBe(error);
+    expect(original.destroyCalls).toBe(1);
+
+    // Reset must finish even when the preliminary flush for pending overrides fails.
+    TestBed.configureTestingModule({
+      imports: [TargetModule],
+      teardown: { destroyAfterEach: true, rethrowErrors: true },
+    });
+    const next = MockRender(TargetComponent);
+    expect(next.point.componentInstance.module).not.toBe(original);
+    expect(ngMocks.formatText(next)).toBe('original local provider');
+    expect(original.destroyCalls).toBe(1);
+  });
+});

--- a/tests/issue-14912/test.spec.ts
+++ b/tests/issue-14912/test.spec.ts
@@ -1,0 +1,188 @@
+import {
+  Component,
+  Injectable,
+  NgModule,
+  OnDestroy,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Injectable()
+class TargetService implements OnDestroy {
+  public destroyCalls = 0;
+  public error?: Error;
+  public value = 'fresh provider';
+
+  public ngOnDestroy(): void {
+    this.destroyCalls += 1;
+    if (this.error) {
+      throw this.error;
+    }
+  }
+}
+
+@Component({
+  selector: 'issue-14912-target',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ service.value }}',
+})
+class TargetComponent {
+  public constructor(public readonly service: TargetService) {}
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+  providers: [TargetService],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14912
+describe('issue-14912', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      ...MockBuilder(TargetComponent, TargetModule)
+        .keep(TargetService)
+        .build(),
+      teardown: { destroyAfterEach: true, rethrowErrors: true },
+    });
+  });
+
+  it('recovers after explicit flush rethrows a provider destruction error', () => {
+    const first = MockRender(TargetComponent);
+    const original = first.point.componentInstance.service;
+    const error = new Error('provider destruction failed');
+    original.error = error;
+
+    // Angular destroys its injector before rethrowing, so keeping that module reference breaks retries.
+    let actual: unknown;
+    try {
+      ngMocks.flushTestBed();
+    } catch (error_) {
+      actual = error_;
+    }
+    expect(actual).toBe(error);
+    expect(original.destroyCalls).toBe(1);
+
+    const next = MockRender(TargetComponent, null, { reset: true });
+    const replacement = next.point.componentInstance.service;
+    expect(replacement).not.toBe(original);
+    expect(TestBed.inject(TargetService)).toBe(replacement);
+    expect(ngMocks.formatText(next)).toBe('fresh provider');
+    expect(original.destroyCalls).toBe(1);
+    expect(replacement.destroyCalls).toBe(0);
+
+    ngMocks.flushTestBed();
+    expect(original.destroyCalls).toBe(1);
+    expect(replacement.destroyCalls).toBe(1);
+  });
+
+  it('recovers when MockRender reset triggers the failing teardown', () => {
+    const first = MockRender(TargetComponent);
+    const original = first.point.componentInstance.service;
+    const error = new Error('reset destruction failed');
+    original.error = error;
+
+    let actual: unknown;
+    try {
+      MockRender(
+        '<issue-14912-target></issue-14912-target>',
+        {},
+        { reset: true },
+      );
+    } catch (error_) {
+      actual = error_;
+    }
+    expect(actual).toBe(error);
+    expect(original.destroyCalls).toBe(1);
+
+    const next = MockRender(
+      '<issue-14912-target></issue-14912-target>',
+      {},
+      { reset: true },
+    );
+    const replacement = ngMocks.findInstance(next, TargetService);
+    expect(replacement).not.toBe(original);
+    expect(TestBed.inject(TargetService)).toBe(replacement);
+    expect(ngMocks.formatText(next)).toBe('fresh provider');
+    expect(original.destroyCalls).toBe(1);
+  });
+
+  it('preserves recovery through Angular resetTestingModule', () => {
+    const first = MockRender(TargetComponent);
+    const original = first.point.componentInstance.service;
+    const error = new Error('Angular reset destruction failed');
+    original.error = error;
+
+    let actual: unknown;
+    try {
+      TestBed.resetTestingModule();
+    } catch (error_) {
+      actual = error_;
+    }
+    expect(actual).toBe(error);
+    expect(original.destroyCalls).toBe(1);
+
+    TestBed.configureTestingModule({
+      ...MockBuilder(TargetComponent, TargetModule)
+        .keep(TargetService)
+        .build(),
+      teardown: { destroyAfterEach: true, rethrowErrors: true },
+    });
+    const next = MockRender(TargetComponent);
+    expect(next.point.componentInstance.service).not.toBe(original);
+    expect(TestBed.inject(TargetService)).toBe(
+      next.point.componentInstance.service,
+    );
+    expect(ngMocks.formatText(next)).toBe('fresh provider');
+    expect(original.destroyCalls).toBe(1);
+  });
+
+  it('preserves the configured suppression of teardown errors', () => {
+    TestBed.configureTestingModule({
+      teardown: { destroyAfterEach: true, rethrowErrors: false },
+    });
+    const first = MockRender(TargetComponent);
+    const original = first.point.componentInstance.service;
+    const error = new Error('logged destruction failure');
+    original.error = error;
+    const log = console.error;
+    ngMocks.stubMember(
+      console,
+      'error',
+      typeof jest === 'undefined'
+        ? jasmine.createSpy('console.error')
+        : jest.fn(),
+    );
+
+    try {
+      expect(() => ngMocks.flushTestBed()).not.toThrow();
+      expect(original.destroyCalls).toBe(1);
+      expect(console.error).toHaveBeenCalledTimes(1);
+
+      const next = MockRender(TargetComponent, null, { reset: true });
+      expect(next.point.componentInstance.service).not.toBe(original);
+      expect(ngMocks.formatText(next)).toBe('fresh provider');
+      expect(original.destroyCalls).toBe(1);
+    } finally {
+      ngMocks.stubMember(console, 'error', log);
+    }
+  });
+
+  it('does not destroy providers when module teardown is disabled', () => {
+    TestBed.configureTestingModule({
+      teardown: { destroyAfterEach: false, rethrowErrors: true },
+    });
+    const first = MockRender(TargetComponent);
+    const original = first.point.componentInstance.service;
+    original.error = new Error('disabled teardown must not run');
+
+    expect(() => ngMocks.flushTestBed()).not.toThrow();
+    expect(original.destroyCalls).toBe(0);
+
+    const next = MockRender(TargetComponent, null, { reset: true });
+    expect(next.point.componentInstance.service).not.toBe(original);
+    expect(ngMocks.formatText(next)).toBe('fresh provider');
+    expect(original.destroyCalls).toBe(0);
+  });
+});

--- a/tests/ng-mocks-faster/nested.spec.ts
+++ b/tests/ng-mocks-faster/nested.spec.ts
@@ -1,0 +1,88 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injectable,
+  NgModule,
+  OnDestroy,
+} from '@angular/core';
+
+import {
+  MockBuilder,
+  MockedComponentFixture,
+  MockRender,
+  ngMocks,
+} from 'ng-mocks';
+
+@Injectable()
+class TargetService implements OnDestroy {
+  public destroyed = false;
+  public value = 'outer';
+
+  public ngOnDestroy(): void {
+    this.destroyed = true;
+  }
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'target-ng-mocks-faster-nested',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ service.value }}',
+})
+class TargetComponent {
+  public constructor(public readonly service: TargetService) {}
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+  providers: [TargetService],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14912
+describe('ngMocks.faster:nested', () => {
+  let fixture: MockedComponentFixture<TargetComponent>;
+  let service: TargetService;
+
+  ngMocks.faster();
+
+  beforeAll(() =>
+    MockBuilder(TargetComponent, TargetModule).keep(TargetService),
+  );
+  beforeAll(() => {
+    fixture = MockRender(TargetComponent);
+    service = fixture.point.componentInstance.service;
+  });
+
+  // Finishing either inner scope must preserve the outer beforeAll fixture
+  // and its module injector for the sibling that runs afterward.
+  describe('first inner scope', () => {
+    ngMocks.faster();
+
+    it('uses the outer fixture and module service', () => {
+      expect(fixture.componentRef.hostView.destroyed).toBe(false);
+      expect(service.destroyed).toBe(false);
+      expect(ngMocks.get(TargetService)).toBe(service);
+
+      service.value = 'first inner scope';
+      fixture.detectChanges();
+
+      expect(ngMocks.formatText(fixture)).toBe('first inner scope');
+    });
+  });
+
+  describe('second inner scope', () => {
+    ngMocks.faster();
+
+    it('uses the outer fixture and module service', () => {
+      expect(fixture.componentRef.hostView.destroyed).toBe(false);
+      expect(service.destroyed).toBe(false);
+      expect(ngMocks.get(TargetService)).toBe(service);
+
+      service.value = 'second inner scope';
+      fixture.detectChanges();
+
+      expect(ngMocks.formatText(fixture)).toBe('second inner scope');
+    });
+  });
+});


### PR DESCRIPTION
## Why

A provider teardown error could leave a destroyed injector attached to TestBed, preventing later rendering. Pending ng-mocks overrides could also stop Angular's own reset, leaving compiler metadata behind. Reviewing the related faster cleanup found that fixture errors interrupted remaining cleanup and finishing an inner faster scope could destroy an outer scope's fixture.

## What

- Clear TestBed initialization state after teardown, including failures, while retaining Angular's teardown configuration.
- Complete pending override restoration and Angular reset while preserving the first error.
- Finish faster fixture cleanup after errors and keep outer faster scopes alive until their own cleanup.
- Add regressions for flush and render retries, overridden declarations, nested fixtures, error precedence, provider destruction, and disabled or suppressed teardown.

## Impact

Tests can recover after a caught teardown error without reusing a destroyed injector or stale compiler metadata. Existing error policies and retained fixtures remain covered. This restores expected behavior and requires no public documentation changes.

Closes #14912.
