### PR TITLE
fix(MockBuilder): preserve replacements across shared and cyclic values #14927

### DIFF
--- a/libs/ng-mocks/src/lib/mock-service/helper.replace-with-mocks.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/helper.replace-with-mocks.spec.ts
@@ -1,0 +1,344 @@
+import { InjectionToken } from '@angular/core';
+
+import {
+  NG_MOCKS_GUARDS,
+  NG_MOCKS_RESOLVERS,
+} from '../common/core.tokens';
+import ngMocksUniverse from '../common/ng-mocks-universe';
+import { MockBuilderStash } from '../mock-builder/mock-builder-stash';
+
+import helperReplaceWithMocks from './helper.replace-with-mocks';
+
+describe('helper.replace-with-mocks', () => {
+  const stash = new MockBuilderStash();
+
+  beforeEach(() => stash.backup());
+  afterEach(() => stash.restore());
+
+  it('uses one processed object for every shared reference', () => {
+    class Original {}
+    class Replacement {}
+    class Excluded {}
+
+    ngMocksUniverse.cacheDeclarations.set(Original, Replacement);
+    ngMocksUniverse.builtDeclarations.set(Excluded, null);
+    const shared = Object.freeze({
+      declaration: Original,
+      excluded: Excluded,
+    });
+    const value = Object.freeze({ first: shared, second: shared });
+
+    const actual: typeof value = helperReplaceWithMocks(value);
+
+    expect(actual).not.toBe(value);
+    expect(actual.first).not.toBe(shared);
+    expect(actual.first).toBe(actual.second);
+    expect(actual.first.declaration).toBe(Replacement);
+    expect(actual.second.declaration).toBe(Replacement);
+    expect('excluded' in actual.first).toBe(false);
+    expect('excluded' in actual.second).toBe(false);
+    expect(value.first).toBe(shared);
+    expect(value.second).toBe(shared);
+    expect(shared.declaration).toBe(Original);
+    expect(shared.excluded).toBe(Excluded);
+  });
+
+  it('uses one processed array for every shared reference', () => {
+    class Original {}
+    class Replacement {}
+    class Excluded {}
+
+    ngMocksUniverse.cacheDeclarations.set(Original, Replacement);
+    ngMocksUniverse.builtDeclarations.set(Excluded, null);
+    const shared = Object.freeze([Original, Excluded]);
+    const value = Object.freeze([shared, shared]);
+
+    const actual: typeof value = helperReplaceWithMocks(value);
+
+    expect(actual).not.toBe(value);
+    expect(actual[0]).not.toBe(shared);
+    expect(actual[0]).toBe(actual[1]);
+    expect(actual[0]).toEqual([Replacement]);
+    expect(actual[1]).toEqual([Replacement]);
+    expect(value[0]).toBe(shared);
+    expect(value[1]).toBe(shared);
+    expect(shared).toEqual([Original, Excluded]);
+  });
+
+  it('honors an explicit replacement before a cached declaration mock', () => {
+    class Original {}
+    class Replacement {}
+    class CachedMock {}
+
+    const resolutions = new Map([[Original, 'replace']]);
+    ngMocksUniverse.config.set('ngMocksDepsResolution', resolutions);
+    ngMocksUniverse.builtDeclarations.set(Original, Replacement);
+    ngMocksUniverse.cacheDeclarations.set(Original, CachedMock);
+    const shared = Object.freeze({ declaration: Original });
+    const value = Object.freeze({ first: shared, second: shared });
+
+    const actual: typeof value = helperReplaceWithMocks(value);
+
+    expect(actual.first.declaration).toBe(Replacement);
+    expect(actual.second.declaration).toBe(Replacement);
+    expect(actual.first).toBe(actual.second);
+    expect(shared.declaration).toBe(Original);
+    expect(value.first).toBe(shared);
+    expect(value.second).toBe(shared);
+    expect(resolutions.get(Original)).toBe('replace');
+    expect(ngMocksUniverse.builtDeclarations.get(Original)).toBe(
+      Replacement,
+    );
+    expect(ngMocksUniverse.cacheDeclarations.get(Original)).toBe(
+      CachedMock,
+    );
+  });
+
+  it('keeps changed self and mutual references inside the processed graph', () => {
+    class Original {}
+    class Replacement {}
+    class Excluded {}
+
+    interface Item {
+      children: Item[];
+      declaration: typeof Original;
+      excluded?: typeof Excluded;
+      self?: Item;
+    }
+
+    ngMocksUniverse.cacheDeclarations.set(Original, Replacement);
+    ngMocksUniverse.builtDeclarations.set(Excluded, null);
+    const value: Item = {
+      children: [],
+      declaration: Original,
+      excluded: Excluded,
+    };
+    const child: Item = {
+      children: [value],
+      declaration: Original,
+      excluded: Excluded,
+    };
+    value.self = value;
+    value.children.push(child, value);
+
+    const actual: Item = helperReplaceWithMocks(value);
+
+    expect(actual).not.toBe(value);
+    expect(actual.self).toBe(actual);
+    expect(actual.children).not.toBe(value.children);
+    expect(actual.children[0]).not.toBe(child);
+    expect(actual.children[0].children[0]).toBe(actual);
+    expect(actual.children[1]).toBe(actual);
+    expect(actual.declaration).toBe(Replacement);
+    expect(actual.children[0].declaration).toBe(Replacement);
+    expect('excluded' in actual).toBe(false);
+    expect('excluded' in actual.children[0]).toBe(false);
+    expect(value.self).toBe(value);
+    expect(value.children[0]).toBe(child);
+    expect(value.children[1]).toBe(value);
+    expect(child.children[0]).toBe(value);
+    expect(value.declaration).toBe(Original);
+    expect(child.declaration).toBe(Original);
+    expect(value.excluded).toBe(Excluded);
+    expect(child.excluded).toBe(Excluded);
+  });
+
+  it('preserves wholly unchanged shared and cyclic graph identities', () => {
+    class Original {}
+
+    interface Graph {
+      first: { declaration: typeof Original; values: string[] };
+      second: { declaration: typeof Original; values: string[] };
+      self?: Graph;
+    }
+
+    const values = ['unchanged'];
+    const shared = { declaration: Original, values };
+    const value: Graph = { first: shared, second: shared };
+
+    expect(helperReplaceWithMocks(value)).toBe(value);
+    value.self = value;
+    const actual: Graph = helperReplaceWithMocks(value);
+
+    expect(actual).toBe(value);
+    expect(actual.self).toBe(value);
+    expect(actual.first).toBe(shared);
+    expect(actual.second).toBe(shared);
+    expect(actual.first.values).toBe(values);
+    expect(actual.first.declaration).toBe(Original);
+  });
+
+  it('keeps shared route references on the final guard and resolver filtering result', () => {
+    class KeptGuard {}
+    class RemovedGuard {}
+    class KeptResolver {}
+    class RemovedResolver {}
+
+    interface Route {
+      canActivate: Array<typeof KeptGuard>;
+      children?: Route[];
+      resolve: {
+        kept: typeof KeptResolver;
+        removed?: typeof RemovedResolver;
+      };
+    }
+
+    ngMocksUniverse.builtDeclarations.set(NG_MOCKS_GUARDS, null);
+    ngMocksUniverse.builtDeclarations.set(NG_MOCKS_RESOLVERS, null);
+    ngMocksUniverse.builtDeclarations.set(KeptGuard, KeptGuard);
+    ngMocksUniverse.builtDeclarations.set(KeptResolver, KeptResolver);
+    const route: Route = {
+      canActivate: [KeptGuard, RemovedGuard],
+      resolve: { kept: KeptResolver, removed: RemovedResolver },
+    };
+    route.children = [route];
+    const value = [route, route];
+
+    const actual: Route[] = helperReplaceWithMocks(value);
+
+    expect(actual).not.toBe(value);
+    expect(actual[0]).not.toBe(route);
+    expect(actual[0]).toBe(actual[1]);
+    expect(actual[0].children?.[0]).toBe(actual[0]);
+    expect(actual[0].canActivate).toEqual([KeptGuard]);
+    expect(actual[1].canActivate).toEqual([KeptGuard]);
+    expect(actual[0].resolve).toEqual({ kept: KeptResolver });
+    expect(actual[1].resolve).toEqual({ kept: KeptResolver });
+    expect(route.children[0]).toBe(route);
+    expect(route.canActivate).toEqual([KeptGuard, RemovedGuard]);
+    expect(route.resolve).toEqual({
+      kept: KeptResolver,
+      removed: RemovedResolver,
+    });
+    expect(value[0]).toBe(route);
+    expect(value[1]).toBe(route);
+  });
+
+  it('preserves kept guard and resolver token identities in a shared route', () => {
+    const keptGuard = new InjectionToken<boolean>('kept-guard-14927');
+    const removedGuard = new InjectionToken<boolean>(
+      'removed-guard-14927',
+    );
+    const keptResolver = new InjectionToken<string>(
+      'kept-resolver-14927',
+    );
+    const removedResolver = new InjectionToken<string>(
+      'removed-resolver-14927',
+    );
+
+    ngMocksUniverse.builtDeclarations.set(NG_MOCKS_GUARDS, null);
+    ngMocksUniverse.builtDeclarations.set(NG_MOCKS_RESOLVERS, null);
+    ngMocksUniverse.builtDeclarations.set(keptGuard, keptGuard);
+    ngMocksUniverse.builtDeclarations.set(keptResolver, keptResolver);
+    const guards = Object.freeze([keptGuard, removedGuard]);
+    const resolvers = Object.freeze({
+      kept: keptResolver,
+      removed: removedResolver,
+    });
+    const route = Object.freeze({
+      canActivate: guards,
+      resolve: resolvers,
+    });
+    const value = Object.freeze([route, route]);
+
+    const actual: typeof value = helperReplaceWithMocks(value);
+
+    expect(actual).not.toBe(value);
+    expect(actual[0]).not.toBe(route);
+    expect(actual[0]).toBe(actual[1]);
+    expect(actual[0].canActivate.length).toBe(1);
+    expect(actual[0].canActivate[0]).toBe(keptGuard);
+    expect(actual[1].canActivate[0]).toBe(keptGuard);
+    expect(actual[0].resolve.kept).toBe(keptResolver);
+    expect(actual[1].resolve.kept).toBe(keptResolver);
+    expect('removed' in actual[0].resolve).toBe(false);
+    expect(ngMocksUniverse.touches.has(keptGuard)).toBe(true);
+    expect(ngMocksUniverse.touches.has(keptResolver)).toBe(true);
+    expect(value[0]).toBe(route);
+    expect(value[1]).toBe(route);
+    expect(route.canActivate).toBe(guards);
+    expect(route.resolve).toBe(resolvers);
+    expect(guards[0]).toBe(keptGuard);
+    expect(guards[1]).toBe(removedGuard);
+    expect(resolvers.kept).toBe(keptResolver);
+    expect(resolvers.removed).toBe(removedResolver);
+  });
+
+  it('preserves a cached declaration replacement as a terminal object', () => {
+    class Original {}
+    class NestedOriginal {}
+    class NestedReplacement {}
+    class Excluded {}
+
+    const replacement = {
+      declaration: NestedOriginal,
+      excluded: Excluded,
+    };
+    ngMocksUniverse.cacheDeclarations.set(Original, replacement);
+    ngMocksUniverse.cacheDeclarations.set(
+      NestedOriginal,
+      NestedReplacement,
+    );
+    ngMocksUniverse.builtDeclarations.set(Excluded, null);
+    const value = { first: Original, second: Original };
+
+    const actual: {
+      first: typeof replacement;
+      second: typeof replacement;
+    } = helperReplaceWithMocks(value);
+
+    expect(actual.first).toBe(replacement);
+    expect(actual.second).toBe(replacement);
+    expect(actual.first.declaration).toBe(NestedOriginal);
+    expect(actual.first.excluded).toBe(Excluded);
+    expect(replacement).toEqual({
+      declaration: NestedOriginal,
+      excluded: Excluded,
+    });
+    expect(value.first).toBe(Original);
+    expect(value.second).toBe(Original);
+  });
+
+  it('filters route sections without filtering their aliases in ordinary configuration data', () => {
+    class KeptGuard {}
+    class OtherGuard {}
+    class KeptResolver {}
+    class OtherResolver {}
+
+    ngMocksUniverse.builtDeclarations.set(NG_MOCKS_GUARDS, null);
+    ngMocksUniverse.builtDeclarations.set(NG_MOCKS_RESOLVERS, null);
+    ngMocksUniverse.builtDeclarations.set(KeptGuard, KeptGuard);
+    ngMocksUniverse.builtDeclarations.set(KeptResolver, KeptResolver);
+    const guards = [KeptGuard, OtherGuard];
+    const resolvers: {
+      kept: typeof KeptResolver;
+      other?: typeof OtherResolver;
+    } = {
+      kept: KeptResolver,
+      other: OtherResolver,
+    };
+    const route = { canActivate: guards, resolve: resolvers };
+
+    for (const value of [
+      { route, guardData: guards, resolverData: resolvers },
+      { guardData: guards, resolverData: resolvers, route },
+    ]) {
+      const actual: typeof value = helperReplaceWithMocks(value);
+
+      expect(actual.route).not.toBe(route);
+      expect(actual.route.canActivate).not.toBe(guards);
+      expect(actual.route.canActivate).toEqual([KeptGuard]);
+      expect(actual.route.resolve).not.toBe(resolvers);
+      expect(actual.route.resolve).toEqual({ kept: KeptResolver });
+      expect(actual.guardData).toBe(guards);
+      expect(actual.resolverData).toBe(resolvers);
+      expect(actual.guardData).toEqual([KeptGuard, OtherGuard]);
+      expect(actual.resolverData).toEqual({
+        kept: KeptResolver,
+        other: OtherResolver,
+      });
+      expect(route.canActivate).toBe(guards);
+      expect(route.resolve).toBe(resolvers);
+    }
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-service/helper.replace-with-mocks.ts
+++ b/libs/ng-mocks/src/lib/mock-service/helper.replace-with-mocks.ts
@@ -2,6 +2,13 @@ import { NG_MOCKS_GUARDS, NG_MOCKS_RESOLVERS } from '../common/core.tokens';
 import { isNgDef } from '../common/func.is-ng-def';
 import ngMocksUniverse from '../common/ng-mocks-universe';
 
+interface CacheEntry {
+  containers: object[];
+  mock: object;
+  parents: Set<CacheEntry>;
+  updated: boolean;
+}
+
 const handleSection = (section: any[]) => {
   const guards: any[] = [];
 
@@ -19,10 +26,11 @@ const handleSection = (section: any[]) => {
   return guards;
 };
 
-const handleArray = (cache: Map<any, any>, value: any[], callback: any): [boolean, any[]] => {
+const handleArray = (cache: Map<unknown, CacheEntry>, value: any[], callback: any): any[] => {
   const mock: Array<any> = [];
+  const entry: CacheEntry = { containers: [mock], mock, parents: new Set(), updated: false };
   let updated = false;
-  cache.set(value, mock);
+  cache.set(value, entry);
 
   for (const valueItem of value) {
     if (ngMocksUniverse.isExcludedDef(valueItem)) {
@@ -30,10 +38,16 @@ const handleArray = (cache: Map<any, any>, value: any[], callback: any): [boolea
       continue;
     }
     mock.push(callback(valueItem, cache));
-    updated = updated || mock[mock.length - 1] !== valueItem;
+    const child = cache.get(valueItem);
+    if (child) {
+      child.parents.add(entry);
+    } else {
+      updated = updated || mock[mock.length - 1] !== valueItem;
+    }
   }
 
-  return [updated, mock];
+  entry.updated = updated;
+  return mock;
 };
 
 const handleItemKeys = ['canActivate', 'canActivateChild', 'canDeactivate', 'canMatch', 'canLoad'];
@@ -41,13 +55,14 @@ const handleItemGetGuards = (mock: any, section: string) =>
   Array.isArray(mock[section]) ? handleSection(mock[section]) : mock[section];
 
 const handleItem = (
-  cache: Map<any, any>,
+  cache: Map<unknown, CacheEntry>,
   value: Record<keyof any, any>,
   callback: any,
-): [boolean, Record<keyof any, any>] => {
-  let mock: Record<keyof any, any> = {};
+): Record<keyof any, any> => {
+  const mock: Record<keyof any, any> = {};
+  const entry: CacheEntry = { containers: [mock], mock, parents: new Set(), updated: false };
   let updated = false;
-  cache.set(value, mock);
+  cache.set(value, entry);
 
   for (const key of Object.keys(value)) {
     if (ngMocksUniverse.isExcludedDef(value[key])) {
@@ -55,7 +70,12 @@ const handleItem = (
       continue;
     }
     mock[key] = callback(value[key], cache);
-    updated = updated || mock[key] !== value[key];
+    const child = cache.get(value[key]);
+    if (child) {
+      child.parents.add(entry);
+    } else {
+      updated = updated || mock[key] !== value[key];
+    }
   }
 
   // Removal of guards.
@@ -63,7 +83,8 @@ const handleItem = (
     const guards: any[] = handleItemGetGuards(mock, section);
     if (guards && mock[section].length !== guards.length) {
       updated = updated || true;
-      mock = { ...mock, [section]: guards };
+      mock[section] = guards;
+      entry.containers.push(guards);
     }
   }
 
@@ -84,48 +105,77 @@ const handleItem = (
     }
     if (resolveUpdated) {
       updated = updated || true;
-      mock = { ...mock, resolve };
+      mock.resolve = resolve;
+      entry.containers.push(resolve);
     }
   }
 
-  return [updated, mock];
+  entry.updated = updated;
+  return mock;
 };
 
-const replaceWithMocks = (value: any, cache: Map<any, any>): any => {
+const replaceWithMocks = (value: any, cache: Map<unknown, CacheEntry>): any => {
+  if (ngMocksUniverse.getResolution(value) === 'replace') {
+    return ngMocksUniverse.getBuildDeclaration(value);
+  }
   if (ngMocksUniverse.cacheDeclarations.has(value)) {
     return ngMocksUniverse.cacheDeclarations.get(value);
   }
-  if (typeof value !== 'object') {
+  if (typeof value !== 'object' || !value || isNgDef(value, 't')) {
     return value;
   }
-  if (cache.has(value)) {
-    return value;
+  const cached = cache.get(value);
+  if (cached) {
+    return cached.mock;
   }
-
-  let mock: any;
-  let updated = false;
 
   if (Array.isArray(value)) {
-    [updated, mock] = handleArray(cache, value, replaceWithMocks);
-  } else if (value) {
-    [updated, mock] = handleItem(cache, value, replaceWithMocks);
+    return handleArray(cache, value, replaceWithMocks);
   }
 
-  if (updated) {
-    Object.setPrototypeOf(mock, Object.getPrototypeOf(value));
-
-    return mock;
-  }
-
-  return value;
+  return handleItem(cache, value, replaceWithMocks);
 };
 
 const replaceWithMocksWrapper = (value: any) => {
-  const cache = new Map();
+  const cache = new Map<unknown, CacheEntry>();
   const result = replaceWithMocks(value, cache);
+  const updated: CacheEntry[] = [];
+  for (const entry of cache.values()) {
+    if (entry.updated) {
+      updated.push(entry);
+    }
+  }
+
+  // A provisional clone is not a change: unchanged cycles must retain their original identities.
+  for (let index = 0; index < updated.length; index += 1) {
+    for (const parent of updated[index].parents) {
+      if (!parent.updated) {
+        parent.updated = true;
+        updated.push(parent);
+      }
+    }
+  }
+
+  const replacements = new Map<unknown, unknown>();
+  for (const [original, entry] of cache) {
+    replacements.set(entry.mock, entry.updated ? entry.mock : original);
+    if (entry.updated) {
+      Object.setPrototypeOf(entry.mock, Object.getPrototypeOf(original));
+    }
+  }
+  for (const entry of updated) {
+    for (const container of entry.containers) {
+      const properties = container as Record<string, unknown>;
+      for (const key of Object.keys(properties)) {
+        if (replacements.has(properties[key])) {
+          properties[key] = replacements.get(properties[key]);
+        }
+      }
+    }
+  }
   cache.clear();
 
-  return result;
+  return replacements.has(result) ? replacements.get(result) : result;
 };
 
 export default (() => replaceWithMocksWrapper)();

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -141,6 +141,7 @@ file|tests/mock-render-metadata/input-transforms.spec.ts|versions=16+
 file|tests/issue-14918/test.spec.ts|versions=16+
 file|tests/issue-14920/test.spec.ts|features=signalQueries,hostDirectives
 file|tests/issue-14922/test.spec.ts|features=standalone
+file|tests/issue-14927/cycles.spec.ts|versions=13+
 file|tests/mock-render-metadata/output-model.spec.ts|features=signalInputs,outputFn
 file|tests/mock-render-metadata/output-observable.spec.ts|features=outputFn
 file|tests/mock-render-metadata/query-signals.spec.ts|features=signalQueries

--- a/tests/issue-14927/cycles.spec.ts
+++ b/tests/issue-14927/cycles.spec.ts
@@ -1,0 +1,122 @@
+import { Directive, InjectionToken, NgModule } from '@angular/core';
+
+import { MockBuilder, ngMocks } from 'ng-mocks';
+
+@Directive({
+  selector: '[excluded]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ExcludedDeclaration {}
+
+interface CyclicNode {
+  label: string;
+  excluded?: typeof ExcludedDeclaration;
+  next?: CyclicNode;
+  alias?: CyclicNode;
+}
+
+const self: CyclicNode = {
+  label: 'self',
+  excluded: ExcludedDeclaration,
+};
+self.next = self;
+self.alias = self;
+
+const left: CyclicNode = { label: 'left' };
+const right: CyclicNode = {
+  label: 'right',
+  excluded: ExcludedDeclaration,
+};
+left.next = right;
+left.alias = right;
+right.next = left;
+right.alias = left;
+
+const original = { self, left };
+const CONFIG = new InjectionToken<typeof original>(
+  'issue-14927-cycles',
+);
+
+@NgModule({
+  declarations: [ExcludedDeclaration],
+  providers: [{ provide: CONFIG, useValue: original }],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14927
+describe('issue-14927:cycles', () => {
+  it('keeps changed self-references inside the transformed graph', async () => {
+    await MockBuilder()
+      .mock(TargetModule)
+      .keep(CONFIG)
+      .exclude(ExcludedDeclaration);
+
+    const config = ngMocks.get(CONFIG);
+
+    // Returning the original node on a cache hit restores the excluded reference.
+    expect(config).not.toBe(original);
+    expect(config.self).not.toBe(self);
+    expect(config.self.label).toEqual('self');
+    expect(config.self.excluded).toBeUndefined();
+    expect(config.self.next).toBe(config.self);
+    expect(config.self.alias).toBe(config.self);
+    expect(config.self.next!.excluded).toBeUndefined();
+    expect(config.self.alias!.excluded).toBeUndefined();
+
+    expect(original.self).toBe(self);
+    expect(self.excluded).toBe(ExcludedDeclaration);
+    expect(self.next).toBe(self);
+    expect(self.alias).toBe(self);
+  });
+
+  it('keeps changed mutual references and aliases inside the transformed graph', async () => {
+    await MockBuilder()
+      .mock(TargetModule)
+      .keep(CONFIG)
+      .exclude(ExcludedDeclaration);
+
+    const config = ngMocks.get(CONFIG);
+    const processedLeft = config.left;
+    const processedRight = processedLeft.next!;
+
+    expect(config).not.toBe(original);
+    expect(processedLeft).not.toBe(left);
+    expect(processedRight).not.toBe(right);
+    expect(processedLeft.label).toEqual('left');
+    expect(processedRight.label).toEqual('right');
+    expect(processedLeft.alias).toBe(processedRight);
+    expect(processedRight.next).toBe(processedLeft);
+    expect(processedRight.alias).toBe(processedLeft);
+    expect(processedRight.excluded).toBeUndefined();
+    expect(processedLeft.alias!.excluded).toBeUndefined();
+    expect(processedRight.next!.next).toBe(processedRight);
+
+    expect(original.left).toBe(left);
+    expect(left.next).toBe(right);
+    expect(left.alias).toBe(right);
+    expect(right.next).toBe(left);
+    expect(right.alias).toBe(left);
+    expect(right.excluded).toBe(ExcludedDeclaration);
+  });
+
+  it('preserves original identity when the cyclic graph is unchanged', async () => {
+    await MockBuilder()
+      .mock(TargetModule)
+      .keep(CONFIG)
+      .keep(ExcludedDeclaration);
+
+    const config = ngMocks.get(CONFIG);
+
+    expect(config).toBe(original);
+    expect(config.self).toBe(self);
+    expect(config.self.next).toBe(self);
+    expect(config.self.alias).toBe(self);
+    expect(config.self.excluded).toBe(ExcludedDeclaration);
+    expect(config.left).toBe(left);
+    expect(config.left.next).toBe(right);
+    expect(config.left.alias).toBe(right);
+    expect(config.left.next!.next).toBe(left);
+    expect(config.left.next!.alias).toBe(left);
+    expect(config.left.next!.excluded).toBe(ExcludedDeclaration);
+  });
+});

--- a/tests/issue-14927/test.spec.ts
+++ b/tests/issue-14927/test.spec.ts
@@ -1,0 +1,143 @@
+import { Directive, InjectionToken, NgModule } from '@angular/core';
+
+import { getMockedNgDefOf, MockBuilder, ngMocks } from 'ng-mocks';
+
+@Directive({
+  selector: '[target]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class TargetDirective {}
+
+@Directive({
+  selector: '[replacement]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class ReplacementDirective {}
+
+// View Engine copies literal provider graphs; class instances retain identity.
+class Value<T> {
+  public constructor(public readonly value: T) {}
+}
+
+const shared = { declaration: TargetDirective, label: 'shared' };
+const untouched = { label: 'untouched' };
+const configuration = {
+  first: shared,
+  second: shared,
+  list: [shared, shared],
+  untouched,
+};
+const sharedArray: Array<typeof TargetDirective | string> = [
+  TargetDirective,
+  'preserved',
+];
+const arrays = [sharedArray, sharedArray];
+const CONFIG = new InjectionToken<Value<typeof configuration>>(
+  'CONFIG',
+);
+const ARRAYS = new InjectionToken<Value<typeof arrays>>('ARRAYS');
+
+@NgModule({
+  declarations: [TargetDirective],
+  providers: [
+    { provide: CONFIG, useValue: new Value(configuration) },
+    { provide: ARRAYS, useValue: new Value(arrays) },
+  ],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14927
+describe('issue-14927', () => {
+  it('excludes declarations through every shared object and array path', async () => {
+    await MockBuilder()
+      .mock(TargetModule)
+      .keep(CONFIG)
+      .keep(ARRAYS)
+      .exclude(TargetDirective);
+
+    const actual = ngMocks.get(CONFIG).value;
+    const actualArrays = ngMocks.get(ARRAYS).value;
+
+    // A cache hit must retain the transformation made on the first path.
+    expect(actual.first.declaration).toBeUndefined();
+    expect(actual.second.declaration).toBeUndefined();
+    expect(actual.first).toBe(actual.second);
+    expect(actual.list[0]).toBe(actual.first);
+    expect(actual.list[1]).toBe(actual.first);
+    expect(actual.first.label).toBe('shared');
+    expect(actual.untouched).toBe(untouched);
+    expect(actualArrays[0]).toEqual(['preserved']);
+    expect(actualArrays[1]).toEqual(['preserved']);
+    expect(actualArrays[0]).toBe(actualArrays[1]);
+    expect(configuration.first).toBe(shared);
+    expect(configuration.second).toBe(shared);
+    expect(configuration.list).toEqual([shared, shared]);
+    expect(shared.declaration).toBe(TargetDirective);
+    expect(arrays[0]).toBe(sharedArray);
+    expect(arrays[1]).toBe(sharedArray);
+    expect(sharedArray).toEqual([TargetDirective, 'preserved']);
+  });
+
+  it('replaces declarations consistently through shared nodes', async () => {
+    await MockBuilder()
+      .mock(TargetModule)
+      .keep(CONFIG)
+      .keep(ARRAYS)
+      .replace(TargetDirective, ReplacementDirective);
+
+    const actual = ngMocks.get(CONFIG).value;
+    const actualArrays = ngMocks.get(ARRAYS).value;
+
+    expect(actual.first.declaration).toBe(ReplacementDirective);
+    expect(actual.second.declaration).toBe(ReplacementDirective);
+    expect(actual.first).toBe(actual.second);
+    expect(actual.list[0]).toBe(actual.first);
+    expect(actual.list[1]).toBe(actual.first);
+    expect(actual.untouched).toBe(untouched);
+    expect(actualArrays[0]).toEqual([
+      ReplacementDirective,
+      'preserved',
+    ]);
+    expect(actualArrays[1]).toEqual([
+      ReplacementDirective,
+      'preserved',
+    ]);
+    expect(actualArrays[0]).toBe(actualArrays[1]);
+    expect(shared.declaration).toBe(TargetDirective);
+    expect(sharedArray).toEqual([TargetDirective, 'preserved']);
+  });
+
+  it('uses the same mock declaration through shared nodes', async () => {
+    await MockBuilder().mock(TargetModule).keep(CONFIG).keep(ARRAYS);
+
+    const actual = ngMocks.get(CONFIG).value;
+    const actualArrays = ngMocks.get(ARRAYS).value;
+
+    expect(actual.first.declaration).toBe(
+      getMockedNgDefOf(TargetDirective, 'd'),
+    );
+    expect(actual.first.declaration).not.toBe(TargetDirective);
+    expect(actual.second.declaration).toBe(actual.first.declaration);
+    expect(actual.first).toBe(actual.second);
+    expect(actual.list[0]).toBe(actual.first);
+    expect(actual.list[1]).toBe(actual.first);
+    expect(actualArrays[0][0]).toBe(actual.first.declaration);
+    expect(actualArrays[1][0]).toBe(actual.first.declaration);
+    expect(actualArrays[0]).toBe(actualArrays[1]);
+    expect(shared.declaration).toBe(TargetDirective);
+    expect(sharedArray).toEqual([TargetDirective, 'preserved']);
+  });
+
+  it('preserves the original shared graph when no declarations change', async () => {
+    await MockBuilder()
+      .mock(TargetModule)
+      .keep(CONFIG)
+      .keep(ARRAYS)
+      .keep(TargetDirective);
+
+    expect(ngMocks.get(CONFIG).value).toBe(configuration);
+    expect(ngMocks.get(ARRAYS).value).toBe(arrays);
+    expect(configuration.first).toBe(configuration.second);
+    expect(arrays[0]).toBe(arrays[1]);
+  });
+});


### PR DESCRIPTION
## Why

The recursion fix in #5262 stopped infinite traversal, but later references to a shared or cyclic provider value could still expose the original declarations. Explicit `.replace()` choices were also missed because the walker only consulted the declaration mock cache.

## What

Keep one processed object or array for each changed value and propagate changes through its references. Resolve unchanged graph regions back to their original objects. Read explicit replacement decisions through the existing policy helpers and preserve dependency token identity during guard and resolver filtering.

Add regressions for shared objects and arrays, self and mutual references, exclusions, replacements, mock identity, unchanged values, and route filtering with shared aliases.

## Impact

Kept configuration providers consistently contain the selected declarations through every reference, while the supplied configuration remains intact. This restores expected behavior and requires no public API or documentation changes.

Fixes #14927.
