### PR TITLE
test(metadata): cover compiled bindings and align integration lint #14919

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -292,6 +292,15 @@ export default defineConfig([
     rules: tsEslintPlugin.configs['eslint-recommended'].overrides[0].rules,
   },
   {
+    files: ['tests-e2e/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        // CI lints before these dependencies are installed; local installs must not change the rules.
+        project: false,
+      },
+    },
+  },
+  {
     files: ['**/*.spec.ts'],
     rules: {
       // Test fixtures may intentionally exercise eager change detection.

--- a/tests-e2e/src/issue-14919/local.spec.ts
+++ b/tests-e2e/src/issue-14919/local.spec.ts
@@ -103,11 +103,13 @@ describe('issue-14919:local', () => {
         const fixture = TestBed.createComponent(HostComponent);
         fixture.detectChanges();
         const host = fixture.componentInstance;
+        // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
         const componentElement = ngMocks.find(
           fixture,
           LocalTimepickerComponent,
         );
         const component = componentElement.componentInstance;
+        // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
         const directiveElement = ngMocks.find(fixture, 'input');
         const directive = ngMocks.get(
           directiveElement,

--- a/tests-e2e/src/issue-14919/local.spec.ts
+++ b/tests-e2e/src/issue-14919/local.spec.ts
@@ -1,0 +1,226 @@
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  Input,
+  input,
+  isSignal,
+  model,
+  NgModule,
+  output,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  isMockOf,
+  MockBuilder,
+  MockComponent,
+  MockDirective,
+  ngMocks,
+} from 'ng-mocks';
+
+@Component({
+  selector: 'local-timepicker-14919',
+  standalone: true,
+  template: '{{ interval() }}:{{ ariaLabel() }}',
+})
+class LocalTimepickerComponent {
+  public readonly interval = input(0, { transform: Number });
+  public readonly ariaLabel = input('', { alias: 'aria-label' });
+  public readonly selected = output<number>();
+}
+
+@Directive({
+  selector: 'input[localTimepicker]',
+  standalone: true,
+})
+class LocalTimepickerDirective {
+  public readonly timepicker =
+    input.required<LocalTimepickerComponent>({
+      alias: 'localTimepicker',
+    });
+  public readonly openOnClick = input(false, {
+    alias: 'localOpenOnClick',
+    transform: booleanAttribute,
+  });
+  public readonly value = model<number>(0);
+  @Input({ transform: booleanAttribute }) public legacy = false;
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  standalone: false,
+  template: `
+    <local-timepicker-14919
+      #picker
+      [interval]="interval"
+      [aria-label]="label"
+      (selected)="selected.push($event)"
+    ></local-timepicker-14919>
+    <input
+      [localTimepicker]="picker"
+      [localOpenOnClick]="enabled"
+      [legacy]="enabled"
+      [value]="value"
+      (valueChange)="value = $event; changes.push($event)"
+    />
+  `,
+})
+class HostComponent {
+  public interval: string | number = '30';
+  public label = 'first';
+  public enabled: string | boolean = 'false';
+  public value = 1;
+  public readonly selected: number[] = [];
+  public readonly changes: number[] = [];
+}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [LocalTimepickerComponent, LocalTimepickerDirective],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14919
+// These local controls use Angular 17.3 authoring APIs; the integration
+// project compiles them with Angular 22 alongside the published-library cases.
+describe('issue-14919:local', () => {
+  for (const direct of [true, false]) {
+    describe(direct ? 'direct mocks' : 'MockBuilder module', () => {
+      beforeEach(() =>
+        direct
+          ? TestBed.configureTestingModule({
+              declarations: [HostComponent],
+              imports: [
+                MockComponent(LocalTimepickerComponent),
+                MockDirective(LocalTimepickerDirective),
+              ],
+            }).compileComponents()
+          : MockBuilder(HostComponent, TargetModule),
+      );
+
+      it('preserves local signal bindings and separate model outputs', () => {
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        const host = fixture.componentInstance;
+        const componentElement = ngMocks.find(
+          fixture,
+          LocalTimepickerComponent,
+        );
+        const component = componentElement.componentInstance;
+        const directiveElement = ngMocks.find(fixture, 'input');
+        const directive = ngMocks.get(
+          directiveElement,
+          LocalTimepickerDirective,
+        );
+        const interval = component.interval;
+        const label = component.ariaLabel;
+        const timepicker = directive.timepicker;
+        const openOnClick = directive.openOnClick;
+        const value = directive.value;
+        const selected = ngMocks.output<number>(
+          componentElement,
+          'selected',
+        );
+        const changes = ngMocks.output<number>(
+          directiveElement,
+          'valueChange',
+        );
+
+        expect(isMockOf(component, LocalTimepickerComponent)).toBe(
+          true,
+        );
+        expect(isMockOf(directive, LocalTimepickerDirective)).toBe(
+          true,
+        );
+        expect(isSignal(interval)).toBe(true);
+        expect(isSignal(label)).toBe(true);
+        expect(isSignal(timepicker)).toBe(true);
+        expect(isSignal(openOnClick)).toBe(true);
+        expect(isSignal(value)).toBe(true);
+        expect(isSignal(directive.legacy)).toBe(false);
+        // Signal transforms belong to skipped initializers, while Angular
+        // retains decorator transforms in the binding metadata.
+        expect<unknown>(interval()).toBe('30');
+        expect(label()).toBe('first');
+        expect(timepicker()).toBe(component);
+        expect<unknown>(openOnClick()).toBe('false');
+        expect(directive.legacy).toBe(false);
+        expect(value()).toBe(1);
+        expect(
+          ngMocks.input<string>(componentElement, 'interval'),
+        ).toBe('30');
+        expect(
+          ngMocks.input<string>(componentElement, 'aria-label'),
+        ).toBe('first');
+        expect(
+          ngMocks.input<LocalTimepickerComponent>(
+            directiveElement,
+            'localTimepicker',
+          ),
+        ).toBe(component);
+        expect(
+          ngMocks.input<string>(directiveElement, 'localOpenOnClick'),
+        ).toBe('false');
+        expect(
+          ngMocks.input<boolean>(directiveElement, 'legacy'),
+        ).toBe(false);
+        expect<unknown>(selected).toBe(component.selected);
+        expect<unknown>(changes).not.toBe(value);
+        expect(host.selected).toEqual([]);
+        expect(host.changes).toEqual([]);
+
+        host.interval = 45;
+        host.label = 'second';
+        host.enabled = true;
+        host.value = 2;
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(interval()).toBe(45);
+        expect(label()).toBe('second');
+        expect(openOnClick()).toBe(true);
+        expect(directive.legacy).toBe(true);
+        expect(value()).toBe(2);
+        expect(host.changes).toEqual([]);
+
+        selected.emit(7);
+        changes.emit(3);
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(host.selected).toEqual([7]);
+        expect(host.changes).toEqual([3]);
+        expect(host.value).toBe(3);
+        expect(value()).toBe(3);
+
+        host.interval = '60';
+        host.label = 'third';
+        host.enabled = 'false';
+        host.value = 4;
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(component.interval).toBe(interval);
+        expect(component.ariaLabel).toBe(label);
+        expect(directive.timepicker).toBe(timepicker);
+        expect(directive.openOnClick).toBe(openOnClick);
+        expect(directive.value).toBe(value);
+        expect<unknown>(interval()).toBe('60');
+        expect(label()).toBe('third');
+        expect(timepicker()).toBe(component);
+        expect<unknown>(openOnClick()).toBe('false');
+        expect(directive.legacy).toBe(false);
+        expect(value()).toBe(4);
+        expect(
+          ngMocks.output<number>(componentElement, 'selected'),
+        ).toBe(selected);
+        expect(
+          ngMocks.output<number>(directiveElement, 'valueChange'),
+        ).toBe(changes);
+        expect(host.selected).toEqual([7]);
+        expect(host.changes).toEqual([3]);
+      });
+    });
+  }
+});

--- a/tests-e2e/src/issue-14919/test.spec.ts
+++ b/tests-e2e/src/issue-14919/test.spec.ts
@@ -125,8 +125,10 @@ describe('issue-14919:library', () => {
 
           const fixture = MockRender(HostComponent);
           const host = fixture.point.componentInstance;
+          // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
           const pickerElement = ngMocks.find(MatTimepicker);
           const picker = pickerElement.componentInstance;
+          // eslint-disable-next-line es-x/no-array-prototype-find -- ngMocks.find is not Array.find.
           const inputElement = ngMocks.find('input');
           const input = ngMocks.get(inputElement, MatTimepickerInput);
           const legacy = ngMocks.get(inputElement, MatInput);

--- a/tests-e2e/src/issue-14919/test.spec.ts
+++ b/tests-e2e/src/issue-14919/test.spec.ts
@@ -1,0 +1,265 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  isSignal,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { MatInput, MatInputModule } from '@angular/material/input';
+import {
+  MatTimepicker,
+  MatTimepickerInput,
+  MatTimepickerModule,
+} from '@angular/material/timepicker';
+import {
+  isMockOf,
+  MockBuilder,
+  MockComponent,
+  MockDirective,
+  MockRender,
+  ngMocks,
+} from 'ng-mocks';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'host-14919-library',
+  standalone: false,
+  template: `
+    <mat-timepicker
+      #picker
+      [interval]="interval"
+      [aria-label]="label"
+      (selected)="selected.push($event.value)"
+    ></mat-timepicker>
+    <input
+      matInput
+      [matTimepicker]="picker"
+      [matTimepickerOpenOnClick]="flag"
+      [disabledInteractive]="flag"
+      [(value)]="value"
+      (valueChange)="changes.push($event)"
+    />
+  `,
+})
+class HostComponent {
+  public interval = '15m';
+  public label = 'initial';
+  public flag = 'false';
+  public value = 1;
+  public readonly selected: unknown[] = [];
+  public readonly changes: unknown[] = [];
+}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [MatTimepickerModule, MatInputModule],
+})
+class HostModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14919
+// @see https://github.com/help-me-mom/ng-mocks/issues/9698
+// Material is an actual precompiled dependency. Current packages also retain
+// development property decorators; hide those in the fallback cases while
+// retaining the original compiled definitions, then restore every descriptor.
+// The integration project uses Angular 22; input/output/model APIs require 17.3.
+describe('issue-14919:library', () => {
+  for (const metadata of ['development', 'definitions']) {
+    for (const setup of ['direct', 'builder']) {
+      it(`binds compiled library metadata with ${metadata} and ${setup} mocking`, async () => {
+        const declarations = [
+          MatTimepicker,
+          MatTimepickerInput,
+          MatInput,
+        ];
+        const componentDefinition = MatTimepicker.ɵcmp;
+        const directiveDefinition = MatTimepickerInput.ɵdir;
+        const inputDefinition = MatInput.ɵdir;
+        const keys =
+          metadata === 'definitions'
+            ? [
+                'propDecorators',
+                '__prop__metadata__',
+                '__ngMocksParsed',
+                '__ngMocksDeclarations',
+              ]
+            : ['__ngMocksParsed', '__ngMocksDeclarations'];
+        const saved = declarations.map(declaration => ({
+          declaration,
+          descriptors: keys.map(key => ({
+            key,
+            descriptor: Object.getOwnPropertyDescriptor(
+              declaration,
+              key,
+            ),
+          })),
+        }));
+
+        ngMocks.reset();
+        try {
+          // Reflection caches must not let an earlier test supply the bindings.
+          for (const declaration of declarations) {
+            for (const key of keys) {
+              Reflect.deleteProperty(declaration, key);
+              expect(
+                Object.getOwnPropertyDescriptor(declaration, key),
+              ).toBeUndefined();
+            }
+          }
+
+          expect(componentDefinition).toBeDefined();
+          expect(directiveDefinition).toBeDefined();
+          expect(inputDefinition).toBeDefined();
+
+          if (setup === 'direct') {
+            await TestBed.configureTestingModule({
+              declarations: [HostComponent],
+              imports: [
+                MockComponent(MatTimepicker),
+                MockDirective(MatTimepickerInput),
+                MockDirective(MatInput),
+              ],
+            }).compileComponents();
+          } else {
+            await MockBuilder(HostComponent, HostModule);
+          }
+
+          const fixture = MockRender(HostComponent);
+          const host = fixture.point.componentInstance;
+          const pickerElement = ngMocks.find(MatTimepicker);
+          const picker = pickerElement.componentInstance;
+          const inputElement = ngMocks.find('input');
+          const input = ngMocks.get(inputElement, MatTimepickerInput);
+          const legacy = ngMocks.get(inputElement, MatInput);
+          const interval = picker.interval;
+          const label = picker.ariaLabel;
+          const timepicker = input.timepicker;
+          const openOnClick = input.openOnClick;
+          const value = input.value;
+          const emitter = ngMocks.output(inputElement, 'valueChange');
+
+          expect(isMockOf(picker, MatTimepicker)).toBe(true);
+          expect(isMockOf(input, MatTimepickerInput)).toBe(true);
+          expect(isMockOf(legacy, MatInput)).toBe(true);
+          expect(isSignal(interval)).toBe(true);
+          expect(isSignal(label)).toBe(true);
+          expect(isSignal(timepicker)).toBe(true);
+          expect(isSignal(openOnClick)).toBe(true);
+          expect(isSignal(value)).toBe(true);
+          // Signal initializer transforms are omitted by mocks. Compiled
+          // decorator transforms remain available and still coerce bindings.
+          expect<unknown>(interval()).toBe('15m');
+          expect(label()).toBe('initial');
+          expect(timepicker()).toBe(picker);
+          expect<unknown>(openOnClick()).toBe('false');
+          expect(legacy.disabledInteractive).toBe(false);
+          expect(value()).toBe(1);
+          expect(ngMocks.input(pickerElement, 'interval')).toBe(
+            '15m',
+          );
+          expect(ngMocks.input(pickerElement, 'aria-label')).toBe(
+            'initial',
+          );
+          expect(ngMocks.input(inputElement, 'matTimepicker')).toBe(
+            picker,
+          );
+          expect(
+            ngMocks.input(inputElement, 'matTimepickerOpenOnClick'),
+          ).toBe('false');
+          expect(
+            ngMocks.input(inputElement, 'disabledInteractive'),
+          ).toBe(false);
+          expect(ngMocks.input(inputElement, 'value')).toBe(1);
+          expect(host.changes).toEqual([]);
+          expect<unknown>(emitter).not.toBe(value);
+
+          ngMocks
+            .output(pickerElement, 'selected')
+            .emit({ source: picker, value: 'first' });
+          emitter.emit(2);
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+
+          expect(host.selected).toEqual(['first']);
+          expect(host.changes).toEqual([2]);
+          expect(host.value).toBe(2);
+          expect(value()).toBe(2);
+          expect(input.value).toBe(value);
+
+          host.interval = '30m';
+          host.label = 'updated';
+          host.flag = 'true';
+          host.value = 3;
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+
+          expect(picker.interval).toBe(interval);
+          expect(picker.ariaLabel).toBe(label);
+          expect(input.timepicker).toBe(timepicker);
+          expect(input.openOnClick).toBe(openOnClick);
+          expect(input.value).toBe(value);
+          expect<unknown>(interval()).toBe('30m');
+          expect(label()).toBe('updated');
+          expect(timepicker()).toBe(picker);
+          expect<unknown>(openOnClick()).toBe('true');
+          expect(legacy.disabledInteractive).toBe(true);
+          expect(value()).toBe(3);
+          expect(host.changes).toEqual([2]);
+
+          host.interval = '45m';
+          host.label = 'last';
+          host.flag = 'false';
+          host.value = 4;
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+          ngMocks
+            .output(pickerElement, 'selected')
+            .emit({ source: picker, value: 'last' });
+          emitter.emit(5);
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+
+          expect(picker.interval).toBe(interval);
+          expect(picker.ariaLabel).toBe(label);
+          expect(input.timepicker).toBe(timepicker);
+          expect(input.openOnClick).toBe(openOnClick);
+          expect(input.value).toBe(value);
+          expect<unknown>(interval()).toBe('45m');
+          expect(label()).toBe('last');
+          expect(timepicker()).toBe(picker);
+          expect<unknown>(openOnClick()).toBe('false');
+          expect(legacy.disabledInteractive).toBe(false);
+          expect(host.value).toBe(5);
+          expect(value()).toBe(5);
+          expect(host.selected).toEqual(['first', 'last']);
+          expect(host.changes).toEqual([2, 5]);
+          expect(ngMocks.input(pickerElement, 'aria-label')).toBe(
+            'last',
+          );
+          expect(ngMocks.input(inputElement, 'value')).toBe(5);
+          expect(MatTimepicker.ɵcmp).toBe(componentDefinition);
+          expect(MatTimepickerInput.ɵdir).toBe(directiveDefinition);
+          expect(MatInput.ɵdir).toBe(inputDefinition);
+        } finally {
+          try {
+            TestBed.resetTestingModule();
+          } finally {
+            for (const { declaration, descriptors } of saved) {
+              for (const { key, descriptor } of descriptors) {
+                if (descriptor) {
+                  // Restore the original flags/accessors as well as the value.
+                  Object.defineProperty(declaration, key, descriptor);
+                } else {
+                  Reflect.deleteProperty(declaration, key);
+                }
+                expect(
+                  Object.getOwnPropertyDescriptor(declaration, key),
+                ).toEqual(descriptor);
+              }
+            }
+            ngMocks.reset();
+          }
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Why

#9698 and #11214 reported signal bindings that differed between external compiled dependencies and local declarations. Local and synthetic metadata coverage did not establish that the compiled-library input, output, and model paths work together.

Integration lint also depended on local dependency installs. The commit hook ran, but resolved types made ES-X treat imported methods differently from CI, which lints before installing integration dependencies.

## What

Add integration regressions using the published Angular Material timepicker component and input directive, both through direct mocks and MockBuilder module consumption. Keep normal package metadata as a control and isolate compiled-definition fallback by temporarily hiding development property annotations and clearing reflection caches. Preserve the actual compiled definitions and restore the original descriptors after each case.

Cover aliased, unaliased, and required signal inputs, repeated parent writes, output delivery, public binding lookup, stable signal identity, and model round trips through the separate mock output emitter. Equivalent local declarations and a decorated Material input distinguish omitted signal initializer transforms from effective decorator transforms.

Use syntax-based lint analysis for the integration project so optional dependency installs cannot alter ES-X inference. Keep the existing narrow explanations for `ngMocks.find` calls, which are not array methods.

## Impact

The existing implementation handles these cases; the regressions run in the Angular 22 integration project against its precompiled dependencies. Local hooks and CI apply the same ES compatibility checks to these integration calls. Root typed lint and all enabled ES restrictions remain in place. Runtime behavior, public APIs, and public documentation do not change.

Fixes #14919
