### PR TITLE
fix(MockBuilder): retain providers across repeated module imports #14929

### DIFF
--- a/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.spec.ts
@@ -190,6 +190,102 @@ describe('MockBuilderPromise', () => {
     );
   });
 
+  const modes: Array<'keep' | 'mock'> = ['keep', 'mock'];
+  for (const mode of modes) {
+    for (const providerFirst of [true, false]) {
+      it(`preserves ${mode} providers with the bare module ${providerFirst ? 'last' : 'first'}`, async () => {
+        const value = { label: 'configured' };
+        const token = new InjectionToken<typeof value>('configured');
+        const providers = [{ provide: token, useValue: value }];
+        const moduleWithProviders = {
+          ngModule: TargetModule,
+          providers,
+        };
+        const builder = MockBuilder().keep(token);
+
+        if (providerFirst) {
+          builder[mode](moduleWithProviders)[mode](TargetModule);
+        } else {
+          builder[mode](TargetModule)[mode](moduleWithProviders);
+        }
+        await builder;
+
+        expect(mockHelperGet(token)).toBe(value);
+        expect(moduleWithProviders.providers).toBe(providers);
+        expect(providers).toEqual([
+          { provide: token, useValue: value },
+        ]);
+      });
+    }
+
+    it(`discards ${mode} providers when changing the module mode`, async () => {
+      const token = new InjectionToken<string>('discarded');
+      const nextMode = mode === 'keep' ? 'mock' : 'keep';
+      await MockBuilder()
+        [mode]({
+          ngModule: TargetModule,
+          providers: [{ provide: token, useValue: 'discarded' }],
+        })
+        [nextMode](TargetModule)
+        .keep(token);
+
+      expect(() => mockHelperGet(token)).toThrowError(
+        /Cannot find an instance/,
+      );
+    });
+  }
+
+  it('accumulates kept multi values across repeated mock module entries', async () => {
+    const token = new InjectionToken<number[]>('multi');
+    const first = [{ provide: token, useValue: 1, multi: true }];
+    const second = [{ provide: token, useValue: 2, multi: true }];
+    await MockBuilder()
+      .mock({ ngModule: TargetModule, providers: first })
+      .mock(TargetModule)
+      .mock({ ngModule: TargetModule, providers: second })
+      .keep(token);
+
+    expect(mockHelperGet(token)).toEqual([1, 2]);
+    expect(first).toEqual([
+      { provide: token, useValue: 1, multi: true },
+    ]);
+    expect(second).toEqual([
+      { provide: token, useValue: 2, multi: true },
+    ]);
+  });
+
+  it('discards prior module providers after exclusion and a later keep', async () => {
+    const token = new InjectionToken<string>('excluded');
+    await MockBuilder()
+      .keep({
+        ngModule: TargetModule,
+        providers: [{ provide: token, useValue: 'discarded' }],
+      })
+      .exclude(TargetModule)
+      .keep(TargetModule)
+      .keep(token);
+
+    expect(() => mockHelperGet(token)).toThrowError(
+      /Cannot find an instance/,
+    );
+  });
+
+  it('keeps an explicit provider override above repeated module providers', async () => {
+    const value = { label: 'override' };
+    const token = new InjectionToken<typeof value>('overridden');
+    const factory = jasmine.createSpy('module provider');
+    await MockBuilder()
+      .provide({ provide: token, useValue: value })
+      .keep({
+        ngModule: TargetModule,
+        providers: [{ provide: token, useFactory: factory }],
+      })
+      .keep(TargetModule);
+
+    expect(mockHelperGet(token)).toBe(value);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
   it('throws an error on a services replacement', () => {
     expect(() =>
       MockBuilder().replace(TargetModule, TargetService),

--- a/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.ts
+++ b/libs/ng-mocks/src/lib/mock-builder/mock-builder.promise.ts
@@ -138,13 +138,13 @@ export class MockBuilderPromise implements IMockBuilder {
   public keep(input: any, config?: IMockBuilderConfig): this {
     const { def, providers } = normaliseModule(input);
 
-    const existing = this.keepDef.has(def) ? this.defProviders.get(def) : [];
+    const existing = this.keepDef.has(def) ? this.defProviders.get(def) : undefined;
     this.wipe(def);
     this.keepDef.add(def);
 
     // a magic to support modules with providers.
-    if (providers) {
-      this.defProviders.set(def, [...(existing || /* istanbul ignore next */ []), ...providers]);
+    if (providers || existing) {
+      this.defProviders.set(def, [...(existing ?? []), ...(providers ?? [])]);
     }
 
     this.setConfigDef(def, config);
@@ -165,13 +165,13 @@ export class MockBuilderPromise implements IMockBuilder {
       );
     }
 
-    const existing = this.mockDef.has(def) ? this.defProviders.get(def) : [];
+    const existing = this.mockDef.has(def) ? this.defProviders.get(def) : undefined;
     this.wipe(def);
     this.mockDef.add(def);
 
     // a magic to support modules with providers.
-    if (providers) {
-      this.defProviders.set(def, [...(existing || /* istanbul ignore next */ []), ...providers]);
+    if (providers || existing) {
+      this.defProviders.set(def, [...(existing ?? []), ...(providers ?? [])]);
     }
 
     this.setDefValue(def, mock);

--- a/tests/issue-14929/test.spec.ts
+++ b/tests/issue-14929/test.spec.ts
@@ -1,0 +1,196 @@
+import {
+  Component,
+  Inject,
+  Injectable,
+  InjectionToken,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+const CONFIG = new InjectionToken<string>('issue-14929-config');
+const MULTI = new InjectionToken<string[]>('issue-14929-multi');
+let factoryCalls = 0;
+let multiFactoryCalls: string[] = [];
+
+@Injectable()
+class ConfiguredService {
+  public readonly value = 'configured service';
+}
+
+const configuredService = new ConfiguredService();
+
+@Component({
+  selector: 'target-14929',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ label }} {{ service.value }}',
+})
+class TargetComponent {
+  public constructor(
+    @Inject(CONFIG) public readonly label: string,
+    public readonly service: ConfiguredService,
+  ) {}
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+  exports: [TargetComponent],
+})
+class TargetModule {
+  public static forRoot(label = 'for-root-14929') {
+    return {
+      ngModule: TargetModule,
+      providers: [
+        { provide: CONFIG, useValue: label },
+        {
+          provide: ConfiguredService,
+          useFactory: () => {
+            factoryCalls += 1;
+
+            return configuredService;
+          },
+        },
+        {
+          provide: MULTI,
+          multi: true,
+          useFactory: () => {
+            multiFactoryCalls.push(label);
+
+            return label;
+          },
+        },
+      ],
+    };
+  }
+}
+
+@Injectable()
+class UnrelatedService {
+  public read(): string {
+    return 'real unrelated service';
+  }
+}
+
+@NgModule({
+  providers: [UnrelatedService],
+})
+class UnrelatedModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14929
+describe('issue-14929', () => {
+  for (const mixed of [false, true]) {
+    describe(
+      mixed ? 'mixed real and mock imports' : 'real Angular imports',
+      () => {
+        beforeEach(() => {
+          factoryCalls = 0;
+          multiFactoryCalls = [];
+        });
+
+        for (const reversed of [false, true]) {
+          it(`preserves forRoot providers with the bare import ${reversed ? 'first' : 'last'}`, async () => {
+            const targetImports = reversed
+              ? [TargetModule, TargetModule.forRoot()]
+              : [TargetModule.forRoot(), TargetModule];
+            await TestBed.configureTestingModule({
+              imports: [
+                ...targetImports,
+                ...(mixed ? [MockModule(UnrelatedModule)] : []),
+              ],
+            }).compileComponents();
+
+            expect(factoryCalls).toBe(0);
+            expect(multiFactoryCalls).toEqual([]);
+            const fixture = TestBed.createComponent(TargetComponent);
+            fixture.detectChanges();
+
+            // An unrelated mock must not discard earlier real forRoot providers.
+            expect(
+              isMockOf(fixture.componentInstance, TargetComponent),
+            ).toBe(false);
+            expect(fixture.componentInstance.label).toBe(
+              'for-root-14929',
+            );
+            expect(fixture.componentInstance.service).toBe(
+              configuredService,
+            );
+            expect(
+              isMockOf(
+                fixture.componentInstance.service,
+                ConfiguredService,
+              ),
+            ).toBe(false);
+            expect(ngMocks.formatText(fixture)).toBe(
+              'for-root-14929 configured service',
+            );
+            expect(fixture.debugElement.injector.get(CONFIG)).toBe(
+              'for-root-14929',
+            );
+            expect(
+              fixture.debugElement.injector.get(ConfiguredService),
+            ).toBe(configuredService);
+            expect(factoryCalls).toBe(1);
+            expect(multiFactoryCalls).toEqual([]);
+
+            if (mixed) {
+              const unrelated =
+                fixture.debugElement.injector.get(UnrelatedService);
+              expect(isMockOf(unrelated, UnrelatedService)).toBe(
+                true,
+              );
+              expect(unrelated.read()).toBeUndefined();
+            }
+          });
+        }
+
+        it('preserves ordered multi providers across an intervening bare import', async () => {
+          await TestBed.configureTestingModule({
+            imports: [
+              TargetModule.forRoot('first'),
+              TargetModule,
+              TargetModule.forRoot('second'),
+              ...(mixed ? [MockModule(UnrelatedModule)] : []),
+            ],
+          }).compileComponents();
+
+          expect(factoryCalls).toBe(0);
+          expect(multiFactoryCalls).toEqual([]);
+          const fixture = TestBed.createComponent(TargetComponent);
+          fixture.detectChanges();
+
+          expect(
+            isMockOf(fixture.componentInstance, TargetComponent),
+          ).toBe(false);
+          expect(fixture.componentInstance.label).toBe('second');
+          expect(fixture.componentInstance.service).toBe(
+            configuredService,
+          );
+          expect(ngMocks.formatText(fixture)).toBe(
+            'second configured service',
+          );
+          expect(factoryCalls).toBe(1);
+          expect(multiFactoryCalls).toEqual([]);
+          const values = fixture.debugElement.injector.get(MULTI);
+          expect(values).toEqual(['first', 'second']);
+          expect(multiFactoryCalls).toEqual(['first', 'second']);
+          expect(fixture.debugElement.injector.get(MULTI)).toBe(
+            values,
+          );
+          expect(multiFactoryCalls).toEqual(['first', 'second']);
+          expect(
+            fixture.debugElement.injector.get(ConfiguredService),
+          ).toBe(configuredService);
+          expect(factoryCalls).toBe(1);
+
+          if (mixed) {
+            const unrelated =
+              fixture.debugElement.injector.get(UnrelatedService);
+            expect(isMockOf(unrelated, UnrelatedService)).toBe(true);
+            expect(unrelated.read()).toBeUndefined();
+          }
+        });
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Why

A bare module imported after its `forRoot()` result discards that result's providers when TestBed contains a mix of real and mocked imports. Repeating `.keep()` or `.mock()` for the same module also loses those providers because the builder clears its previous list and restores it only when the latest call supplies providers.

This occurs before the root provider placement handled by #4613.

## What

Retain the previous provider list across repeated calls in the same mode, appending newly supplied providers in their existing order. Add real Angular and mixed TestBed regressions for both import orders, provider identity, lazy factory execution, and multi-provider order, together with focused builder coverage.

## Impact

Repeated imports preserve configured providers and match the corresponding real Angular behavior. Deliberate keep/mock/exclude transitions and explicit provider precedence retain their existing behavior. No public API or documentation changes are needed.

Fixes #14929
