### PR TITLE
test(MockBuilder): cover real kept standalone value accessors #14922

### DIFF
--- a/test-spread.conf
+++ b/test-spread.conf
@@ -140,6 +140,7 @@ file|tests/mock-render-metadata/static-queries.spec.ts|versions=8+
 file|tests/mock-render-metadata/input-transforms.spec.ts|versions=16+
 file|tests/issue-14918/test.spec.ts|versions=16+
 file|tests/issue-14920/test.spec.ts|features=signalQueries,hostDirectives
+file|tests/issue-14922/test.spec.ts|features=standalone
 file|tests/mock-render-metadata/output-model.spec.ts|features=signalInputs,outputFn
 file|tests/mock-render-metadata/output-observable.spec.ts|features=outputFn
 file|tests/mock-render-metadata/query-signals.spec.ts|features=signalQueries

--- a/tests/issue-10960/test.spec.ts
+++ b/tests/issue-10960/test.spec.ts
@@ -8,23 +8,14 @@ import {
 } from '@angular/forms';
 
 import {
+  isMockOf,
   MockBuilder,
   MockInstance,
   MockRender,
   ngMocks,
 } from 'ng-mocks';
 
-// This standalone CVA is the minimal reproduction of the reported issue:
-// - it imports ReactiveFormsModule by itself
-// - it provides NG_VALUE_ACCESSOR via useExisting + forwardRef to itself
-//
-// Before the fix, MockBuilder kept this declaration in skipMock mode, but the
-// provider override logic still rewrote the useExisting target. That broke
-// Angular's value-accessor lookup and rendering the host form crashed with:
-// "Cannot read properties of undefined (reading 'constructor')".
-//
-// After the fix, a kept standalone declaration keeps its own useExisting
-// provider, so Angular receives the real accessor and forms work normally.
+// The reported standalone CVA imports forms and provides itself as the accessor.
 @Component({
   selector: 'standalone-cva',
   template: '<input [formControl]="control" />',
@@ -62,10 +53,6 @@ class StandaloneCVAComponent implements ControlValueAccessor {
   }
 }
 
-// The host renders the standalone CVA through formControlName.
-// This is the path that failed before the fix: ng-mocks kept the real
-// standalone component, but its aliased NG_VALUE_ACCESSOR provider got
-// rewritten as if the declaration had been mocked.
 @Component({
   selector: 'target',
   template:
@@ -82,6 +69,7 @@ class TargetComponent {
   });
 }
 
+// @see https://github.com/help-me-mom/ng-mocks/issues/10960
 describe('issue-10960', () => {
   // Standalone components are only supported by the repo matrix from Angular 14.
   // Older targets still compile this file, so we keep the compatibility guard in
@@ -97,37 +85,32 @@ describe('issue-10960', () => {
   MockInstance.scope();
 
   beforeEach(() =>
-    // We intentionally keep the host and the standalone accessor real.
-    // That forces ng-mocks through the skipMock path that used to rewrite the
-    // self-referencing useExisting provider incorrectly.
+    // The host stays real while its standalone accessor dependency is mocked.
     MockBuilder(TargetComponent).keep(ReactiveFormsModule),
   );
 
-  it('keeps the standalone value accessor intact', () => {
+  it('connects the mocked standalone value accessor to the host form', () => {
     const writeValue =
       typeof jest === 'undefined'
         ? jasmine.createSpy('writeValue')
         : jest.fn();
 
-    // We spy on writeValue instead of asserting DOM details so that the test
-    // stays focused on the value-accessor handshake:
-    // - the parent form should initialize the accessor with the form value
-    // - later parent-driven updates should still reach the accessor
+    // Capture host writes to the mock, whose original inner input is not rendered.
     MockInstance(StandaloneCVAComponent, 'writeValue', writeValue);
 
-    // Before the fix, this render threw while Angular was selecting the value
-    // accessor because NG_VALUE_ACCESSOR.useExisting no longer pointed at the
-    // kept standalone component.
     const fixture = MockRender(TargetComponent);
     const component = fixture.point.componentInstance;
     const accessor = ngMocks.find(StandaloneCVAComponent);
+
+    expect(
+      isMockOf(accessor.componentInstance, StandaloneCVAComponent),
+    ).toBe(true);
 
     // Host -> accessor on first render: Angular should push the initial form
     // value into the CVA through writeValue.
     expect(writeValue).toHaveBeenCalledWith('http://example.com');
 
-    // Accessor -> host: changing the real input should still update the host
-    // form control, proving the accessor was wired up successfully.
+    // Simulate a change through the mocked accessor's registered callback.
     ngMocks.change(accessor, 'foo');
     expect(component.form.controls['nestedForm'].value).toBe('foo');
 

--- a/tests/issue-14922/test.spec.ts
+++ b/tests/issue-14922/test.spec.ts
@@ -1,0 +1,129 @@
+import { Component, forwardRef } from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormControl,
+  FormGroup,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+} from '@angular/forms';
+
+import { isMockOf, MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'standalone-cva',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  template: '<input [formControl]="control" />',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => StandaloneCVAComponent),
+      multi: true,
+    },
+  ],
+})
+class StandaloneCVAComponent implements ControlValueAccessor {
+  public readonly control = new FormControl('');
+
+  public registerOnChange(
+    callback: (value: string | null) => void,
+  ): void {
+    this.control.valueChanges.subscribe(callback);
+  }
+
+  public registerOnTouched(): void {}
+
+  public setDisabledState(isDisabled: boolean): void {
+    if (isDisabled) {
+      this.control.disable({ emitEvent: false });
+    } else {
+      this.control.enable({ emitEvent: false });
+    }
+  }
+
+  public writeValue(value: string | null): void {
+    this.control.setValue(value, { emitEvent: false });
+  }
+}
+
+@Component({
+  selector: 'target',
+  standalone: true,
+  imports: [ReactiveFormsModule, StandaloneCVAComponent],
+  template: `
+    <ng-container [formGroup]="form">
+      <standalone-cva formControlName="nestedForm"></standalone-cva>
+    </ng-container>
+  `,
+})
+class TargetComponent {
+  public readonly form = new FormGroup({
+    nestedForm: new FormControl('http://example.com'),
+  });
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14922
+describe('issue-14922', () => {
+  beforeEach(() =>
+    MockBuilder(TargetComponent)
+      .keep(StandaloneCVAComponent)
+      .keep(ReactiveFormsModule),
+  );
+
+  it('preserves the real accessor self alias and its inner reactive control', () => {
+    const fixture = MockRender(TargetComponent);
+    const parent =
+      fixture.point.componentInstance.form.controls.nestedForm;
+    const element = ngMocks.find(StandaloneCVAComponent);
+    const accessor = element.componentInstance;
+    const accessors = element.injector.get(NG_VALUE_ACCESSOR);
+    const inputElement = ngMocks.find(element, 'input');
+    const input: HTMLInputElement = inputElement.nativeElement;
+
+    expect(isMockOf(accessor, StandaloneCVAComponent)).toBe(false);
+    expect(accessor.constructor).toBe(StandaloneCVAComponent);
+    expect(accessors.length).toBe(1);
+    expect(accessors[0]).toBe(accessor);
+    expect(accessor.control.value).toBe('http://example.com');
+    expect(input.value).toBe('http://example.com');
+    expect(accessor.control.enabled).toBe(true);
+    expect(input.disabled).toBe(false);
+
+    const values: Array<string | null> = [];
+    const subscription = parent.valueChanges.subscribe(value =>
+      values.push(value),
+    );
+    ngMocks.change(inputElement, 'inner');
+    fixture.detectChanges();
+    subscription.unsubscribe();
+
+    expect(parent.value).toBe('inner');
+    expect(accessor.control.value).toBe('inner');
+    expect(input.value).toBe('inner');
+    expect(values).toEqual(['inner']);
+
+    parent.setValue('parent');
+    fixture.detectChanges();
+
+    expect(accessor.control.value).toBe('parent');
+    expect(input.value).toBe('parent');
+
+    parent.disable();
+    fixture.detectChanges();
+
+    expect(parent.disabled).toBe(true);
+    expect(accessor.control.disabled).toBe(true);
+    expect(input.disabled).toBe(true);
+
+    parent.enable();
+    fixture.detectChanges();
+
+    expect(parent.enabled).toBe(true);
+    expect(accessor.control.enabled).toBe(true);
+    expect(input.disabled).toBe(false);
+    expect(parent.value).toBe('parent');
+    expect(accessor.control.value).toBe('parent');
+    expect(input.value).toBe('parent');
+    expect(element.injector.get(NG_VALUE_ACCESSOR)[0]).toBe(accessor);
+  });
+});


### PR DESCRIPTION
## Why

The regression for #10960 shallow-mocks the standalone value accessor, despite comments claiming that it keeps the real control. It covers the mock's forms handshake but does not establish that a kept accessor can import `ReactiveFormsModule` and retain its self-referencing provider.

## What

Add an independent regression that explicitly keeps the accessor and `ReactiveFormsModule`. It verifies that the element injector provides exactly the real accessor instance, the inner input receives the initial value, an inner change reaches the parent once, parent writes reach the input, and disable/enable state propagates.

Preserve the original mocked case, assert its mock identity, and correct its comments. Existing explicit forms-token override controls remain applicable.

## Impact

Both the real and mocked standalone-control paths have functional regression coverage. The current implementation already supports the real case; no runtime or public documentation change is needed.

Closes #14922
