### PR TITLE
fix(MockService): mock own accessors without invoking them #14916

### DIFF
--- a/.agents/skills/triage-issue/SKILL.md
+++ b/.agents/skills/triage-issue/SKILL.md
@@ -89,6 +89,7 @@ Create and maintain a plain Markdown checklist:
    - Correct the confirmed shared cause and its affected paths. Preserve adjacent cases that already work and
      avoid speculative source changes for cases that only need regression coverage.
    - Prefer existing ng-mocks helpers and patterns over new abstractions.
+   - Follow `AGENTS.md`'s typing guidance: avoid `any` where practical, including in regression tests.
    - Avoid expanding functionality while fixing wider defects; use existing entry points and defaults unless
      a demonstrated requirement needs an addition, following `Fix Scope Review` in `AGENTS.md`.
    - Add code comments only for non-obvious Angular behavior, compatibility constraints, or private API handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,10 @@
 
 - Prefer existing library helpers when their semantics fit the task, including in tests; for example, use
   `coreDefineProperty` for compatible property definitions.
+- Make a best effort to avoid `any`, including in tests. Prefer inference, concrete types, or narrower object
+  shapes; consider `unknown` with narrowing or `never` when their semantics fit and the target TypeScript version
+  supports them. Try a different declaration or approach before accepting `any`, and do not use casts merely to
+  hide a type error.
 - Follow `Spec and Documentation Examples` before changing specs or docs. If current guidance and the selected
   examples still leave a pattern unclear, inspect analogous local history or recent merged non-bot PRs. Prefer human-authored examples over generated dependency-update text.
 - Keep implementation narrow and follow `Test Style` for issue reproducers, compatibility gates, layered coverage,

--- a/libs/ng-mocks/src/lib/mock-service/mock-service.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/mock-service.spec.ts
@@ -307,6 +307,137 @@ describe('MockService', () => {
     );
   });
 
