### PR TITLE
fix(ngMocks): isolate replayed declaration accessor values #14924

### DIFF
--- a/libs/ng-mocks/src/lib/mock-service/helper.replay-instance.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/helper.replay-instance.spec.ts
@@ -1,4 +1,8 @@
+import { ngMocks } from '../mock-helper/mock-helper';
+
+import helperDefinePropertyDescriptor from './helper.define-property-descriptor';
 import helperReplayInstance from './helper.replay-instance';
+import { MockService } from './mock-service';
 
 describe('helper.replay-instance', () => {
   it('returns early for empty or identical instances', () => {
@@ -10,6 +14,272 @@ describe('helper.replay-instance', () => {
     expect(() =>
       helperReplayInstance(instance, instance),
     ).not.toThrow();
+  });
+
+  it('keeps generated accessor state local while replaying the same method spy', () => {
+    class Target {
+      public constructor() {
+        throw new Error('original constructor');
+      }
+
+      public get value(): string {
+        throw new Error('original getter');
+      }
+
+      public set value(value: string) {
+        throw new Error(`original setter: ${value}`);
+      }
+
+      public echo(): string {
+        throw new Error('original method');
+      }
+    }
+
+    const seed = MockService(Target);
+    const first = MockService(Target);
+    const second = MockService(Target);
+    const echo = jasmine
+      .createSpy('echo')
+      .and.returnValue('configured');
+    ngMocks.stubMember(seed, 'echo', echo);
+
+    helperReplayInstance(seed, first);
+    helperReplayInstance(seed, second);
+
+    expect(first.value).toBeUndefined();
+    expect(second.value).toBeUndefined();
+    first.value = 'first';
+    second.value = 'second';
+    expect(first.value).toBe('first');
+    expect(second.value).toBe('second');
+    expect(seed.value).toBeUndefined();
+
+    first.value = 'updated';
+    seed.value = 'seed';
+    expect(first.value).toBe('updated');
+    expect(second.value).toBe('second');
+    expect(seed.value).toBe('seed');
+    expect(first.echo).toBe(echo);
+    expect(second.echo).toBe(echo);
+    expect(seed.echo).toBe(echo);
+    expect(first.echo()).toBe('configured');
+    expect(second.echo()).toBe('configured');
+    expect(echo).toHaveBeenCalledTimes(2);
+  });
+
+  it('copies an assigned generated accessor value without sharing subsequent writes', () => {
+    class Target {
+      public get value(): string {
+        throw new Error('original getter');
+      }
+
+      public set value(value: string) {
+        throw new Error(`original setter: ${value}`);
+      }
+    }
+
+    const seed = MockService(Target);
+    const first = MockService(Target);
+    const second = MockService(Target);
+    seed.value = 'initial';
+
+    helperReplayInstance(seed, first);
+    helperReplayInstance(seed, second);
+
+    expect(first.value).toBe('initial');
+    expect(second.value).toBe('initial');
+    first.value = 'first';
+    expect(first.value).toBe('first');
+    expect(second.value).toBe('initial');
+    expect(seed.value).toBe('initial');
+
+    second.value = 'second';
+    seed.value = 'updated seed';
+    expect(first.value).toBe('first');
+    expect(second.value).toBe('second');
+    expect(seed.value).toBe('updated seed');
+
+    const third = MockService(Target);
+    helperReplayInstance(seed, third);
+    expect(third.value).toBe('updated seed');
+    third.value = 'third';
+    expect(third.value).toBe('third');
+    expect(first.value).toBe('first');
+    expect(second.value).toBe('second');
+    expect(seed.value).toBe('updated seed');
+  });
+
+  it('replaces configurable target accessors without invoking them and preserves locked targets', () => {
+    class Target {
+      public get value(): string {
+        throw new Error('original getter');
+      }
+
+      public set value(value: string) {
+        throw new Error(`original setter: ${value}`);
+      }
+    }
+
+    const seed = MockService(Target);
+    seed.value = 'initial';
+    helperDefinePropertyDescriptor(seed, 'value', {
+      ...Object.getOwnPropertyDescriptor(seed, 'value'),
+      enumerable: false,
+    });
+    const seedDescriptor = Object.getOwnPropertyDescriptor(
+      seed,
+      'value',
+    );
+    const plain: Partial<Target> = {};
+    const customized: Partial<Target> = {};
+    const getter = jasmine
+      .createSpy('target getter')
+      .and.returnValue('target');
+    const setter = jasmine.createSpy('target setter');
+    helperDefinePropertyDescriptor(customized, 'value', {
+      enumerable: true,
+      get: getter,
+      set: setter,
+    });
+    const locked = Object.freeze({ value: 'locked' });
+    const lockedDescriptor = Object.getOwnPropertyDescriptor(
+      locked,
+      'value',
+    );
+
+    for (const target of [plain, customized]) {
+      helperReplayInstance(seed, target);
+
+      expect(target.value).toBe('initial');
+      const descriptor = Object.getOwnPropertyDescriptor(
+        target,
+        'value',
+      );
+      expect(typeof descriptor?.get).toBe('function');
+      expect(typeof descriptor?.set).toBe('function');
+      expect(descriptor?.enumerable).toBe(false);
+      expect(descriptor?.configurable).toBe(true);
+    }
+    helperReplayInstance(seed, locked);
+    plain.value = 'plain';
+    customized.value = 'customized';
+
+    expect(plain.value).toBe('plain');
+    expect(customized.value).toBe('customized');
+    expect(seed.value).toBe('initial');
+    expect(getter).not.toHaveBeenCalled();
+    expect(setter).not.toHaveBeenCalled();
+    expect(locked.value).toBe('locked');
+    expect(Object.getOwnPropertyDescriptor(locked, 'value')).toEqual(
+      lockedDescriptor,
+    );
+    expect(Object.getOwnPropertyDescriptor(seed, 'value')).toEqual(
+      seedDescriptor,
+    );
+  });
+
+  it('preserves a generated getter whose setter was explicitly removed', () => {
+    class Target {
+      public get value(): string {
+        throw new Error('original getter');
+      }
+
+      public set value(value: string) {
+        throw new Error(`original setter: ${value}`);
+      }
+    }
+
+    const seed = MockService(Target);
+    seed.value = 'configured';
+    const getter = Object.getOwnPropertyDescriptor(
+      seed,
+      'value',
+    )?.get;
+    helperDefinePropertyDescriptor(seed, 'value', {
+      enumerable: false,
+      get: getter,
+      set: undefined,
+    });
+    const target: Partial<Target> = {};
+
+    helperReplayInstance(seed, target);
+
+    expect(target.value).toBe('configured');
+    expect(seed.value).toBe('configured');
+    expect(Object.getOwnPropertyDescriptor(target, 'value')).toEqual({
+      configurable: true,
+      enumerable: false,
+      get: getter,
+      set: undefined,
+    });
+    expect(
+      Object.getOwnPropertyDescriptor(target, 'value')?.get,
+    ).toBe(getter);
+    expect(
+      Object.getOwnPropertyDescriptor(seed, 'value')?.set,
+    ).toBeUndefined();
+  });
+
+  it('replays deliberate getter and setter replacements without invoking them', () => {
+    class Target {
+      public get read(): string {
+        throw new Error('original getter');
+      }
+
+      public set read(value: string) {
+        throw new Error(`original setter: ${value}`);
+      }
+
+      public get write(): string {
+        throw new Error('original getter');
+      }
+
+      public set write(value: string) {
+        throw new Error(`original setter: ${value}`);
+      }
+    }
+
+    const seed = MockService(Target);
+    const first = MockService(Target);
+    const second = MockService(Target);
+    const getter = jasmine
+      .createSpy('getter')
+      .and.returnValue('configured');
+    const setter = jasmine.createSpy('setter');
+    ngMocks.stubMember(seed, 'read', getter, 'get');
+    ngMocks.stubMember(seed, 'write', setter, 'set');
+
+    helperReplayInstance(seed, first);
+    helperReplayInstance(seed, second);
+
+    expect(getter).not.toHaveBeenCalled();
+    expect(setter).not.toHaveBeenCalled();
+    expect(Object.getOwnPropertyDescriptor(first, 'read')?.get).toBe(
+      getter,
+    );
+    expect(Object.getOwnPropertyDescriptor(second, 'read')?.get).toBe(
+      getter,
+    );
+    expect(Object.getOwnPropertyDescriptor(first, 'write')?.set).toBe(
+      setter,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(second, 'write')?.set,
+    ).toBe(setter);
+    expect(first.read).toBe('configured');
+    expect(second.read).toBe('configured');
+    expect(getter).toHaveBeenCalledTimes(2);
+    first.write = 'first';
+    second.write = 'second';
+    expect(setter).toHaveBeenCalledWith('first');
+    expect(setter).toHaveBeenCalledWith('second');
+    expect(setter).toHaveBeenCalledTimes(2);
+    expect(Object.getOwnPropertyDescriptor(seed, 'read')?.get).toBe(
+      getter,
+    );
+    expect(Object.getOwnPropertyDescriptor(seed, 'write')?.set).toBe(
+      setter,
+    );
   });
 
   it('copies symbol descriptors and skips internal keys', () => {

--- a/libs/ng-mocks/src/lib/mock-service/helper.replay-instance.ts
+++ b/libs/ng-mocks/src/lib/mock-service/helper.replay-instance.ts
@@ -1,5 +1,6 @@
 import helperDefinePropertyDescriptor from './helper.define-property-descriptor';
 import helperExtractPropertyDescriptor from './helper.extract-property-descriptor';
+import helperMockService from './helper.mock-service';
 
 const shouldSkipKey = (key: string | symbol): boolean => {
   if (typeof key === 'symbol') {
@@ -24,6 +25,17 @@ export default (seed: any, target: any): void => {
     const descriptor = helperExtractPropertyDescriptor(seed, key);
     if (!descriptor || descriptor.configurable === false) {
       continue;
+    }
+
+    const getter = descriptor.get as ((() => unknown) & { __ngMocksGet?: unknown }) | undefined;
+    const setter = descriptor.set as (((value: unknown) => void) & { __ngMocksSet?: unknown }) | undefined;
+    if (typeof getter?.__ngMocksGet === 'function' && typeof setter?.__ngMocksSet === 'function') {
+      // Generated accessors keep their value in a closure. Replay its current value into a fresh
+      // pair, while deliberately replaced getters or setters retain their exact function identity.
+      const accessors = {};
+      descriptor.get = helperMockService.mock(accessors, String(key), 'get');
+      descriptor.set = helperMockService.mock(accessors, String(key), 'set');
+      descriptor.set!(getter!());
     }
 
     helperDefinePropertyDescriptor(target, key, descriptor);

--- a/tests/issue-14924/test.spec.ts
+++ b/tests/issue-14924/test.spec.ts
@@ -1,0 +1,191 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  Injectable,
+  Input,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockBuilder, ngMocks } from 'ng-mocks';
+
+@Injectable()
+class TargetService {
+  public constructor() {
+    throw new Error('real constructor');
+  }
+
+  public echo(): string {
+    throw new Error('real method');
+  }
+}
+
+@Component({
+  selector: 'target-14924',
+  template: '',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ServiceToComponent extends TargetService {
+  @Input() public plain = '';
+
+  @Input('value')
+  public get accessor(): string {
+    throw new Error('real component getter');
+  }
+
+  public set accessor(value: string) {
+    throw new Error(`real component setter: ${value}`);
+  }
+}
+
+@Directive({
+  selector: '[target14924]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ServiceToDirective extends TargetService {
+  @Input() public plain = '';
+
+  @Input('value')
+  public get accessor(): string {
+    throw new Error('real directive getter');
+  }
+
+  public set accessor(value: string) {
+    throw new Error(`real directive setter: ${value}`);
+  }
+}
+
+@Component({
+  selector: 'host-14924',
+  changeDetection: ChangeDetectionStrategy.Default,
+  template: `
+    <target-14924 [value]="left" [plain]="left"></target-14924>
+    <target-14924 [value]="right" [plain]="right"></target-14924>
+    <span target14924 [value]="left" [plain]="left"></span>
+    <span target14924 [value]="right" [plain]="right"></span>
+  `,
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class HostComponent {
+  public left = 'A';
+  public right = 'B';
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14924
+describe('issue-14924', () => {
+  for (const declaration of [
+    ServiceToComponent,
+    ServiceToDirective,
+  ]) {
+    describe(declaration.name, () => {
+      beforeEach(() =>
+        MockBuilder(HostComponent)
+          .mock(ServiceToComponent)
+          .mock(ServiceToDirective),
+      );
+
+      for (const injectSeed of [false, true]) {
+        it(`keeps bound values independent with seed=${injectSeed}`, () => {
+          const echo =
+            typeof jest === 'undefined'
+              ? jasmine.createSpy().and.returnValue('configured')
+              : jest.fn().mockReturnValue('configured');
+          const seed = injectSeed
+            ? ngMocks.findInstance(declaration)
+            : undefined;
+          if (seed) {
+            ngMocks.stub(seed, { echo });
+          }
+
+          const fixture = TestBed.createComponent(HostComponent);
+          fixture.detectChanges();
+          const nodes = ngMocks.findAll(fixture, declaration);
+          const instances = nodes.map(node =>
+            ngMocks.get(node, declaration),
+          );
+
+          expect(nodes.length).toEqual(2);
+          expect(instances.length).toEqual(2);
+          expect(instances[0]).not.toBe(instances[1]);
+          for (const instance of instances) {
+            expect(isMockOf(instance, declaration)).toEqual(true);
+            if (seed) {
+              expect(instance).not.toBe(seed);
+              expect(instance.echo).toBe(echo);
+              expect(instance.echo()).toEqual('configured');
+            }
+          }
+
+          // Replaying a seed must not share its generated accessor's backing value.
+          expect(instances[0].accessor).toEqual('A');
+          expect(instances[1].accessor).toEqual('B');
+          expect(ngMocks.input(nodes[0], 'value')).toEqual('A');
+          expect(ngMocks.input(nodes[1], 'value')).toEqual('B');
+          expect(instances[0].plain).toEqual('A');
+          expect(instances[1].plain).toEqual('B');
+
+          fixture.componentInstance.left = 'C';
+          fixture.changeDetectorRef.markForCheck();
+          fixture.detectChanges();
+
+          expect(instances[0].accessor).toEqual('C');
+          expect(instances[1].accessor).toEqual('B');
+          expect(ngMocks.input(nodes[0], 'value')).toEqual('C');
+          expect(ngMocks.input(nodes[1], 'value')).toEqual('B');
+          expect(instances[0].plain).toEqual('C');
+          expect(instances[1].plain).toEqual('B');
+          if (seed) {
+            expect(seed.accessor).toBeUndefined();
+            expect(seed.plain).toBeUndefined();
+            expect(echo).toHaveBeenCalledTimes(2);
+          }
+        });
+      }
+
+      it('preserves deliberately stubbed seed accessors', () => {
+        const seed = ngMocks.findInstance(declaration);
+        const get =
+          typeof jest === 'undefined'
+            ? jasmine.createSpy().and.returnValue('configured')
+            : jest.fn().mockReturnValue('configured');
+        const set =
+          typeof jest === 'undefined'
+            ? jasmine.createSpy()
+            : jest.fn();
+        ngMocks.stubMember(seed, 'accessor', get, 'get');
+        ngMocks.stubMember(seed, 'accessor', set, 'set');
+
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        const instances = ngMocks
+          .findAll(fixture, declaration)
+          .map(node => ngMocks.get(node, declaration));
+
+        expect(instances.length).toEqual(2);
+        expect(get).not.toHaveBeenCalled();
+        expect(set).toHaveBeenCalledTimes(2);
+        expect(set).toHaveBeenCalledWith('A');
+        expect(set).toHaveBeenCalledWith('B');
+        for (const instance of instances) {
+          const descriptor = Object.getOwnPropertyDescriptor(
+            instance,
+            'accessor',
+          );
+          expect(descriptor && descriptor.get).toBe(get);
+          expect(descriptor && descriptor.set).toBe(set);
+          expect(instance.accessor).toEqual('configured');
+        }
+        expect(instances[0].plain).toEqual('A');
+        expect(instances[1].plain).toEqual('B');
+
+        fixture.componentInstance.left = 'C';
+        fixture.changeDetectorRef.markForCheck();
+        fixture.detectChanges();
+
+        expect(set).toHaveBeenCalledTimes(3);
+        expect(set).toHaveBeenCalledWith('C');
+        expect(instances[1].plain).toEqual('B');
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Why

When a mock declaration was injected before rendering, seed replay copied its generated getter and setter functions into every later instance. Those functions shared one backing value, so two independently bound component or directive inputs could overwrite each other and the injected seed.

This follows the declaration-provider seed replay introduced for #7937 and #13312.

## What

Replay generated accessor pairs with independent storage initialized from the seed's current value. Continue copying deliberately customized accessors and method spies with their original identities.

Add real Angular regressions for two instances of both a component and an attribute directive, including independent binding updates, ordinary field inputs, no-seed behavior, and explicit accessor stubs. Source tests cover configured seed values, later instances, descriptor preservation, and existing target accessors without invoking them.

## Impact

Tests can configure a declaration's methods before rendering while keeping each rendered instance's input values independent. The existing injector identity and reset behavior is unchanged. Public APIs and documentation are unchanged.

Fixes #14924
