### PR TITLE
test(standalone): cover omitted declaration defaults #14932

### DIFF
--- a/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
+++ b/libs/ng-mocks/src/lib/resolve/collect-declarations.spec.ts
@@ -1,10 +1,75 @@
 import { Component, EventEmitter, Output } from '@angular/core';
 
+import coreDefineProperty from '../common/core.define-property';
 import funcGetGlobal from '../common/func.get-global';
+import { isStandalone } from '../common/func.is-standalone';
 
 import collectDeclarations from './collect-declarations';
 
 describe('collect-declarations', () => {
+  describe('standalone', () => {
+    let reflectionOverride: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      reflectionOverride = Object.getOwnPropertyDescriptor(
+        funcGetGlobal(),
+        '__ngMocksReflectComponentType',
+      );
+      coreDefineProperty(
+        funcGetGlobal(),
+        '__ngMocksReflectComponentType',
+        false,
+      );
+    });
+
+    afterEach(() => {
+      if (reflectionOverride) {
+        Object.defineProperty(
+          funcGetGlobal(),
+          '__ngMocksReflectComponentType',
+          reflectionOverride,
+        );
+      } else {
+        delete funcGetGlobal().__ngMocksReflectComponentType;
+      }
+    });
+
+    for (const [ngMetadataName, property] of [
+      ['Component', 'ɵcmp'],
+      ['Directive', 'ɵdir'],
+      ['Pipe', 'ɵpipe'],
+    ]) {
+      for (const standalone of [true, false]) {
+        it(`uses compiled ${ngMetadataName} standalone:${standalone} when its annotation omits the flag`, () => {
+          class Target {}
+
+          const annotation = Object.freeze({ ngMetadataName });
+          const annotations = Object.freeze([annotation]);
+          const definition = Object.freeze({ standalone });
+          coreDefineProperty(Target, '__annotations__', annotations);
+          coreDefineProperty(Target, property, definition);
+
+          const actual = collectDeclarations(Target);
+
+          expect(actual.standalone).toBe(standalone);
+          expect(actual[ngMetadataName].standalone).toBe(standalone);
+          expect(isStandalone(Target)).toBe(standalone);
+          expect(collectDeclarations(Target)).toBe(actual);
+          expect(actual[ngMetadataName]).not.toBe(annotation);
+          expect(annotation).toEqual({ ngMetadataName });
+          expect(definition).toEqual({ standalone });
+          expect(
+            Object.getOwnPropertyDescriptor(Target, '__annotations__')
+              ?.value,
+          ).toBe(annotations);
+          expect(
+            Object.getOwnPropertyDescriptor(Target, property)?.value,
+          ).toBe(definition);
+        });
+      }
+    }
+  });
+
   describe('classic', () => {
     it('skips unknown annotations', () => {
       const actual = collectDeclarations({

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -54,6 +54,7 @@ file|examples/TestRoutingGuard/standalone.spec.ts|features=standalone,routerFns
 file|examples/TestRoutingResolver/fn.spec.ts|features=routerFns
 file|examples/TestRoutingResolver/standalone.spec.ts|features=standalone,routerFns
 file|tests/issue-7495/*.ts|features=standalone,routerFns
+file|tests/issue-14932/test.spec.ts|features=standaloneDefaultTrue
 file|tests/issue-4282/*.ts|versions=6+
 file|tests/issue-14528/*.ts|versions=6+
 file|tests/issue-14917/test.spec.ts|versions=6+

--- a/tests/issue-14932/test.spec.ts
+++ b/tests/issue-14932/test.spec.ts
@@ -1,0 +1,204 @@
+import {
+  Component,
+  Directive,
+  Input,
+  isStandalone,
+  Pipe,
+  PipeTransform,
+  Type,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockBuilder, MockRender, ngMocks } from 'ng-mocks';
+
+@Component({
+  selector: 'child-14932',
+  template: 'child:{{ value }} <ng-content></ng-content>',
+})
+class ChildComponent {
+  @Input() public value = '';
+}
+
+@Directive({ selector: '[directive14932]' })
+class DependencyDirective {
+  @Input() public value = '';
+
+  public read(): string {
+    return `directive:${this.value}`;
+  }
+}
+
+@Pipe({ name: 'pipe14932' })
+class DependencyPipe implements PipeTransform {
+  public transform(value: string): string {
+    return `pipe:${value}`;
+  }
+}
+
+@Component({
+  imports: [ChildComponent, DependencyDirective, DependencyPipe],
+  template: `
+    <child-14932 [value]="value">
+      <b>projected:{{ value }}</b>
+    </child-14932>
+    <span directive14932 [value]="value"></span>
+    <p>{{ value | pipe14932 }}</p>
+  `,
+})
+class HostComponent {
+  @Input() public value = 'initial';
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14932
+// These application declarations intentionally omit standalone: Angular 19+ supplies true.
+describe('issue-14932', () => {
+  ngMocks.throwOnConsole();
+
+  beforeEach(() => {
+    expect(
+      (
+        ChildComponent as typeof ChildComponent & {
+          ɵcmp: { standalone: boolean };
+        }
+      ).ɵcmp.standalone,
+    ).toBe(true);
+    expect(
+      (
+        DependencyDirective as typeof DependencyDirective & {
+          ɵdir: { standalone: boolean };
+        }
+      ).ɵdir.standalone,
+    ).toBe(true);
+    expect(
+      (
+        DependencyPipe as typeof DependencyPipe & {
+          ɵpipe: { standalone: boolean };
+        }
+      ).ɵpipe.standalone,
+    ).toBe(true);
+    expect(
+      (
+        HostComponent as typeof HostComponent & {
+          ɵcmp: { standalone: boolean };
+        }
+      ).ɵcmp.standalone,
+    ).toBe(true);
+  });
+
+  for (const mocked of [false, true]) {
+    it(`renders omitted-default declarations through ${mocked ? 'mocked' : 'real'} imports`, async () => {
+      if (mocked) {
+        await MockBuilder(HostComponent).mock(
+          DependencyPipe,
+          (value: string) => `mock:${value}`,
+        );
+      } else {
+        await TestBed.configureTestingModule({
+          imports: [HostComponent],
+        }).compileComponents();
+      }
+
+      const fixture = MockRender(HostComponent, { value: 'initial' });
+      const component = ngMocks.findInstance(ChildComponent);
+      const directive = ngMocks.findInstance(DependencyDirective);
+      const pipe = ngMocks.findInstance(DependencyPipe);
+
+      expect(
+        isMockOf(fixture.point.componentInstance, HostComponent),
+      ).toBe(false);
+      expect(
+        isStandalone(
+          fixture.point.componentInstance
+            .constructor as Type<unknown>,
+        ),
+      ).toBe(true);
+      expect(isMockOf(component, ChildComponent)).toBe(mocked);
+      expect(isMockOf(directive, DependencyDirective)).toBe(mocked);
+      expect(isMockOf(pipe, DependencyPipe)).toBe(mocked);
+      expect(
+        isStandalone(component.constructor as Type<unknown>),
+      ).toBe(true);
+      expect(
+        isStandalone(directive.constructor as Type<unknown>),
+      ).toBe(true);
+      expect(isStandalone(pipe.constructor as Type<unknown>)).toBe(
+        true,
+      );
+      expect(isStandalone(fixture.componentRef.componentType)).toBe(
+        false,
+      );
+      expect(component.value).toBe('initial');
+      expect(directive.value).toBe('initial');
+      if (mocked) {
+        expect(directive.read()).toBeUndefined();
+      } else {
+        expect(directive.read()).toBe('directive:initial');
+      }
+      expect(ngMocks.formatText(fixture)).toBe(
+        mocked
+          ? 'projected:initialmock:initial'
+          : 'child:initial projected:initialpipe:initial',
+      );
+
+      fixture.componentInstance.value = 'updated';
+      fixture.detectChanges();
+
+      expect(fixture.point.componentInstance.value).toBe('updated');
+      expect(component.value).toBe('updated');
+      expect(directive.value).toBe('updated');
+      if (mocked) {
+        expect(directive.read()).toBeUndefined();
+      } else {
+        expect(directive.read()).toBe('directive:updated');
+      }
+      expect(ngMocks.formatText(fixture)).toBe(
+        mocked
+          ? 'projected:updatedmock:updated'
+          : 'child:updated projected:updatedpipe:updated',
+      );
+    });
+  }
+
+  it('keeps the empty render wrapper nonstandalone', async () => {
+    await MockBuilder();
+
+    const fixture = MockRender();
+
+    expect(isStandalone(fixture.componentRef.componentType)).toBe(
+      false,
+    );
+    expect(ngMocks.formatText(fixture)).toBe('');
+  });
+
+  it('renders real omitted-default imports through a nonstandalone custom wrapper', async () => {
+    await MockBuilder([
+      ChildComponent,
+      DependencyDirective,
+      DependencyPipe,
+    ]);
+
+    const fixture = MockRender(
+      `
+        <child-14932 [value]="value"></child-14932>
+        <span directive14932 [value]="value"></span>
+        <p>{{ value | pipe14932 }}</p>
+      `,
+      { value: 'custom' },
+    );
+    const component = ngMocks.findInstance(ChildComponent);
+    const directive = ngMocks.findInstance(DependencyDirective);
+    const pipe = ngMocks.findInstance(DependencyPipe);
+
+    expect(isStandalone(fixture.componentRef.componentType)).toBe(
+      false,
+    );
+    expect(isMockOf(component, ChildComponent)).toBe(false);
+    expect(isMockOf(directive, DependencyDirective)).toBe(false);
+    expect(isMockOf(pipe, DependencyPipe)).toBe(false);
+    expect(component.value).toBe('custom');
+    expect(directive.value).toBe('custom');
+    expect(ngMocks.formatText(fixture)).toBe(
+      'child:custom pipe:custom',
+    );
+  });
+});


### PR DESCRIPTION
## Why

The standalone-default fixes in #10306, #10762, and #10752 need regression coverage for application declarations that omit `standalone`. Angular 19 and later compile those components, directives, and pipes as standalone, while older compiled declarations can still carry `false`.

## What

Add collector tests for compiled `true` and `false` across all three declaration kinds, including cache identity and preservation of the original metadata. Add Angular 19+ rendering regressions for real and mocked dependencies, input updates, projection, and a selectorless host that exercises declaration cloning.

The rendering cases also verify that generated mocks remain standalone and that empty, typed, and custom-template render wrappers remain nonstandalone.

## Impact

The existing implementation already handles these cases. This PR preserves that behavior with focused regression coverage; no public API or documentation changes are needed.

Fixes #14932