+  it('mocks an own getter without reading it and permits writes and explicit stubbing', () => {
+    const getter = jasmine
+      .createSpy('original getter')
+      .and.throwError('real getter');
+    const shape = {
+      get value(): string {
+        return getter();
+      },
+    };
+    const descriptor = Object.getOwnPropertyDescriptor(
+      shape,
+      'value',
+    );
+
+    const mock = MockService(shape);
+    const sibling = MockService(shape);
+
+    expect(mock.value).toBeUndefined();
+    mock.value = 'mock';
+    expect(mock.value).toBe('mock');
+    expect(sibling.value).toBeUndefined();
+    spyOnProperty(mock, 'value', 'get').and.returnValue('stubbed');
+    expect(mock.value).toBe('stubbed');
+    expect(getter).not.toHaveBeenCalled();
+    expect(Object.getOwnPropertyDescriptor(shape, 'value')).toEqual(
+      descriptor,
+    );
+  });
+
+  it('mocks an own setter without calling it and provides readable mock state', () => {
+    const setter = jasmine
+      .createSpy('original setter')
+      .and.throwError('real setter');
+    const shape = {
+      set value(value: string) {
+        setter(value);
+      },
+    };
+    const descriptor = Object.getOwnPropertyDescriptor(
+      shape,
+      'value',
+    );
+
+    const mock = MockService(shape);
+    const mockDescriptor = Object.getOwnPropertyDescriptor(
+      mock,
+      'value',
+    );
+
+    expect(mockDescriptor?.get).toEqual(jasmine.any(Function));
+    expect(mockDescriptor?.set).toEqual(jasmine.any(Function));
+    expect(mock.value).toBeUndefined();
+    mock.value = 'mock';
+    expect(mock.value).toBe('mock');
+    expect(setter).not.toHaveBeenCalled();
+    expect(Object.getOwnPropertyDescriptor(shape, 'value')).toEqual(
+      descriptor,
+    );
+  });
+
+  it('mocks own accessors that shadow prototype methods and accessors', () => {
+    const original = jasmine
+      .createSpy('prototype member')
+      .and.throwError('real prototype member');
+    const getter = jasmine
+      .createSpy('own getter')
+      .and.throwError('real own getter');
+    const setter = jasmine
+      .createSpy('own setter')
+      .and.throwError('real own setter');
+    class Target {
+      public method(): string {
+        return original();
+      }
+
+      public get value(): string {
+        return original();
+      }
+    }
+    const shape: object = Object.create(Target.prototype);
+    Object.defineProperty(shape, 'method', {
+      configurable: true,
+      enumerable: true,
+      get: getter,
+    });
+    Object.defineProperty(shape, 'value', {
+      configurable: true,
+      enumerable: true,
+      get: getter,
+      set: setter,
+    });
+    const ownMethod = Object.getOwnPropertyDescriptor(
+      shape,
+      'method',
+    );
+    const ownValue = Object.getOwnPropertyDescriptor(shape, 'value');
+    const prototypeMethod = Object.getOwnPropertyDescriptor(
+      Target.prototype,
+      'method',
+    );
+    const prototypeValue = Object.getOwnPropertyDescriptor(
+      Target.prototype,
+      'value',
+    );
+
+    const mock = MockService(shape);
+
+    expect(mock instanceof Target).toBe(true);
+    expect(mock.method).toBeUndefined();
+    expect(mock.value).toBeUndefined();
+    mock.method = 'method';
+    mock.value = 'value';
+    expect(mock.method).toBe('method');
+    expect(mock.value).toBe('value');
+    expect(original).not.toHaveBeenCalled();
+    expect(getter).not.toHaveBeenCalled();
+    expect(setter).not.toHaveBeenCalled();
+    expect(Object.getOwnPropertyDescriptor(shape, 'method')).toEqual(
+      ownMethod,
+    );
+    expect(Object.getOwnPropertyDescriptor(shape, 'value')).toEqual(
+      ownValue,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(Target.prototype, 'method'),
+    ).toEqual(prototypeMethod);
+    expect(
+      Object.getOwnPropertyDescriptor(Target.prototype, 'value'),
+    ).toEqual(prototypeValue);
+  });
+
   it('mocks getters, setters and methods in a way that jasmine can mock them w/o an issue', () => {
     const mock: GetterSetterMethodHuetod = MockService(
       GetterSetterMethodHuetod,

--- a/libs/ng-mocks/src/lib/mock-service/mock-service.ts
+++ b/libs/ng-mocks/src/lib/mock-service/mock-service.ts
@@ -35,6 +35,12 @@ const mockVariableMap: Array<[(def: any) => boolean, MockServiceHandler]> = [
       const value = helperMockService.createMockFromPrototype(service.constructor.prototype);
       cache.set(service, value);
       for (const property of Object.keys(service)) {
+        const { get, set } = helperMockService.extractPropertyDescriptor(service, property) as PropertyDescriptor;
+        if (get || set) {
+          helperMockService.mock(value, property, 'get', prefix || 'instance');
+          helperMockService.mock(value, property, 'set', prefix || 'instance');
+          continue;
+        }
         const mock: any = callback(cache, service[property], `${prefix || 'instance'}.${property}`);
         if (mock !== undefined) {
           value[property] = mock;

--- a/tests/issue-14916/test.spec.ts
+++ b/tests/issue-14916/test.spec.ts
@@ -43,7 +43,8 @@ describe('issue-14916', () => {
     ngMocks.autoSpy(
       typeof jest === 'undefined'
         ? 'jasmine'
-        : typeof (window as any).vi === 'undefined'
+        : typeof (window as Window & { vi?: object }).vi ===
+            'undefined'
           ? 'jest'
           : 'vitest',
     ),

--- a/tests/issue-14916/test.spec.ts
+++ b/tests/issue-14916/test.spec.ts
@@ -1,0 +1,114 @@
+import { Injectable, InjectionToken, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MockBuilder,
+  MockProvider,
+  MockService,
+  ngMocks,
+} from 'ng-mocks';
+
+@Injectable()
+class TargetService {
+  public readonly info = {
+    get value(): string {
+      throw new Error('real getter');
+    },
+  };
+
+  public constructor() {
+    throw new Error('real constructor');
+  }
+}
+
+const TOKEN = new InjectionToken<{ value: string }>('TOKEN');
+
+@NgModule({
+  providers: [
+    {
+      provide: TOKEN,
+      useValue: {
+        get value(): string {
+          throw new Error('real provider getter');
+        },
+      },
+    },
+  ],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14916
+describe('issue-14916', () => {
+  beforeEach(() =>
+    ngMocks.autoSpy(
+      typeof jest === 'undefined'
+        ? 'jasmine'
+        : typeof (window as any).vi === 'undefined'
+          ? 'jest'
+          : 'vitest',
+    ),
+  );
+
+  afterEach(() => ngMocks.autoSpy('reset'));
+
+  it('mocks own accessors without reading or writing the original object', () => {
+    let reads = 0;
+    let writes = 0;
+    const shape = {
+      get value(): string {
+        reads += 1;
+
+        return 'real';
+      },
+      set value(value: string) {
+        writes += 1;
+      },
+      nested: { request: () => 'real' },
+      count: 1,
+    };
+
+    // Reading an own property to discover its shape runs real accessor code.
+    const mock = MockService(shape);
+    expect(reads).toEqual(0);
+    expect(mock.value).toBeUndefined();
+    mock.value = 'mock';
+    expect(mock.value).toEqual('mock');
+    expect(reads).toEqual(0);
+    expect(writes).toEqual(0);
+    expect(mock.count).toBeUndefined();
+    expect(mock.nested.request()).toBeUndefined();
+    expect(mock.nested.request).toHaveBeenCalled();
+
+    ngMocks.stubMember(mock, 'value', () => 'stubbed', 'get');
+    expect(mock.value).toEqual('stubbed');
+    expect(reads).toEqual(0);
+  });
+
+  it('accepts an explicit accessor shape in a MockProvider override', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        MockProvider(TargetService, {
+          info: MockService({
+            get value(): string {
+              throw new Error('real override getter');
+            },
+          }),
+        }),
+      ],
+    });
+
+    const service = ngMocks.get(TargetService);
+    expect(service.info.value).toBeUndefined();
+    ngMocks.stubMember(service.info, 'value', () => 'stubbed', 'get');
+    expect(service.info.value).toEqual('stubbed');
+  });
+
+  it('mocks own accessors in useValue providers', async () => {
+    await MockBuilder(null, TargetModule);
+
+    const value = ngMocks.get(TOKEN);
+    expect(value.value).toBeUndefined();
+    value.value = 'mock';
+    expect(value.value).toEqual('mock');
+  });
+});


### PR DESCRIPTION
## Why

Mocking an explicit object shape reads its enumerable own properties to discover nested values. For accessors, that executes the real getter during mock construction and can trigger side effects or throw. Setter-only properties are omitted instead of receiving the usual mock accessor behavior.

## What

Inspect own property descriptors and reuse the existing getter/setter mocking helpers. Add regressions for getter-only, setter-only, paired and shadowing accessors, explicit nested `MockService` overrides in `MockProvider`, and mocked `useValue` providers.

Record agent guidance to prefer precise types over `any`, and use an explicit optional global shape in the new runner setup.

## Impact

Accessor mocks start undefined, retain assigned mock values and accept explicit getter stubs without calling the original accessors. Nested method auto-spies, original descriptors and constructor suppression remain intact. This restores the existing mock behavior without new API parameters or public documentation changes.

Fixes #14916.
