### PR TITLE
test(TestBed): cover inherited structural input aliases #14918

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -136,6 +136,7 @@ file|examples/TestContentChild/signals.spec.ts|features=signalQueries
 file|tests/mock-render-metadata/host-directives.spec.ts|features=hostDirectives
 file|tests/mock-render-metadata/static-queries.spec.ts|versions=8+
 file|tests/mock-render-metadata/input-transforms.spec.ts|versions=16+
+file|tests/issue-14918/test.spec.ts|versions=16+
 file|tests/mock-render-metadata/output-model.spec.ts|features=signalInputs,outputFn
 file|tests/mock-render-metadata/output-observable.spec.ts|features=outputFn
 file|tests/mock-render-metadata/query-signals.spec.ts|features=signalQueries

--- a/tests/issue-14918/test.spec.ts
+++ b/tests/issue-14918/test.spec.ts
@@ -1,0 +1,148 @@
+import {
+  booleanAttribute,
+  Component,
+  Directive,
+  Input,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { MockDirective } from 'ng-mocks';
+
+const baseInputs = [{ name: 'foo', alias: 'appBaseHeader' }];
+const baseBar = {
+  alias: 'appBaseHeaderBar',
+  transform: booleanAttribute,
+};
+const derivedInputs = [
+  { name: 'foo', alias: 'appSomeHeader' },
+  {
+    name: 'bar',
+    alias: 'appSomeHeaderBar',
+    transform: booleanAttribute,
+  },
+];
+
+@Directive({
+  selector: '[appBaseHeader]',
+  standalone: true,
+  inputs: baseInputs,
+})
+class BaseHeaderDirective {
+  public foo = '';
+  @Input(baseBar) public bar = false;
+}
+
+@Directive({
+  selector: '[appSomeHeader]',
+  standalone: true,
+  inputs: derivedInputs,
+})
+class SomeHeaderDirective extends BaseHeaderDirective {}
+
+@Component({
+  standalone: true,
+  imports: [SomeHeaderDirective],
+  template: `
+    <div *appSomeHeader="'foo'; bar: true"></div>
+    <div *appSomeHeader="'other'; bar: 'false'"></div>
+  `,
+})
+class DerivedHostComponent {}
+
+@Component({
+  standalone: true,
+  imports: [BaseHeaderDirective],
+  template: `
+    <div *appBaseHeader="'base'; bar: true"></div>
+    <div *appBaseHeader="'original'; bar: 'false'"></div>
+  `,
+})
+class BaseHostComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14918
+// @see https://github.com/help-me-mom/ng-mocks/issues/9655
+// Importing ng-mocks installs TestBed interception. The derived class-array
+// alias must not replace the base property's decorated alias during reflection.
+// Input transforms require Angular 16.1 or newer.
+describe('issue-14918', () => {
+  for (const reflect of [false, true]) {
+    it(
+      reflect
+        ? 'preserves structural aliases and transforms after reflecting a derived directive'
+        : 'preserves structural aliases and transforms in ordinary TestBed',
+      async () => {
+        if (reflect) {
+          MockDirective(SomeHeaderDirective);
+        }
+
+        for (let cycle = 0; cycle < 2; cycle += 1) {
+          await TestBed.configureTestingModule({
+            imports: [DerivedHostComponent],
+          }).compileComponents();
+          const derivedFixture = TestBed.createComponent(
+            DerivedHostComponent,
+          );
+          derivedFixture.detectChanges();
+          const derivedNodes =
+            derivedFixture.debugElement.queryAllNodes(
+              By.directive(SomeHeaderDirective),
+            );
+
+          expect(derivedNodes.length).toBe(2);
+          const derived = derivedNodes[0].injector.get(
+            SomeHeaderDirective,
+          );
+          const transformedDerived = derivedNodes[1].injector.get(
+            SomeHeaderDirective,
+          );
+          expect(derived.foo).toBe('foo');
+          expect(derived.bar).toBe(true);
+          expect(transformedDerived.foo).toBe('other');
+          expect(transformedDerived.bar).toBe(false);
+
+          derivedFixture.destroy();
+          TestBed.resetTestingModule();
+
+          await TestBed.configureTestingModule({
+            imports: [BaseHostComponent],
+          }).compileComponents();
+          const baseFixture =
+            TestBed.createComponent(BaseHostComponent);
+          baseFixture.detectChanges();
+          const baseNodes = baseFixture.debugElement.queryAllNodes(
+            By.directive(BaseHeaderDirective),
+          );
+
+          expect(baseNodes.length).toBe(2);
+          const base = baseNodes[0].injector.get(BaseHeaderDirective);
+          const transformedBase = baseNodes[1].injector.get(
+            BaseHeaderDirective,
+          );
+          expect(base.foo).toBe('base');
+          expect(base.bar).toBe(true);
+          expect(transformedBase.foo).toBe('original');
+          expect(transformedBase.bar).toBe(false);
+          expect(baseInputs).toEqual([
+            { name: 'foo', alias: 'appBaseHeader' },
+          ]);
+          expect(baseBar).toEqual({
+            alias: 'appBaseHeaderBar',
+            transform: booleanAttribute,
+          });
+          expect(derivedInputs).toEqual([
+            { name: 'foo', alias: 'appSomeHeader' },
+            {
+              name: 'bar',
+              alias: 'appSomeHeaderBar',
+              transform: booleanAttribute,
+            },
+          ]);
+
+          baseFixture.destroy();
+          TestBed.resetTestingModule();
+        }
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Why

The inherited structural-directive setup from #9655 now works, but lacked a retained regression. Its derived `inputs` array overrides an alias declared by a transformed input on the base directive, and the failure originally affected ordinary TestBed tests merely because ng-mocks was loaded.

## What

Retain the reported microsyntax binding in ordinary TestBed and repeat it after explicitly reflecting the derived directive. Exercise true and string-false inputs, then render the base using its original aliases across repeated setup/reset cycles. Assert that the original input arrays and decorated input options remain unchanged.

Gate the regression at the input-transform API boundary, Angular 16.1 (the repository's Angular 16 target uses 16.2).

## Impact

Protect the existing behavior and metadata isolation without changing library functionality. Public documentation does not need an update.

Fixes #14918
