### PR TITLE
fix(MockService): cache function mocks without invoking them #14928

### DIFF
--- a/libs/ng-mocks/src/lib/mock-service/mock-service.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-service/mock-service.spec.ts
@@ -137,6 +137,115 @@ describe('MockService', () => {
     expect(mockService.and.identity).toBe('func:test');
   });
 
+  it('caches a custom mock function rather than its configured return value', () => {
+    let originalCalls = 0;
+    const original = (value: string) => {
+      originalCalls += 1;
+
+      return { value };
+    };
+    const result = { value: 'configured' };
+    const generated: jasmine.Spy[] = [];
+    const shape = { first: original, second: original };
+
+    ngMocks.autoSpy(name => {
+      const mock = jasmine.createSpy(name).and.returnValue(result);
+      generated.push(mock);
+
+      return mock;
+    });
+    try {
+      const mock = MockService<typeof shape>(shape, 'custom');
+
+      expect(generated.length).toBe(1);
+      expect(generated[0].and.identity).toBe('func:custom.first');
+      expect(generated[0]).not.toHaveBeenCalled();
+      expect(mock.first).toBe(generated[0]);
+      expect(mock.second).toBe(mock.first);
+      expect(originalCalls).toBe(0);
+
+      expect(mock.first('first')).toBe(result);
+      expect(mock.second('second')).toBe(result);
+      expect(generated[0]).toHaveBeenCalledTimes(2);
+      expect(generated[0].calls.allArgs()).toEqual([
+        ['first'],
+        ['second'],
+      ]);
+      expect(originalCalls).toBe(0);
+      expect(shape.first).toBe(original);
+      expect(shape.second).toBe(original);
+    } finally {
+      ngMocks.autoSpy('reset');
+    }
+  });
+
+  it('does not invoke a throwing custom mock while creating it', () => {
+    const originalError = new Error('configured mock failure');
+    const generated = jasmine
+      .createSpy('throwing mock')
+      .and.callFake(() => {
+        throw originalError;
+      });
+    const factory = jasmine
+      .createSpy('factory')
+      .and.returnValue(generated);
+    let originalCalls = 0;
+    const original = () => {
+      originalCalls += 1;
+    };
+
+    ngMocks.autoSpy(factory);
+    try {
+      const mock = MockService<() => void>(original, 'direct');
+
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(factory).toHaveBeenCalledWith('func:direct');
+      expect(mock).toBe(generated);
+      expect(generated).not.toHaveBeenCalled();
+      expect(originalCalls).toBe(0);
+      expect(() => mock()).toThrow(originalError);
+      expect(generated).toHaveBeenCalledTimes(1);
+      expect(originalCalls).toBe(0);
+    } finally {
+      ngMocks.autoSpy('reset');
+    }
+  });
+
+  it('keeps default functions and prototype methods independent between mocks', () => {
+    const original = () => 'real';
+    const shape = { first: original, second: original };
+
+    ngMocks.autoSpy('default');
+    try {
+      const first = MockService<typeof original>(original);
+      const second = MockService<typeof original>(original);
+      const mock = MockService<typeof shape>(shape);
+      const firstInstance = MockService(DeepParentClass);
+      const secondInstance = MockService(DeepParentClass);
+
+      expect(first).not.toBe(original);
+      expect(first).not.toBe(second);
+      expect(jasmine.isSpy(first)).toBe(false);
+      expect(first()).toBeUndefined();
+      expect(second()).toBeUndefined();
+      expect(mock.first).toBe(mock.second);
+      expect(mock.first()).toBeUndefined();
+      expect(firstInstance.deepParentMethod).not.toBe(
+        DeepParentClass.prototype.deepParentMethod,
+      );
+      expect(firstInstance.deepParentMethod).not.toBe(
+        secondInstance.deepParentMethod,
+      );
+      expect(jasmine.isSpy(firstInstance.deepParentMethod)).toBe(
+        false,
+      );
+      expect(firstInstance.deepParentMethod()).toBeUndefined();
+      expect(secondInstance.deepParentMethod()).toBeUndefined();
+    } finally {
+      ngMocks.autoSpy('reset');
+    }
+  });
+
   it('should convert normal class to an empty object', () => {
     const mockService = MockService(
       class Test {

--- a/libs/ng-mocks/src/lib/mock-service/mock-service.ts
+++ b/libs/ng-mocks/src/lib/mock-service/mock-service.ts
@@ -23,7 +23,7 @@ const mockVariableMap: Array<[(def: any) => boolean, MockServiceHandler]> = [
     checkIsFunc,
     (cache, service, prefix) => {
       const value = helperMockService.mockFunction(`func:${prefix || funcGetName(service)}`);
-      cache.set(service, value());
+      cache.set(service, value);
 
       return value;
     },

--- a/tests/issue-14928/test.spec.ts
+++ b/tests/issue-14928/test.spec.ts
@@ -1,0 +1,166 @@
+import { Injectable, InjectionToken, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  MockBuilder,
+  MockProvider,
+  MockService,
+  ngMocks,
+} from 'ng-mocks';
+
+@Injectable()
+class TargetService {
+  public readonly info = {
+    request: (value: string) => value,
+    alias: (value: string) => value,
+  };
+
+  public constructor() {
+    throw new Error('issue-14928 real constructor');
+  }
+}
+
+let providerCalls = 0;
+const providerOriginal = (value: string): string => {
+  providerCalls += 1;
+
+  return value;
+};
+const TOKEN = new InjectionToken<{
+  first: typeof providerOriginal;
+  second: typeof providerOriginal;
+}>('issue-14928-provider');
+
+@NgModule({
+  providers: [
+    {
+      provide: TOKEN,
+      useValue: { first: providerOriginal, second: providerOriginal },
+    },
+  ],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14928
+describe('issue-14928', () => {
+  beforeEach(() =>
+    ngMocks.autoSpy(
+      typeof jest === 'undefined'
+        ? 'jasmine'
+        : typeof (window as Window & { vi?: object }).vi ===
+            'undefined'
+          ? 'jest'
+          : 'vitest',
+    ),
+  );
+
+  afterEach(() => ngMocks.autoSpy('reset'));
+
+  it('creates a direct function mock without invoking it', () => {
+    let originalCalls = 0;
+    const original = (value: string, count: number): string => {
+      originalCalls += 1;
+
+      return value + count;
+    };
+
+    const mock = MockService<typeof original>(original);
+
+    // Caching the result of calling the mock records an unwanted initial call.
+    expect(mock).not.toHaveBeenCalled();
+    expect(originalCalls).toBe(0);
+    expect(mock('explicit', 1)).toBeUndefined();
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('explicit', 1);
+    expect(originalCalls).toBe(0);
+  });
+
+  it('shares own function aliases while isolating distinct functions and separate mocks', () => {
+    let originalCalls = 0;
+    const shared = (value: string): string => {
+      originalCalls += 1;
+
+      return value;
+    };
+    const distinct = (value: string): string => {
+      originalCalls += 1;
+
+      return value;
+    };
+    const shape = { first: shared, second: shared, other: distinct };
+
+    const mock = MockService<typeof shape>(shape);
+    const independent = MockService<typeof shape>(shape);
+
+    expect(mock.first).toBe(mock.second);
+    expect(mock.first).not.toBe(mock.other);
+    expect(independent.first).toBe(independent.second);
+    expect(independent.first).not.toBe(mock.first);
+    expect(independent.other).not.toBe(mock.other);
+    expect(mock.first).not.toHaveBeenCalled();
+    expect(mock.other).not.toHaveBeenCalled();
+    expect(independent.first).not.toHaveBeenCalled();
+    expect(independent.other).not.toHaveBeenCalled();
+    expect(originalCalls).toBe(0);
+
+    expect(mock.first('shared')).toBeUndefined();
+    expect(mock.second).toHaveBeenCalledTimes(1);
+    expect(mock.second).toHaveBeenCalledWith('shared');
+    expect(mock.other).not.toHaveBeenCalled();
+    expect(independent.first).not.toHaveBeenCalled();
+
+    expect(mock.other('distinct')).toBeUndefined();
+    expect(mock.other).toHaveBeenCalledTimes(1);
+    expect(mock.other).toHaveBeenCalledWith('distinct');
+    expect(independent.first('independent')).toBeUndefined();
+    expect(independent.second).toHaveBeenCalledTimes(1);
+    expect(independent.second).toHaveBeenCalledWith('independent');
+    expect(independent.other).not.toHaveBeenCalled();
+    expect(mock.first).toHaveBeenCalledTimes(1);
+    expect(originalCalls).toBe(0);
+    expect(shape.first).toBe(shared);
+    expect(shape.second).toBe(shared);
+    expect(shape.other).toBe(distinct);
+  });
+
+  it('preserves pristine shared spies in an explicit provider override', () => {
+    let originalCalls = 0;
+    const original = (value: string): string => {
+      originalCalls += 1;
+
+      return value;
+    };
+    const shape = { request: original, alias: original };
+    const info = MockService<typeof shape>(shape);
+    expect(info.request).not.toHaveBeenCalled();
+
+    TestBed.configureTestingModule({
+      providers: [MockProvider(TargetService, { info })],
+    });
+    const service = ngMocks.get(TargetService);
+
+    expect(service.info).toBe(info);
+    expect(service.info.request).toBe(service.info.alias);
+    expect(service.info.request).not.toHaveBeenCalled();
+    expect(originalCalls).toBe(0);
+    expect(service.info.request('provided')).toBeUndefined();
+    expect(service.info.alias).toHaveBeenCalledTimes(1);
+    expect(service.info.alias).toHaveBeenCalledWith('provided');
+    expect(originalCalls).toBe(0);
+  });
+
+  it('creates pristine shared spies when mocking a module useValue provider', async () => {
+    providerCalls = 0;
+    await MockBuilder(null, TargetModule);
+
+    const value = ngMocks.get(TOKEN);
+
+    expect(value.first).toBe(value.second);
+    expect(value.first).not.toHaveBeenCalled();
+    expect(providerCalls).toBe(0);
+    expect(value.second('module')).toBeUndefined();
+    expect(value.first).toHaveBeenCalledTimes(1);
+    expect(value.first).toHaveBeenCalledWith('module');
+    expect(providerCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Creating a function mock invokes it while populating the cache. This adds a call to a new spy and caches its return value, so repeated references receive separate mocks or even a configured return value instead of a function. A custom mock that throws also makes construction fail.

The same path affects function fields in explicit object shapes and mocked object providers, following the recursive-cache change in #5262.

## What

Cache the generated function itself. Add regressions for pristine call history, shared function references, independent mocks, provider overrides and automatically mocked `useValue` providers, including default and custom spy factories.

## Impact

Function mocks are called only by their consumers, and repeated references within one `MockService` operation share the same mock. Separate operations and prototype methods remain independent. Existing arguments, naming, constructor suppression, and documented behavior are preserved; no public API or documentation changes are needed.

Fixes #14928
