### PR TITLE
test(jest): cover native ESM package consumers #14931

### DIFF
--- a/e2e/jest/jest.config.esm.ivy-zoned.mjs
+++ b/e2e/jest/jest.config.esm.ivy-zoned.mjs
@@ -1,0 +1,12 @@
+import presets from 'jest-preset-angular/presets/index.js';
+
+export default {
+  ...presets.createEsmPreset({ tsconfig: '<rootDir>/tsconfig.json' }),
+  workerIdleMemoryLimit: '1024MB',
+  maxWorkers: 1,
+  setupFilesAfterEnv: ['<rootDir>/src/setup-jest-esm.ts'],
+  testEnvironmentOptions: {
+    url: 'http://localhost',
+  },
+  testMatch: ['<rootDir>/src/esm/**/*.spec.ts', '<rootDir>/src/tests/issue-14931/test.spec.ts'],
+};

--- a/e2e/jest/jest.config.ts
+++ b/e2e/jest/jest.config.ts
@@ -7,6 +7,7 @@ export default {
     url: 'http://localhost',
   },
   testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  testPathIgnorePatterns: ['<rootDir>/src/esm/'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   transform: {
     '^.+\\.(ts|mjs|js|html)$': ['jest-preset-angular', { tsconfig: './tsconfig.json' }],

--- a/e2e/jest/package.json
+++ b/e2e/jest/package.json
@@ -8,8 +8,9 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "npm run test:jest",
+    "test": "npm run test:jest && npm run test:jest:esm:ivy-zoned",
     "test:jest": "jest --config jest.config.ts",
+    "test:jest:esm:ivy-zoned": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config jest.config.esm.ivy-zoned.mjs",
     "test:jest:debug": "jest -i --watch"
   },
   "dependencies": {

--- a/e2e/jest/src/esm/issue-14931/test.spec.ts
+++ b/e2e/jest/src/esm/issue-14931/test.spec.ts
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+import { MockComponent } from 'ng-mocks';
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14931
+describe('issue-14931:esm', () => {
+  it('loads the public import entry in native Jest ESM', () => {
+    expect(import.meta.jest).toBe(jest);
+    expect(typeof require).toBe('undefined');
+    expect(import.meta.resolve('ng-mocks')).toMatch(
+      /\/node_modules\/ng-mocks\/index\.mjs$/,
+    );
+    expect(typeof MockComponent).toBe('function');
+  });
+});

--- a/e2e/jest/src/setup-jest-esm.ts
+++ b/e2e/jest/src/setup-jest-esm.ts
@@ -1,0 +1,8 @@
+import { jest } from '@jest/globals';
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone/index.mjs';
+import { ngMocks } from 'ng-mocks';
+
+setupZoneTestEnv();
+
+// Native ESM exposes Jest through imports instead of a module-scoped global.
+ngMocks.autoSpy(name => jest.fn().mockName(name));

--- a/e2e/jest/src/tests/issue-14931/test.spec.ts
+++ b/e2e/jest/src/tests/issue-14931/test.spec.ts
@@ -1,0 +1,207 @@
+import {
+  Component,
+  Directive,
+  EventEmitter,
+  Input,
+  NgModule,
+  Output,
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { jest } from '@jest/globals';
+import {
+  isMockOf,
+  MockBuilder,
+  MockComponent,
+  MockRender,
+  MockService,
+  ngMocks,
+} from 'ng-mocks';
+
+const realCalls: string[] = [];
+
+@Component({
+  selector: 'issue-14931-child',
+  standalone: false,
+  template: 'real child',
+})
+class ChildComponent {
+  @Input() public value = 'real';
+  @Output() public changed = new EventEmitter<string>();
+
+  public constructor() {
+    realCalls.push('component constructor');
+  }
+
+  public run(value: string): string {
+    realCalls.push(`component method: ${value}`);
+
+    return value;
+  }
+}
+
+@Directive({
+  selector: '[issue14931]',
+  standalone: false,
+})
+class DependencyDirective {
+  @Input() public value = 'real';
+
+  public constructor() {
+    realCalls.push('directive constructor');
+  }
+
+  public run(value: string): string {
+    realCalls.push(`directive method: ${value}`);
+
+    return value;
+  }
+}
+
+@Pipe({ name: 'issue14931', standalone: false })
+class DependencyPipe implements PipeTransform {
+  public constructor() {
+    realCalls.push('pipe constructor');
+  }
+
+  public transform(value: string): string {
+    realCalls.push(`pipe transform: ${value}`);
+
+    return `real: ${value}`;
+  }
+}
+
+@Component({
+  selector: 'issue-14931-host',
+  standalone: false,
+  template: `
+    <issue-14931-child [value]="value" (changed)="value = $event">
+      <span>{{ value }}</span>
+    </issue-14931-child>
+    <span issue14931 [value]="value"></span>
+    <p>{{ value | issue14931 }}</p>
+  `,
+})
+class HostComponent {
+  public value = 'initial';
+}
+
+@NgModule({
+  declarations: [
+    HostComponent,
+    ChildComponent,
+    DependencyDirective,
+    DependencyPipe,
+  ],
+})
+class TargetModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14931
+describe('issue-14931', () => {
+  beforeEach(() => {
+    realCalls.length = 0;
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('creates a component mock with runner-native spies', async () => {
+    const mock = MockComponent(ChildComponent);
+
+    await TestBed.configureTestingModule({
+      declarations: [mock],
+    }).compileComponents();
+
+    const fixture = MockRender(ChildComponent, { value: 'direct' });
+    const component = fixture.point.componentInstance;
+
+    expect(MockComponent(ChildComponent)).toBe(mock);
+    expect(isMockOf(component, ChildComponent)).toBe(true);
+    expect(ngMocks.findInstance(ChildComponent)).toBe(component);
+    expect(component.value).toBe('direct');
+    expect(ngMocks.formatText(fixture)).toBe('');
+    expect(jest.isMockFunction(component.run)).toBe(true);
+    expect(component.run).not.toHaveBeenCalled();
+    expect(component.run('direct')).toBeUndefined();
+    expect(component.run).toHaveBeenCalledWith('direct');
+    expect(component.run).toHaveBeenCalledTimes(1);
+    expect(realCalls).toEqual([]);
+  });
+
+  it('renders a kept host with mocked declarations and updated bindings', async () => {
+    await MockBuilder(HostComponent, TargetModule);
+
+    const fixture = MockRender(HostComponent);
+    const component = ngMocks.findInstance(ChildComponent);
+    const directive = ngMocks.findInstance(DependencyDirective);
+    const pipe = ngMocks.findInstance(DependencyPipe);
+
+    expect(
+      isMockOf(fixture.point.componentInstance, HostComponent),
+    ).toBe(false);
+    expect(isMockOf(component, ChildComponent)).toBe(true);
+    expect(isMockOf(directive, DependencyDirective)).toBe(true);
+    expect(isMockOf(pipe, DependencyPipe)).toBe(true);
+    expect(component.value).toBe('initial');
+    expect(directive.value).toBe('initial');
+    expect(ngMocks.formatText(fixture)).toBe('initial');
+    expect(jest.isMockFunction(pipe.transform)).toBe(true);
+    expect(pipe.transform).toHaveBeenCalledWith('initial');
+    expect(pipe.transform).toHaveBeenCalledTimes(1);
+    expect(jest.isMockFunction(directive.run)).toBe(true);
+    expect(directive.run).not.toHaveBeenCalled();
+    expect(directive.run('test')).toBeUndefined();
+    expect(directive.run).toHaveBeenCalledWith('test');
+    expect(directive.run).toHaveBeenCalledTimes(1);
+
+    component.changed.emit('updated');
+    fixture.detectChanges();
+
+    expect(fixture.point.componentInstance.value).toBe('updated');
+    expect(component.value).toBe('updated');
+    expect(directive.value).toBe('updated');
+    expect(ngMocks.formatText(fixture)).toBe('updated');
+    expect(pipe.transform).toHaveBeenLastCalledWith('updated');
+    expect(pipe.transform).toHaveBeenCalledTimes(2);
+    expect(realCalls).toEqual([]);
+  });
+
+  it('restores the configured spy factory after a temporary default', () => {
+    const initial = MockService(ChildComponent);
+
+    expect(jest.isMockFunction(initial.run)).toBe(true);
+    expect(jest.mocked(initial.run).getMockName()).toBe(
+      'ChildComponent.run',
+    );
+    expect(initial.run).not.toHaveBeenCalled();
+    expect(initial.run('initial')).toBeUndefined();
+    expect(initial.run).toHaveBeenCalledWith('initial');
+    expect(initial.run).toHaveBeenCalledTimes(1);
+
+    ngMocks.autoSpy('default');
+    try {
+      const plain = MockService(ChildComponent);
+
+      expect(jest.isMockFunction(plain.run)).toBe(false);
+      expect(plain.run('plain')).toBeUndefined();
+    } finally {
+      ngMocks.autoSpy('reset');
+    }
+
+    const restored = MockService(ChildComponent);
+
+    expect(jest.isMockFunction(restored.run)).toBe(true);
+    expect(jest.mocked(restored.run).getMockName()).toBe(
+      'ChildComponent.run',
+    );
+    expect(restored.run).not.toBe(initial.run);
+    expect(restored.run).not.toHaveBeenCalled();
+    expect(restored.run('restored')).toBeUndefined();
+    expect(restored.run).toHaveBeenCalledWith('restored');
+    expect(restored.run).toHaveBeenCalledTimes(1);
+    expect(initial.run).toHaveBeenCalledTimes(1);
+    expect(realCalls).toEqual([]);
+  });
+});

--- a/e2e/jest/tsconfig.json
+++ b/e2e/jest/tsconfig.json
@@ -28,6 +28,6 @@
     "strictInputAccessModifiers": true,
     "strictTemplates": true
   },
-  "files": ["src/main.ts", "src/setup-jest.ts"],
+  "files": ["src/main.ts", "src/setup-jest.ts", "src/setup-jest-esm.ts"],
   "include": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Why

The ESM package entry added for #2846 lacked a retained consumer running Jest in native ESM mode. The existing Jest configuration transforms tests to CommonJS, so it could not detect regressions in the public `import` entry or ESM initialization.

## What

Add a focused native ESM run to the existing Jest consumer using the installed Angular preset. Verify native execution and resolution of the public `index.mjs` export. Run shared regressions in both CommonJS and ESM for direct component mocking, a kept host with mocked components/directives/pipes, input and output updates, suppression of original behavior, and automatic spy restoration.

The ESM setup uses the existing custom spy factory with Jest's imported object.

## Impact

The existing Jest test command now exercises both package-consumer modes. CommonJS and minimal-dependency coverage remain intact. This adds regression coverage without changing published library behavior or its API; public documentation is unnecessary.

Fixes #14931
