### PR TITLE
fix(TestBed): preserve mixed import order #14937

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.imports.spec.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.imports.spec.ts
@@ -1,0 +1,486 @@
+import {
+  Component,
+  Injectable,
+  InjectionToken,
+  NgModule,
+} from '@angular/core';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
+
+import funcExtractTokens from '../mock-builder/func.extract-tokens';
+import { MockBuilderStash } from '../mock-builder/mock-builder-stash';
+import { EntryComponentsModule } from '../mock-builder/promise/handle-entry-components';
+import { MockComponent } from '../mock-component/mock-component';
+import { ngMocks } from '../mock-helper/mock-helper';
+import mockHelperFasterInstall from '../mock-helper/mock-helper.faster-install';
+import { MockModule } from '../mock-module/mock-module';
+
+import { flatten } from './core.helpers';
+import { getSourceOfMock } from './func.get-source-of-mock';
+import { isMockedNgDefOf } from './func.is-mocked-ng-def-of';
+import { isNgDef } from './func.is-ng-def';
+import { isNgModuleDefWithProviders } from './func.is-ng-module-def-with-providers';
+
+import './ng-mocks-global-overrides';
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14937
+describe('ng-mocks-global-overrides:imports', () => {
+  const stash = new MockBuilderStash();
+
+  beforeEach(() => {
+    ngMocks.flushTestBed();
+    stash.backup();
+    expect(mockHelperFasterInstall().before.length).toBe(1);
+  });
+
+  afterEach(() => {
+    try {
+      ngMocks.flushTestBed();
+      TestBed.resetTestingModule();
+    } finally {
+      stash.restore();
+    }
+  });
+
+  for (const mockFirst of [false, true]) {
+    it(`preserves explicit imports with the mock ${mockFirst ? 'first' : 'last'}`, () => {
+      @Injectable()
+      class BoundaryService {
+        public read(): string {
+          return 'original';
+        }
+      }
+
+      @NgModule({ providers: [BoundaryService] })
+      class BoundaryModule {}
+
+      @NgModule({})
+      class RealModule {}
+
+      const boundary = MockModule(BoundaryModule);
+      const imports = mockFirst
+        ? [boundary, RealModule]
+        : [RealModule, boundary];
+      const input = { imports };
+      let metadata: TestModuleMetadata = {};
+      const nativeConfigure = jasmine
+        .createSpy('nativeConfigure')
+        .and.callFake((value: TestModuleMetadata) => {
+          metadata = value;
+
+          return TestBed;
+        });
+      const configure = mockHelperFasterInstall().before[0](
+        nativeConfigure,
+        TestBed,
+      );
+
+      expect(configure(input)).toBe(TestBed);
+
+      const actual = flatten<unknown>(metadata.imports || []);
+      const mock = funcExtractTokens(metadata.providers).mocks?.get(
+        BoundaryModule,
+      );
+      expect(isMockedNgDefOf(mock, BoundaryModule, 'm')).toBe(true);
+      expect(actual.slice(0, -1)).toEqual(
+        mockFirst ? [mock, RealModule] : [RealModule, mock],
+      );
+      const entryModule = actual[actual.length - 1];
+      expect(typeof entryModule).toBe('function');
+      if (typeof entryModule === 'function') {
+        expect(
+          entryModule.prototype instanceof EntryComponentsModule,
+        ).toBe(true);
+      }
+      expect(nativeConfigure).toHaveBeenCalledTimes(1);
+      expect(nativeConfigure.calls.mostRecent().object).toBe(TestBed);
+      expect(input.imports).toBe(imports);
+      expect(imports).toEqual(
+        mockFirst ? [boundary, RealModule] : [RealModule, boundary],
+      );
+    });
+  }
+
+  it('preserves flattened import order without changing nested source arrays', () => {
+    @Injectable()
+    class BoundaryService {
+      public read(): string {
+        return 'original';
+      }
+    }
+
+    @NgModule({ providers: [BoundaryService] })
+    class BoundaryModule {}
+
+    @NgModule({})
+    class FirstModule {}
+
+    @NgModule({})
+    class LastModule {}
+
+    const boundary = MockModule(BoundaryModule);
+    const nested = [boundary, [undefined, LastModule]];
+    const imports = [[FirstModule], nested];
+    const input = { imports };
+    let metadata: TestModuleMetadata = {};
+    const nativeConfigure = jasmine
+      .createSpy('nativeConfigure')
+      .and.callFake((value: TestModuleMetadata) => {
+        metadata = value;
+
+        return TestBed;
+      });
+
+    mockHelperFasterInstall().before[0](
+      nativeConfigure,
+      TestBed,
+    )(input);
+
+    const mock = funcExtractTokens(metadata.providers).mocks?.get(
+      BoundaryModule,
+    );
+    expect(isMockedNgDefOf(mock, BoundaryModule, 'm')).toBe(true);
+    const actual = flatten<unknown>(metadata.imports || []);
+    expect(actual.slice(0, -1)).toEqual([
+      FirstModule,
+      mock,
+      LastModule,
+    ]);
+    const entryModule = actual[actual.length - 1];
+    expect(typeof entryModule).toBe('function');
+    if (typeof entryModule === 'function') {
+      expect(
+        entryModule.prototype instanceof EntryComponentsModule,
+      ).toBe(true);
+    }
+    expect(nativeConfigure).toHaveBeenCalledTimes(1);
+    expect(input.imports).toBe(imports);
+    expect(imports[1]).toBe(nested);
+    expect(imports).toEqual([
+      [FirstModule],
+      [boundary, [undefined, LastModule]],
+    ]);
+  });
+
+  it('preserves ModuleWithProviders placement and provider identities', () => {
+    @Injectable()
+    class BoundaryService {
+      public read(): string {
+        return 'original';
+      }
+    }
+
+    @NgModule({ providers: [BoundaryService] })
+    class BoundaryModule {}
+
+    @NgModule({})
+    class RealModule {}
+
+    const token = new InjectionToken<object>('configured value');
+    const factoryToken = new InjectionToken<object>(
+      'configured factory',
+    );
+    const value = { label: 'configured' };
+    const factory = jasmine
+      .createSpy('provider factory')
+      .and.returnValue(value);
+    const valueProvider = { provide: token, useValue: value };
+    const factoryProvider = {
+      provide: factoryToken,
+      useFactory: factory,
+    };
+    const providers = [valueProvider, factoryProvider];
+    const configured = { ngModule: RealModule, providers };
+    const boundary = MockModule(BoundaryModule);
+    const imports = [configured, boundary];
+    let metadata: TestModuleMetadata = {};
+    const nativeConfigure = jasmine
+      .createSpy('nativeConfigure')
+      .and.callFake((result: TestModuleMetadata) => {
+        metadata = result;
+
+        return TestBed;
+      });
+
+    mockHelperFasterInstall().before[0](
+      nativeConfigure,
+      TestBed,
+    )({ imports });
+
+    const actual = flatten<unknown>(metadata.imports || []);
+    const mock = funcExtractTokens(metadata.providers).mocks?.get(
+      BoundaryModule,
+    );
+    expect(isMockedNgDefOf(mock, BoundaryModule, 'm')).toBe(true);
+    expect(actual.length).toBe(3);
+    expect(actual[1]).toBe(mock);
+    expect(isNgModuleDefWithProviders(actual[0])).toBe(true);
+    if (isNgModuleDefWithProviders(actual[0])) {
+      expect(actual[0].ngModule).toBe(RealModule);
+      expect(actual[0].providers).toEqual(providers);
+      expect(actual[0].providers?.[0]).toBe(valueProvider);
+      expect(actual[0].providers?.[1]).toBe(factoryProvider);
+    }
+    const entryModule = actual[actual.length - 1];
+    expect(typeof entryModule).toBe('function');
+    if (typeof entryModule === 'function') {
+      expect(
+        entryModule.prototype instanceof EntryComponentsModule,
+      ).toBe(true);
+    }
+    expect(valueProvider.useValue).toBe(value);
+    expect(factoryProvider.useFactory).toBe(factory);
+    expect(factory).not.toHaveBeenCalled();
+    expect(configured.ngModule).toBe(RealModule);
+    expect(configured.providers).toBe(providers);
+    expect(imports).toEqual([configured, boundary]);
+    expect(nativeConfigure).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves provider precedence when repeated ModuleWithProviders entries are merged', () => {
+    @Injectable()
+    class BoundaryService {
+      public read(): string {
+        return 'original';
+      }
+    }
+
+    @NgModule({ providers: [BoundaryService] })
+    class BoundaryModule {}
+
+    @NgModule({})
+    class AModule {}
+
+    @NgModule({})
+    class BModule {}
+
+    const token = new InjectionToken<number>(
+      'repeated configuration',
+    );
+    const firstProvider = { provide: token, useValue: 1 };
+    const secondProvider = { provide: token, useValue: 2 };
+    const lastProvider = { provide: token, useValue: 3 };
+    const first = { ngModule: AModule, providers: [firstProvider] };
+    const second = { ngModule: BModule, providers: [secondProvider] };
+    const last = { ngModule: AModule, providers: [lastProvider] };
+    const boundary = MockModule(BoundaryModule);
+    const imports = [first, second, last, boundary];
+    let metadata: TestModuleMetadata = {};
+    const nativeConfigure = jasmine
+      .createSpy('nativeConfigure')
+      .and.callFake((value: TestModuleMetadata) => {
+        metadata = value;
+
+        return TestBed;
+      });
+
+    mockHelperFasterInstall().before[0](
+      nativeConfigure,
+      TestBed,
+    )({ imports });
+
+    const actual = flatten<unknown>(metadata.imports || []);
+    const configured = actual.filter(isNgModuleDefWithProviders);
+    const [mergedB, mergedA] = configured;
+    const mock = funcExtractTokens(metadata.providers).mocks?.get(
+      BoundaryModule,
+    );
+    expect(isMockedNgDefOf(mock, BoundaryModule, 'm')).toBe(true);
+    expect(configured.map(module => module.ngModule)).toEqual([
+      BModule,
+      AModule,
+    ]);
+    expect(actual.slice(0, -1)).toEqual([mergedB, mergedA, mock]);
+    const entryModule = actual[actual.length - 1];
+    expect(typeof entryModule).toBe('function');
+    if (typeof entryModule === 'function') {
+      expect(
+        entryModule.prototype instanceof EntryComponentsModule,
+      ).toBe(true);
+    }
+    expect(mergedA?.providers).toEqual([firstProvider, lastProvider]);
+    expect(mergedA?.providers?.[0]).toBe(firstProvider);
+    expect(mergedA?.providers?.[1]).toBe(lastProvider);
+    expect(mergedB?.providers).toEqual([secondProvider]);
+    expect(mergedB?.providers?.[0]).toBe(secondProvider);
+    expect(imports).toEqual([first, second, last, boundary]);
+    expect(first.providers).toEqual([firstProvider]);
+    expect(first.providers[0]).toBe(firstProvider);
+    expect(second.providers).toEqual([secondProvider]);
+    expect(last.providers).toEqual([lastProvider]);
+    expect(last.providers[0]).toBe(lastProvider);
+    expect(nativeConfigure).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves configured providers when a replacement also adds a bare module import', () => {
+    @Injectable()
+    class BoundaryService {
+      public read(): string {
+        return 'original';
+      }
+    }
+
+    @NgModule({ providers: [BoundaryService] })
+    class BoundaryModule {}
+
+    @NgModule({})
+    class OriginalModule {}
+
+    @NgModule({})
+    class ReplacementModule {}
+
+    @NgModule({ imports: [OriginalModule] })
+    class HostModule {}
+
+    const token = new InjectionToken<object>(
+      'replacement configuration',
+    );
+    const value = { label: 'configured replacement' };
+    const valueProvider = { provide: token, useValue: value };
+    const providers = [valueProvider];
+    const configured = { ngModule: ReplacementModule, providers };
+    const boundary = MockModule(BoundaryModule);
+    const imports = [HostModule, configured, boundary];
+    let metadata: TestModuleMetadata = {};
+    const nativeConfigure = jasmine
+      .createSpy('nativeConfigure')
+      .and.callFake((result: TestModuleMetadata) => {
+        metadata = result;
+
+        return TestBed;
+      });
+    ngMocks.globalReplace(OriginalModule, ReplacementModule);
+
+    try {
+      mockHelperFasterInstall().before[0](
+        nativeConfigure,
+        TestBed,
+      )({ imports });
+
+      const actual = flatten<unknown>(metadata.imports || []);
+      const wrappers = actual.filter(isNgModuleDefWithProviders);
+      expect(wrappers.length).toBe(1);
+      const [replacement] = wrappers;
+      const mocks = funcExtractTokens(metadata.providers).mocks;
+      const mock = mocks?.get(BoundaryModule);
+      expect(isMockedNgDefOf(mock, BoundaryModule, 'm')).toBe(true);
+      expect(replacement).toBeDefined();
+      expect(replacement?.ngModule).toBe(ReplacementModule);
+      expect(replacement?.providers).toEqual([valueProvider]);
+      expect(replacement?.providers?.[0]).toBe(valueProvider);
+      expect(
+        actual.filter(module =>
+          isNgModuleDefWithProviders(module)
+            ? module.ngModule === ReplacementModule
+            : module === ReplacementModule,
+        ).length,
+      ).toBe(2);
+      const host = actual[0];
+      expect(isNgDef(host, 'm')).toBe(true);
+      if (isNgDef(host, 'm')) {
+        expect(getSourceOfMock(host)).toBe(HostModule);
+      }
+      expect(actual.slice(1, -1)).toEqual([
+        replacement,
+        ReplacementModule,
+        mock,
+      ]);
+      const entryModule = actual[actual.length - 1];
+      expect(typeof entryModule).toBe('function');
+      if (typeof entryModule === 'function') {
+        expect(
+          entryModule.prototype instanceof EntryComponentsModule,
+        ).toBe(true);
+      }
+      expect(configured.providers).toBe(providers);
+      expect(configured.providers[0]).toBe(valueProvider);
+      expect(valueProvider.useValue).toBe(value);
+      expect(imports).toEqual([HostModule, configured, boundary]);
+      expect(nativeConfigure).toHaveBeenCalledTimes(1);
+    } finally {
+      ngMocks.globalWipe(OriginalModule);
+    }
+  });
+
+  it('preserves standalone imports interleaved with real and mocked modules', () => {
+    @Injectable()
+    class BoundaryService {
+      public read(): string {
+        return 'original';
+      }
+    }
+
+    @NgModule({ providers: [BoundaryService] })
+    class BoundaryModule {}
+
+    @NgModule({})
+    class RealModule {}
+
+    @Component({
+      selector: 'real-import',
+      standalone: true,
+      template: '',
+    })
+    class RealComponent {}
+
+    @Component({
+      selector: 'mock-import',
+      standalone: true,
+      template: '',
+    })
+    class BoundaryComponent {}
+
+    const boundaryModule = MockModule(BoundaryModule);
+    const boundaryComponent = MockComponent(BoundaryComponent);
+    const imports = [
+      RealComponent,
+      boundaryModule,
+      boundaryComponent,
+      RealModule,
+    ];
+    let metadata: TestModuleMetadata = {};
+    const nativeConfigure = jasmine
+      .createSpy('nativeConfigure')
+      .and.callFake((value: TestModuleMetadata) => {
+        metadata = value;
+
+        return TestBed;
+      });
+
+    mockHelperFasterInstall().before[0](
+      nativeConfigure,
+      TestBed,
+    )({ imports });
+
+    const mocks = funcExtractTokens(metadata.providers).mocks;
+    const mockModule = mocks?.get(BoundaryModule);
+    const mockComponent = mocks?.get(BoundaryComponent);
+    expect(isMockedNgDefOf(mockModule, BoundaryModule, 'm')).toBe(
+      true,
+    );
+    expect(
+      isMockedNgDefOf(mockComponent, BoundaryComponent, 'c'),
+    ).toBe(true);
+    const actual = flatten<unknown>(metadata.imports || []);
+    expect(actual.slice(0, -1)).toEqual([
+      RealComponent,
+      mockModule,
+      mockComponent,
+      RealModule,
+    ]);
+    const entryModule = actual[actual.length - 1];
+    expect(typeof entryModule).toBe('function');
+    if (typeof entryModule === 'function') {
+      expect(
+        entryModule.prototype instanceof EntryComponentsModule,
+      ).toBe(true);
+    }
+    expect(metadata.declarations).toEqual([]);
+    expect(imports).toEqual([
+      RealComponent,
+      boundaryModule,
+      boundaryComponent,
+      RealModule,
+    ]);
+    expect(nativeConfigure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -8,7 +8,7 @@ import mockHelperFasterInstall from '../mock-helper/mock-helper.faster-install';
 import coreDefineProperty from './core.define-property';
 import { flatten } from './core.helpers';
 import { NG_MOCKS_ROOT_PROVIDERS } from './core.tokens';
-import { AnyDeclaration, AnyType } from './core.types';
+import { AnyDeclaration, AnyType, Type } from './core.types';
 import funcApplyTestBedOverride from './func.apply-test-bed-override';
 import { funcExtractDeps } from './func.extract-deps';
 import { getSourceOfMock } from './func.get-source-of-mock';
@@ -184,6 +184,31 @@ const configureTestingModule =
       }
 
       finalModuleDef = builder.build();
+      // Ivy's module override traversal depends on the explicit import order.
+      // Repeated ModuleWithProviders entries are already merged at their last occurrence.
+      const importOrder = new Set<Type<unknown>>();
+      for (const declaration of flatten(moduleDef.imports ?? [])) {
+        const source = getSourceOfMock(funcGetType(declaration));
+        importOrder.delete(source);
+        importOrder.add(source);
+      }
+      const imports = new Map<Type<unknown>, unknown[]>();
+      for (const declaration of finalModuleDef.imports!) {
+        const source = getSourceOfMock(funcGetType(declaration));
+        const entries = imports.get(source) ?? [];
+        entries.push(declaration);
+        imports.set(source, entries);
+      }
+      finalModuleDef.imports = [];
+      for (const source of importOrder) {
+        if (imports.has(source)) {
+          finalModuleDef.imports.push(...imports.get(source)!);
+          imports.delete(source);
+        }
+      }
+      for (const entries of imports.values()) {
+        finalModuleDef.imports.push(...entries);
+      }
       finalModuleDef = {
         ...moduleDef,
         ...finalModuleDef,

--- a/tests/issue-14937/providers.spec.ts
+++ b/tests/issue-14937/providers.spec.ts
@@ -1,0 +1,101 @@
+import {
+  Component,
+  Inject,
+  InjectionToken,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+class Value {
+  public constructor(public readonly label: string) {}
+}
+
+const TOKEN = new InjectionToken<Value>('issue-14937-provider');
+// Class instances preserve useValue identity in View Engine too.
+const configuredValue = new Value('explicit replacement provider');
+let boundaryConstructions = 0;
+
+@NgModule({})
+class OriginalModule {}
+
+@NgModule({})
+class ReplacementModule {}
+
+@Component({
+  selector: 'boundary-14937-providers',
+  ['standalone' as never]: false,
+  template: 'real boundary',
+})
+class BoundaryComponent {
+  public constructor() {
+    boundaryConstructions += 1;
+  }
+}
+
+@NgModule({
+  declarations: [BoundaryComponent],
+  exports: [BoundaryComponent],
+})
+class BoundaryModule {}
+
+@Component({
+  selector: 'host-14937-providers',
+  ['standalone' as never]: false,
+  template:
+    '<span>{{ value.label }}</span><boundary-14937-providers></boundary-14937-providers>',
+})
+class HostComponent {
+  public constructor(@Inject(TOKEN) public readonly value: Value) {}
+}
+
+@NgModule({
+  declarations: [HostComponent],
+  imports: [OriginalModule, BoundaryModule],
+})
+class HostModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14937
+// An inferred bare replacement must not discard its explicit provider-bearing import.
+describe('issue-14937:providers', () => {
+  beforeEach(() => {
+    boundaryConstructions = 0;
+    ngMocks.globalReplace(OriginalModule, ReplacementModule);
+  });
+  afterEach(() => ngMocks.globalWipe(OriginalModule));
+
+  it('preserves providers on an explicitly imported replacement module', async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HostModule,
+        {
+          ngModule: ReplacementModule,
+          providers: [{ provide: TOKEN, useValue: configuredValue }],
+        },
+        MockModule(BoundaryModule),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    const boundary = ngMocks.find(fixture, BoundaryComponent);
+
+    expect(isMockOf(fixture.componentInstance, HostComponent)).toBe(
+      false,
+    );
+    expect(fixture.componentInstance.value).toBe(configuredValue);
+    expect(ngMocks.get(TOKEN)).toBe(configuredValue);
+    expect(ngMocks.findInstance(fixture, TOKEN)).toBe(
+      configuredValue,
+    );
+    expect(ngMocks.formatText(fixture)).toBe(
+      'explicit replacement provider',
+    );
+    expect(
+      isMockOf(boundary.componentInstance, BoundaryComponent),
+    ).toBe(true);
+    expect(boundaryConstructions).toBe(0);
+    expect(ngMocks.formatText(boundary)).toBe('');
+  });
+});

--- a/tests/issue-14937/real.spec.ts
+++ b/tests/issue-14937/real.spec.ts
@@ -1,0 +1,166 @@
+import { Component, Input, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, ngMocks } from 'ng-mocks';
+
+let boundaryConstructions = 0;
+
+@Component({
+  selector: 'replace-14937-real',
+  ['standalone' as never]: false,
+  template: 'original:{{ marker }}',
+})
+class OriginalComponent {
+  @Input() public marker = '';
+}
+
+@NgModule({
+  declarations: [OriginalComponent],
+  exports: [OriginalComponent],
+})
+class ReplaceModule {}
+
+@Component({
+  selector: 'replace-14937-real',
+  ['standalone' as never]: false,
+  template: 'replacement:{{ marker }}',
+  host: { 'data-replacement': '' },
+})
+class ReplacementComponent {
+  @Input() public marker = '';
+}
+
+@Component({
+  selector: 'nested-14937-real',
+  ['standalone' as never]: false,
+  template:
+    '<replace-14937-real marker="nested"></replace-14937-real>',
+})
+class NestedComponent {}
+
+@NgModule({
+  declarations: [NestedComponent],
+  exports: [NestedComponent],
+  imports: [ReplaceModule],
+})
+class NestedModule {}
+
+@Component({
+  selector: 'boundary-14937-real',
+  ['standalone' as never]: false,
+  template:
+    '<replace-14937-real marker="boundary"></replace-14937-real>',
+})
+class BoundaryComponent {
+  public constructor() {
+    boundaryConstructions += 1;
+  }
+}
+
+@NgModule({
+  declarations: [BoundaryComponent],
+  exports: [BoundaryComponent],
+  imports: [ReplaceModule],
+})
+class BoundaryModule {}
+
+@Component({
+  selector: 'target-14937-real',
+  ['standalone' as never]: false,
+  template: `
+    <section class="root">
+      <replace-14937-real marker="root"></replace-14937-real>
+    </section>
+    <nested-14937-real></nested-14937-real>
+    <boundary-14937-real></boundary-14937-real>
+  `,
+})
+class TargetComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14937
+// Independent classes prevent another case's cached module scopes affecting this baseline.
+describe('issue-14937:real', () => {
+  beforeEach(() => {
+    ngMocks.flushTestBed();
+    boundaryConstructions = 0;
+  });
+
+  it('applies the override to root and the first nested path in the real graph', async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TargetComponent],
+      imports: [NestedModule, BoundaryModule, ReplaceModule],
+    })
+      .overrideModule(ReplaceModule, {
+        remove: {
+          declarations: [OriginalComponent],
+          exports: [OriginalComponent],
+        },
+        add: {
+          declarations: [ReplacementComponent],
+          exports: [ReplacementComponent],
+        },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(TargetComponent);
+    fixture.detectChanges();
+    const root = ngMocks.find(fixture, '.root');
+    const nested = ngMocks.find(fixture, NestedComponent);
+    const boundary = ngMocks.find(fixture, BoundaryComponent);
+    const rootReplacement = ngMocks.find(root, 'replace-14937-real');
+    const nestedReplacement = ngMocks.find(
+      nested,
+      'replace-14937-real',
+    );
+
+    expect(isMockOf(fixture.componentInstance, TargetComponent)).toBe(
+      false,
+    );
+    expect(isMockOf(nested.componentInstance, NestedComponent)).toBe(
+      false,
+    );
+    expect(ngMocks.formatText(root)).toBe('replacement:root');
+    expect(ngMocks.formatText(nested)).toBe('replacement:nested');
+    expect(rootReplacement.componentInstance.marker).toBe('root');
+    expect(nestedReplacement.componentInstance.marker).toBe('nested');
+    expect(
+      ngMocks.findInstance(
+        rootReplacement,
+        ReplacementComponent,
+        null,
+      ),
+    ).toBe(rootReplacement.componentInstance);
+    expect(
+      ngMocks.findInstance(
+        nestedReplacement,
+        ReplacementComponent,
+        null,
+      ),
+    ).toBe(nestedReplacement.componentInstance);
+    expect(
+      ngMocks.findInstance(root, OriginalComponent, null),
+    ).toBeNull();
+    expect(
+      ngMocks.findInstance(nested, OriginalComponent, null),
+    ).toBeNull();
+    expect(rootReplacement.componentInstance).not.toBe(
+      nestedReplacement.componentInstance,
+    );
+    expect(
+      isMockOf(
+        rootReplacement.componentInstance,
+        ReplacementComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(
+        nestedReplacement.componentInstance,
+        ReplacementComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(boundary.componentInstance, BoundaryComponent),
+    ).toBe(false);
+    expect(boundaryConstructions).toBe(1);
+  });
+});

--- a/tests/issue-14937/test.spec.ts
+++ b/tests/issue-14937/test.spec.ts
@@ -1,0 +1,168 @@
+import { Component, Input, NgModule } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { isMockOf, MockModule, ngMocks } from 'ng-mocks';
+
+let originalConstructions = 0;
+let boundaryConstructions = 0;
+
+@Component({
+  selector: 'replace-14937',
+  ['standalone' as never]: false,
+  template: 'original:{{ marker }}',
+})
+class OriginalComponent {
+  @Input() public marker = '';
+
+  public constructor() {
+    originalConstructions += 1;
+  }
+}
+
+@NgModule({
+  declarations: [OriginalComponent],
+  exports: [OriginalComponent],
+})
+class ReplaceModule {}
+
+@Component({
+  selector: 'replace-14937',
+  ['standalone' as never]: false,
+  template: 'replacement:{{ marker }}',
+  host: { 'data-replacement': '' },
+})
+class ReplacementComponent {
+  @Input() public marker = '';
+}
+
+@Component({
+  selector: 'nested-14937',
+  ['standalone' as never]: false,
+  template: '<replace-14937 marker="nested"></replace-14937>',
+})
+class NestedComponent {}
+
+@NgModule({
+  declarations: [NestedComponent],
+  exports: [NestedComponent],
+  imports: [ReplaceModule],
+})
+class NestedModule {}
+
+@Component({
+  selector: 'boundary-14937',
+  ['standalone' as never]: false,
+  template: '<replace-14937 marker="boundary"></replace-14937>',
+})
+class BoundaryComponent {
+  public constructor() {
+    boundaryConstructions += 1;
+  }
+}
+
+@NgModule({
+  declarations: [BoundaryComponent],
+  exports: [BoundaryComponent],
+  imports: [ReplaceModule],
+})
+class BoundaryModule {}
+
+@Component({
+  selector: 'target-14937',
+  ['standalone' as never]: false,
+  template: `
+    <section class="root">
+      <replace-14937 marker="root"></replace-14937>
+    </section>
+    <nested-14937></nested-14937>
+    <boundary-14937></boundary-14937>
+  `,
+})
+class TargetComponent {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14937
+// Keep this graph separate from the real baseline: Angular caches ancestor scopes.
+describe('issue-14937', () => {
+  beforeEach(() => {
+    ngMocks.flushTestBed();
+    originalConstructions = 0;
+    boundaryConstructions = 0;
+  });
+
+  it('preserves a nested-first override before the explicit mocked module', async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TargetComponent],
+      imports: [
+        NestedModule,
+        MockModule(BoundaryModule),
+        ReplaceModule,
+      ],
+    })
+      .overrideModule(ReplaceModule, {
+        remove: {
+          declarations: [OriginalComponent],
+          exports: [OriginalComponent],
+        },
+        add: {
+          declarations: [ReplacementComponent],
+          exports: [ReplacementComponent],
+        },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(TargetComponent);
+    fixture.detectChanges();
+    const root = ngMocks.find(fixture, '.root');
+    const nested = ngMocks.find(fixture, NestedComponent);
+    const boundary = ngMocks.find(fixture, BoundaryComponent);
+    const rootReplacement = ngMocks.find(root, 'replace-14937');
+    const nestedReplacement = ngMocks.find(nested, 'replace-14937');
+
+    expect(isMockOf(fixture.componentInstance, TargetComponent)).toBe(
+      false,
+    );
+    expect(isMockOf(nested.componentInstance, NestedComponent)).toBe(
+      false,
+    );
+    expect(originalConstructions).toBe(0);
+    expect(ngMocks.formatText(root)).toBe('replacement:root');
+    expect(ngMocks.formatText(nested)).toBe('replacement:nested');
+    expect(rootReplacement.componentInstance.marker).toBe('root');
+    expect(nestedReplacement.componentInstance.marker).toBe('nested');
+    expect(
+      ngMocks.findInstance(
+        rootReplacement,
+        ReplacementComponent,
+        null,
+      ),
+    ).toBe(rootReplacement.componentInstance);
+    expect(
+      ngMocks.findInstance(
+        nestedReplacement,
+        ReplacementComponent,
+        null,
+      ),
+    ).toBe(nestedReplacement.componentInstance);
+    expect(rootReplacement.componentInstance).not.toBe(
+      nestedReplacement.componentInstance,
+    );
+    expect(
+      isMockOf(
+        rootReplacement.componentInstance,
+        ReplacementComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(
+        nestedReplacement.componentInstance,
+        ReplacementComponent,
+      ),
+    ).toBe(false);
+    expect(
+      isMockOf(boundary.componentInstance, BoundaryComponent),
+    ).toBe(true);
+    expect(boundaryConstructions).toBe(0);
+    expect(ngMocks.formatText(boundary)).toBe('');
+    expect(ngMocks.find(boundary, 'replace-14937', null)).toBeNull();
+  });
+});

--- a/tests/issue-4641/test.spec.ts
+++ b/tests/issue-4641/test.spec.ts
@@ -77,7 +77,8 @@ describe('issue-4641:test', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       declarations: [TargetComponent],
-      imports: [MockModule(Dep1Module), Dep2Module, ReplaceModule],
+      // Ivy visits the shared module through its first importing consumer.
+      imports: [Dep2Module, MockModule(Dep1Module), ReplaceModule],
     })
       .overrideModule(ReplaceModule, {
         remove: {
@@ -98,8 +99,9 @@ describe('issue-4641:test', () => {
     // dep1 is mock and should have an empty template
     expect(ngMocks.formatText(fixture)).not.toContain('dep1:replace');
     // dep2 was kept, but it should rely on the replaced declaration.
-    // TODO it looks like Angular bug itself, it doesn't redefine nested imports
-    // expect(ngMocks.formatText(fixture)).toContain('dep2:replace-mock');
+    expect(ngMocks.formatText(fixture)).toContain(
+      'dep2:replace-mock',
+    );
     // replace was replaced, therefore, it should rely on the replaced declaration.
     expect(ngMocks.formatText(fixture)).toContain(
       'replace:replace-mock',


### PR DESCRIPTION
## Why

Mixed `TestBed.configureTestingModule` setups rebuild imports through MockBuilder, which places mocked modules before kept modules. Ivy's shared-module override traversal depends on import order: moving a mocked module ahead of a real nested consumer can leave that consumer using the original declaration after `TestBed.overrideModule`.

This establishes the missing nested-consumer baseline from #4641 and fixes the divergence in #14937.

## What

- Preserve explicit import order when passing reconstructed metadata to TestBed, retaining generated module identities, provider wrappers, and internal imports. Repeated module configurations retain their existing merged-provider precedence.
- Add independent real and mixed Angular regressions for root and nested replacement rendering and identity, with original-constructor and mocked-boundary suppression checks.
- Cover reversed ordering, nested import arrays, empty entries, standalone imports, and module-provider preservation in focused source tests. An Angular injection regression also protects explicit providers when a global replacement adds another import of the same module. Enable the original #4641 nested assertion using the order supported by Angular's baseline.

## Impact

Existing mixed TestBed setups retain the nested override behavior supported by their real-module equivalents. This restores the existing contract, so public documentation does not need to change.

Fixes #14937
