### PR TITLE
fix(ngMocks): preserve provider errors across lookup and pipe rendering #14926

### DIFF
--- a/libs/ng-mocks/src/lib/mock-helper/find-instance/mock-helper.find-instance.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/find-instance/mock-helper.find-instance.ts
@@ -1,4 +1,5 @@
-import { getInjection } from '../../common/core.helpers';
+import { getTestBed } from '@angular/core/testing';
+
 import { Type } from '../../common/core.types';
 import { getSourceOfMock } from '../../common/func.get-source-of-mock';
 import { isNgDef } from '../../common/func.is-ng-def';
@@ -36,13 +37,15 @@ export default <T>(...args: any[]): T => {
       true,
     );
   } else {
-    try {
-      result.push(getInjection(declaration));
-    } catch (error) {
-      // forwarding unexpected errors: https://github.com/help-me-mom/ng-mocks/issues/7041
-      if (!error || typeof error !== 'object' || (error as any).ngTokenPath === undefined) {
-        throw error;
-      }
+    const testBed = getTestBed();
+    const instance = testBed.inject
+      ? testBed.inject(declaration, defaultNotFoundValue)
+      : /* istanbul ignore next */ (testBed as typeof testBed & { get: typeof testBed.inject }).get(
+          declaration,
+          defaultNotFoundValue,
+        );
+    if (instance !== defaultNotFoundValue) {
+      result.push(instance);
     }
   }
 

--- a/libs/ng-mocks/src/lib/mock-helper/find-instance/mock-helper.find-instances.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/find-instance/mock-helper.find-instances.ts
@@ -1,4 +1,5 @@
-import { getInjection } from '../../common/core.helpers';
+import { getTestBed } from '@angular/core/testing';
+
 import { Type } from '../../common/core.types';
 import { getSourceOfMock } from '../../common/func.get-source-of-mock';
 import { isNgDef } from '../../common/func.is-ng-def';
@@ -39,10 +40,16 @@ export default <T>(...args: any[]): T[] => {
       );
     }
   } else {
-    try {
-      result.push(getInjection(declaration));
-    } catch {
-      // nothing to do
+    const testBed = getTestBed();
+    const notFoundValue = {};
+    const instance = testBed.inject
+      ? testBed.inject(declaration, notFoundValue)
+      : /* istanbul ignore next */ (testBed as typeof testBed & { get: typeof testBed.inject }).get(
+          declaration,
+          notFoundValue,
+        );
+    if (instance !== notFoundValue) {
+      result.push(instance);
     }
   }
 

--- a/libs/ng-mocks/src/lib/mock-helper/func.get-from-node-injector.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/func.get-from-node-injector.spec.ts
@@ -1,0 +1,246 @@
+import {
+  InjectionToken,
+  Injector,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+
+import coreInjector from '../common/core.injector';
+
+import funcGetFromNodeInjector from './func.get-from-node-injector';
+
+@Pipe({ name: 'target14926' })
+class TargetPipe implements PipeTransform {
+  public transform(value: string): string {
+    return value;
+  }
+}
+
+describe('func.get-from-node-injector', () => {
+  it('forwards a local lazy provider failure without changing the results', () => {
+    const token = new InjectionToken<string>('local');
+    const originalError = new Error('local provider failure');
+    const factory = jasmine.createSpy('factory').and.callFake(() => {
+      throw originalError;
+    });
+    const node = {
+      injector: Injector.create({
+        providers: [{ provide: token, useFactory: factory }],
+      }),
+      parent: null,
+    };
+    const result: string[] = ['existing'];
+    let caught = false;
+
+    try {
+      funcGetFromNodeInjector(result, node as never, token);
+    } catch (error) {
+      caught = true;
+      expect(error).toBe(originalError);
+    }
+
+    expect(caught).toBe(true);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(['existing']);
+  });
+
+  it('forwards an inherited factory failure before a parent probe can retry it', () => {
+    const token = new InjectionToken<string>('inherited');
+    const originalError = new Error('inherited provider failure');
+    const factory = jasmine.createSpy('factory').and.callFake(() => {
+      throw originalError;
+    });
+    const parent = Injector.create({
+      providers: [{ provide: token, useFactory: factory }],
+    });
+    const node = {
+      injector: Injector.create({ parent, providers: [] }),
+      parent: { injector: parent, parent: null },
+    };
+    const result: string[] = [];
+    let caught = false;
+
+    try {
+      funcGetFromNodeInjector(result, node as never, token);
+    } catch (error) {
+      caught = true;
+      expect(error).toBe(originalError);
+    }
+
+    expect(caught).toBe(true);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it('keeps a successful local override when the optional parent provider fails', () => {
+    const token = new InjectionToken<object>('override');
+    const instance = {};
+    const factory = jasmine
+      .createSpy('parent factory')
+      .and.callFake(() => {
+        throw new Error('unused parent provider');
+      });
+    const parent = Injector.create({
+      providers: [{ provide: token, useFactory: factory }],
+    });
+    const node = {
+      injector: Injector.create({
+        parent,
+        providers: [{ provide: token, useValue: instance }],
+      }),
+      parent: { injector: parent, parent: null },
+    };
+    const result: object[] = [];
+
+    funcGetFromNodeInjector(result, node as never, token);
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(instance);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves missing and undefined node results while retaining null and false', () => {
+    const missing = new InjectionToken<string>('missing');
+    const provided = new InjectionToken<undefined | null | boolean>(
+      'provided',
+    );
+    const missingResult: string[] = [];
+    const result: Array<undefined | null | boolean> = [];
+    const missingNode = {
+      injector: Injector.create({ providers: [] }),
+      parent: null,
+    };
+
+    funcGetFromNodeInjector(
+      missingResult,
+      missingNode as never,
+      missing,
+    );
+    expect(missingResult).toEqual([]);
+    for (const value of [undefined, null, false]) {
+      const node = {
+        injector: Injector.create({
+          providers: [{ provide: provided, useValue: value }],
+        }),
+        parent: null,
+      };
+      funcGetFromNodeInjector(result, node as never, provided);
+    }
+
+    expect(result).toEqual([null, false]);
+  });
+
+  it('keeps inherited instances at the parent and deduplicates shared class instances', () => {
+    class Service {}
+
+    const instance = new Service();
+    const parentInjector = Injector.create({
+      providers: [{ provide: Service, useValue: instance }],
+    });
+    const parent = { injector: parentInjector, parent: null };
+    const child = {
+      injector: Injector.create({
+        parent: parentInjector,
+        providers: [],
+      }),
+      parent,
+    };
+    const sibling = {
+      injector: Injector.create({
+        providers: [{ provide: Service, useValue: instance }],
+      }),
+      parent: null,
+    };
+    const result: Service[] = [];
+
+    funcGetFromNodeInjector(result, child as never, Service);
+    expect(result).toEqual([]);
+    funcGetFromNodeInjector(result, parent as never, Service);
+    funcGetFromNodeInjector(result, sibling as never, Service);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(instance);
+  });
+
+  it('keeps the shared optional injector probe tolerant of failures', () => {
+    const token = new InjectionToken<string>('optional');
+    const factory = jasmine.createSpy('factory').and.callFake(() => {
+      throw new Error('optional probe failure');
+    });
+    const injector = Injector.create({
+      providers: [{ provide: token, useFactory: factory }],
+    });
+
+    expect(coreInjector(token, injector)).toBeUndefined();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a failing nonlocal pipe provider optional during declaration discovery', () => {
+    const factory = jasmine
+      .createSpy('pipe factory')
+      .and.callFake(() => {
+        throw new Error(
+          'nonlocal pipe cannot resolve its dependency',
+        );
+      });
+    const node = {
+      injector: Injector.create({
+        providers: [{ provide: TargetPipe, useFactory: factory }],
+      }),
+      parent: null,
+      providerTokens: [],
+    };
+    const result: TargetPipe[] = [];
+
+    funcGetFromNodeInjector(result, node as never, TargetPipe);
+
+    expect(result).toEqual([]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the original error from a local pipe provider', () => {
+    const originalError = new Error('local pipe provider failure');
+    const factory = jasmine
+      .createSpy('pipe factory')
+      .and.callFake(() => {
+        throw originalError;
+      });
+    const node = {
+      injector: Injector.create({
+        providers: [{ provide: TargetPipe, useFactory: factory }],
+      }),
+      parent: null,
+      providerTokens: [TargetPipe],
+    };
+    const result: TargetPipe[] = [];
+    let caught = false;
+
+    try {
+      funcGetFromNodeInjector(result, node as never, TargetPipe);
+    } catch (error) {
+      caught = true;
+      expect(error).toBe(originalError);
+    }
+
+    expect(caught).toBe(true);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it('preserves a successful nonlocal pipe provider identity', () => {
+    const instance = new TargetPipe();
+    const node = {
+      injector: Injector.create({
+        providers: [{ provide: TargetPipe, useValue: instance }],
+      }),
+      parent: null,
+      providerTokens: [],
+    };
+    const result: TargetPipe[] = [];
+
+    funcGetFromNodeInjector(result, node as never, TargetPipe);
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(instance);
+    expect(result[0].transform('value')).toBe('value');
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-helper/func.get-from-node-injector.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/func.get-from-node-injector.ts
@@ -24,9 +24,17 @@ export default <T>(result: T[], node: DebugNode & Node, proto: AnyDeclaration<T>
     return;
   }
 
+  // Resolve the requested provider before optional parent probes can consume its error.
+  const notFoundValue = {};
+  // Pipes found in views can require a node-specific ChangeDetectorRef. Their
+  // unrelated module provider is only a fallback probe, as in issue-4344.
+  const value =
+    isNgDef(proto, 'p') && (!node.providerTokens || node.providerTokens.indexOf(proto) === -1)
+      ? coreInjector(proto, node.injector)
+      : node.injector.get(proto, notFoundValue);
+  const instance = value === notFoundValue ? undefined : value;
   const parentInjector = getParentWithInjector(node.parent);
   const parentInstance = parentInjector ? coreInjector(proto, parentInjector) : undefined;
-  const instance = coreInjector(proto, node.injector);
   // a way to avoid inherited injections
   if (parentInstance === instance) {
     return;

--- a/libs/ng-mocks/src/lib/mock-helper/mock-helper.get.ts
+++ b/libs/ng-mocks/src/lib/mock-helper/mock-helper.get.ts
@@ -28,15 +28,16 @@ const parseArgs = <T>(
 
 export default <T>(...args: any[]) => {
   if (args.length === 1) {
-    try {
-      return TestBed.inject ? TestBed.inject(args[0]) : /* istanbul ignore next */ (TestBed as any).get(args[0]);
-    } catch (error) {
-      // forwarding unexpected errors: https://github.com/help-me-mom/ng-mocks/issues/7041
-      if (!error || typeof error !== 'object' || (error as any).ngTokenPath === undefined) {
-        throw error;
-      }
-      throw new Error(`Cannot find an instance via ngMocks.get(${funcParseFindArgsName(args[0])})`);
+    const instance = TestBed.inject
+      ? TestBed.inject(args[0], defaultNotFoundValue)
+      : /* istanbul ignore next */ (TestBed as typeof TestBed & { get: typeof TestBed.inject }).get(
+          args[0],
+          defaultNotFoundValue,
+        );
+    if (instance !== defaultNotFoundValue) {
+      return instance;
     }
+    throw new Error(`Cannot find an instance via ngMocks.get(${funcParseFindArgsName(args[0])})`);
   }
 
   const { el, sel, notFoundValue } = parseArgs<T>(args);

--- a/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
+++ b/libs/ng-mocks/src/lib/mock-render/mock-render-factory.ts
@@ -47,20 +47,24 @@ const renderDeclaration = (fixture: any, template: any, params: any): void => {
 };
 
 const renderInjection = (fixture: any, template: any, params: any, valueKeys: string[]): void => {
-  let instance: any;
-  try {
-    instance = getInjection(template);
-  } catch (error) {
-    if (isNgDef(template, 'p')) {
-      throw new Error(
-        [
-          `Cannot render ${funcGetName(template)}.`,
-          'Did you forget to set $implicit param, or add the pipe to providers?',
-          'https://ng-mocks.sudo.eu/guides/pipe',
-        ].join(' '),
-      );
-    }
-    throw error;
+  const testBed = getTestBed();
+  const notFoundValue = {};
+  const instance = isNgDef(template, 'p')
+    ? testBed.inject
+      ? testBed.inject(template, notFoundValue)
+      : /* istanbul ignore next */ (testBed as typeof testBed & { get: typeof testBed.inject }).get(
+          template,
+          notFoundValue,
+        )
+    : getInjection(template);
+  if (instance === notFoundValue) {
+    throw new Error(
+      [
+        `Cannot render ${funcGetName(template)}.`,
+        'Did you forget to set $implicit param, or add the pipe to providers?',
+        'https://ng-mocks.sudo.eu/guides/pipe',
+      ].join(' '),
+    );
   }
   if (params) {
     ngMocks.stub(instance, params);

--- a/tests/issue-14926/no-fixture.spec.ts
+++ b/tests/issue-14926/no-fixture.spec.ts
@@ -1,0 +1,121 @@
+import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ngMocks } from 'ng-mocks';
+
+const FAILING_TOKEN = new InjectionToken<string>(
+  'failing-token-14926',
+);
+const MISSING_TOKEN = new InjectionToken<string>(
+  'missing-dependency-14926',
+);
+const UNDEFINED_TOKEN = new InjectionToken<undefined>(
+  'undefined-14926',
+);
+const NULL_TOKEN = new InjectionToken<null>('null-14926');
+const FALSE_TOKEN = new InjectionToken<boolean>('false-14926');
+const OBJECT_TOKEN = new InjectionToken<object>('object-14926');
+
+@Injectable()
+class NestedService {
+  public constructor(
+    @Inject(FAILING_TOKEN) public readonly value: string,
+  ) {}
+}
+
+@Injectable()
+class PresentService {
+  public constructor(
+    @Inject(MISSING_TOKEN) public readonly value: string,
+  ) {}
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14926
+describe('issue-14926:no-fixture', () => {
+  let originalError: Error;
+  let instance: object;
+
+  beforeEach(() => {
+    originalError = new Error('original provider failure 14926');
+    instance = {};
+
+    return TestBed.configureTestingModule({
+      providers: [
+        NestedService,
+        PresentService,
+        {
+          provide: FAILING_TOKEN,
+          useFactory: () => {
+            throw originalError;
+          },
+        },
+        { provide: UNDEFINED_TOKEN, useValue: undefined },
+        { provide: NULL_TOKEN, useValue: null },
+        { provide: FALSE_TOKEN, useValue: false },
+        { provide: OBJECT_TOKEN, useFactory: () => instance },
+      ],
+    }).compileComponents();
+  });
+
+  it('forwards a lazy factory error from plural lookup', () => {
+    let caught = false;
+    try {
+      ngMocks.findInstances(FAILING_TOKEN);
+    } catch (error) {
+      caught = true;
+      expect(error).toBe(originalError);
+    }
+
+    expect(caught).toBe(true);
+  });
+
+  it('forwards a nested service dependency error from plural lookup', () => {
+    let caught = false;
+    try {
+      ngMocks.findInstances(NestedService);
+    } catch (error) {
+      caught = true;
+      expect(error).toBe(originalError);
+    }
+
+    expect(caught).toBe(true);
+  });
+
+  for (const lookup of ['findInstance', 'get', 'findInstances']) {
+    it(`preserves a present service's missing dependency through ${lookup}`, () => {
+      let caught = false;
+      try {
+        if (lookup === 'findInstance') {
+          ngMocks.findInstance(PresentService);
+        } else if (lookup === 'get') {
+          ngMocks.get(PresentService);
+        } else {
+          ngMocks.findInstances(PresentService);
+        }
+      } catch (error) {
+        caught = true;
+        expect((error as Error).message).toContain(
+          'missing-dependency-14926',
+        );
+        expect((error as Error).message).toContain('No provider');
+      }
+
+      expect(caught).toBe(true);
+    });
+  }
+
+  it('returns an empty collection only when the requested provider is absent', () => {
+    expect(ngMocks.findInstances(MISSING_TOKEN)).toEqual([]);
+  });
+
+  it('preserves successful undefined, null, false and object provider values', () => {
+    expect(ngMocks.findInstances(UNDEFINED_TOKEN)).toEqual([
+      undefined,
+    ]);
+    expect(ngMocks.findInstances(NULL_TOKEN)).toEqual([null]);
+    expect(ngMocks.findInstances(FALSE_TOKEN)).toEqual([false]);
+    const instances = ngMocks.findInstances(OBJECT_TOKEN);
+    expect(instances.length).toBe(1);
+    expect(instances[0]).toBe(instance);
+  });
+});

--- a/tests/issue-14926/pipe.spec.ts
+++ b/tests/issue-14926/pipe.spec.ts
@@ -1,0 +1,212 @@
+import {
+  Component,
+  Inject,
+  InjectionToken,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+
+import {
+  isMockOf,
+  MockBuilder,
+  MockRender,
+  MockRenderFactory,
+  ngMocks,
+} from 'ng-mocks';
+
+const constructorError = new Error('issue-14926 pipe constructor');
+const localFactoryError = new Error('issue-14926 local pipe factory');
+let localFactoryCalls = 0;
+const MISSING_PIPE_DEPENDENCY = new InjectionToken<string>(
+  'issue-14926 missing pipe dependency',
+);
+
+@Pipe({
+  name: 'target',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class TargetPipe implements PipeTransform {
+  public transform(value: string): string {
+    return `pipe:${value}`;
+  }
+}
+
+@Component({
+  selector: 'local-pipe',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '<span></span>',
+  providers: [
+    {
+      provide: TargetPipe,
+      useFactory: () => {
+        localFactoryCalls += 1;
+        throw localFactoryError;
+      },
+    },
+  ],
+})
+class LocalPipeComponent {}
+
+@Pipe({
+  name: 'throwing',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ThrowingPipe implements PipeTransform {
+  public constructor() {
+    throw constructorError;
+  }
+
+  public transform(value: string): string {
+    return value;
+  }
+}
+
+@Pipe({
+  name: 'missingDependency',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class MissingDependencyPipe implements PipeTransform {
+  public constructor(
+    @Inject(MISSING_PIPE_DEPENDENCY) public readonly prefix: string,
+  ) {}
+
+  public transform(value: string): string {
+    return this.prefix + value;
+  }
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14926
+describe('issue-14926:pipe', () => {
+  it('preserves a provided pipe factory error', async () => {
+    const factoryError = new Error('issue-14926 pipe factory');
+    await MockBuilder(TargetPipe).provide({
+      provide: TargetPipe,
+      useFactory: () => {
+        throw factoryError;
+      },
+    });
+
+    // A provided pipe failure must not become the missing-provider hint.
+    try {
+      MockRender(TargetPipe);
+      fail('an error expected');
+    } catch (error) {
+      expect(error).toBe(factoryError);
+    }
+  });
+
+  it('preserves a provided pipe constructor error', async () => {
+    await MockBuilder(ThrowingPipe).provide(ThrowingPipe);
+
+    try {
+      MockRender(ThrowingPipe);
+      fail('an error expected');
+    } catch (error) {
+      expect(error).toBe(constructorError);
+    }
+  });
+
+  it('preserves a provided pipe missing dependency error', async () => {
+    await MockBuilder(MissingDependencyPipe)
+      .provide(MissingDependencyPipe)
+      .exclude(MISSING_PIPE_DEPENDENCY);
+
+    try {
+      MockRender(MissingDependencyPipe);
+      fail('an error expected');
+    } catch (error) {
+      expect((error as Error).message).toMatch(
+        /No provider( found)? for/,
+      );
+      expect((error as Error).message).toContain(
+        'issue-14926 missing pipe dependency',
+      );
+      expect((error as Error).message).not.toContain(
+        'Did you forget to set $implicit param',
+      );
+    }
+  });
+
+  it('preserves the pipe error through a prepared render factory', async () => {
+    const factoryError = new Error('issue-14926 render factory');
+    await MockBuilder(TargetPipe).provide({
+      provide: TargetPipe,
+      useFactory: () => {
+        throw factoryError;
+      },
+    });
+    const factory = MockRenderFactory(TargetPipe);
+    factory.configureTestBed();
+
+    try {
+      factory();
+      fail('an error expected');
+    } catch (error) {
+      expect(error).toBe(factoryError);
+    }
+  });
+
+  it('keeps the hint when a declared pipe has no provider', async () => {
+    await MockBuilder(TargetPipe);
+
+    try {
+      MockRender(TargetPipe);
+      fail('an error expected');
+    } catch (error) {
+      expect((error as Error).message).toContain(
+        `Cannot render ${TargetPipe.name}.`,
+      );
+      expect((error as Error).message).toContain(
+        'Did you forget to set $implicit param, or add the pipe to providers?',
+      );
+    }
+  });
+
+  it('renders the real provided pipe instance', async () => {
+    const provided = new TargetPipe();
+    await MockBuilder(TargetPipe).provide({
+      provide: TargetPipe,
+      useValue: provided,
+    });
+
+    const fixture = MockRender(TargetPipe);
+
+    expect(fixture.point.componentInstance).toBe(provided);
+    expect(
+      isMockOf(fixture.point.componentInstance, TargetPipe),
+    ).toBe(false);
+    expect(
+      fixture.point.componentInstance.transform('value'),
+    ).toEqual('pipe:value');
+  });
+
+  for (const lookup of ['get', 'findInstance', 'findInstances']) {
+    it(`preserves a lazy local pipe factory error through ${lookup}`, async () => {
+      localFactoryCalls = 0;
+      await MockBuilder(LocalPipeComponent).keep(TargetPipe);
+      const fixture = MockRender(LocalPipeComponent);
+      expect(
+        isMockOf(fixture.point.componentInstance, LocalPipeComponent),
+      ).toBe(false);
+      expect(localFactoryCalls).toBe(0);
+      let caught = false;
+
+      // A pipe explicitly provided on this element is a strict local lookup.
+      try {
+        if (lookup === 'get') {
+          ngMocks.get(fixture.point, TargetPipe);
+        } else if (lookup === 'findInstance') {
+          ngMocks.findInstance(fixture, TargetPipe);
+        } else {
+          ngMocks.findInstances(fixture, TargetPipe);
+        }
+      } catch (error) {
+        caught = true;
+        expect(error).toBe(localFactoryError);
+      }
+
+      expect(caught).toBe(true);
+      expect(localFactoryCalls).toBe(1);
+    });
+  }
+});

--- a/tests/issue-14926/test.spec.ts
+++ b/tests/issue-14926/test.spec.ts
@@ -1,0 +1,123 @@
+import { Component, Directive, InjectionToken } from '@angular/core';
+
+import { MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+const FAILING_TOKEN = new InjectionToken<string>(
+  'local-failure-14926',
+);
+const MISSING_TOKEN = new InjectionToken<string>(
+  'local-missing-14926',
+);
+const originalError = new Error(
+  'original local provider failure 14926',
+);
+let factoryCalls = 0;
+
+class LocalService {}
+const instance = new LocalService();
+const providers = [
+  {
+    provide: FAILING_TOKEN,
+    useFactory: () => {
+      factoryCalls += 1;
+      throw originalError;
+    },
+  },
+  { provide: LocalService, useValue: instance },
+];
+
+@Component({
+  selector: 'target',
+  template: '<span></span>',
+  providers,
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class TargetComponent {}
+
+@Directive({
+  selector: '[target]',
+  providers,
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class TargetDirective {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14926
+describe('issue-14926', () => {
+  for (const template of [
+    '<target></target>',
+    '<div target><span></span></div>',
+  ]) {
+    describe(template, () => {
+      beforeEach(() => {
+        factoryCalls = 0;
+        return MockBuilder(TargetComponent).keep(TargetDirective);
+      });
+
+      for (const lookup of [
+        'findInstance',
+        'findInstance fallback',
+        'findInstances',
+        'get',
+        'get fallback',
+      ]) {
+        it(`preserves a lazy local factory error through ${lookup}`, () => {
+          const fixture = MockRender(template);
+          const element = fixture.point;
+          expect(factoryCalls).toBe(0);
+          let caught = false;
+
+          // The provider is first requested by the public lookup, not rendering.
+          try {
+            if (lookup === 'findInstance') {
+              ngMocks.findInstance(element, FAILING_TOKEN);
+            } else if (lookup === 'findInstance fallback') {
+              ngMocks.findInstance(
+                element,
+                FAILING_TOKEN,
+                'fallback',
+              );
+            } else if (lookup === 'findInstances') {
+              ngMocks.findInstances(element, FAILING_TOKEN);
+            } else if (lookup === 'get') {
+              ngMocks.get(element, FAILING_TOKEN);
+            } else {
+              ngMocks.get(element, FAILING_TOKEN, 'fallback');
+            }
+          } catch (error) {
+            caught = true;
+            expect(error).toBe(originalError);
+          }
+
+          expect(caught).toBe(true);
+          expect(factoryCalls).toBe(1);
+        });
+      }
+
+      it('preserves missing-provider fallbacks and successful lookup identity', () => {
+        const fixture = MockRender(template);
+        const element = fixture.point;
+
+        expect(
+          ngMocks.findInstance(element, MISSING_TOKEN, 'fallback'),
+        ).toBe('fallback');
+        expect(ngMocks.get(element, MISSING_TOKEN, 'fallback')).toBe(
+          'fallback',
+        );
+        expect(ngMocks.findInstances(element, MISSING_TOKEN)).toEqual(
+          [],
+        );
+        expect(ngMocks.findInstance(element, LocalService)).toBe(
+          instance,
+        );
+        expect(ngMocks.get(element, LocalService)).toBe(instance);
+        const instances = ngMocks.findInstances(
+          element,
+          LocalService,
+        );
+        expect(instances.length).toBe(1);
+        expect(instances[0]).toBe(instance);
+        expect(factoryCalls).toBe(0);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Why

A present provider's factory or dependency error can be replaced by a missing-instance message, fallback value, or empty collection. Rendering a provided pipe can similarly replace its real failure with advice to provide the pipe.

Fixes #14926. Follow-up to #7041 / #7442 and the provided-pipe behavior from #2398.

## What

Use Angular's native missing-provider fallback to distinguish absence from creation failures in lookup and pipe-rendering paths. Resolve requested node providers before optional parent probes can consume their original error, while retaining optional discovery of nonlocal pipes that require a different view context.

Add regressions for component and directive local providers, root and nested dependencies, pipe factories and constructors, explicit fallbacks, and successful lookup identity and deduplication.

## Impact

Provider failures retain their actionable diagnostics. Genuine absence keeps its existing behavior, and fixture searches continue to discover valid component-local pipes. The fix restores existing behavior without changing public APIs or documentation.
