### PR TITLE
fix(MockRender): apply overrides to render middleware #14945

### DIFF
--- a/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-global-overrides.ts
@@ -20,6 +20,7 @@ import { resetDeclarationFactories } from './ng-mocks-declaration-factories';
 import { rememberMockDeclarations, resetInjectedDeclarations } from './ng-mocks-injected-declarations';
 import { applyPlatformOverrides, defineTouches } from './ng-mocks-platform-overrides';
 import { resetRuntimeInject } from './ng-mocks-runtime-inject';
+import { installTemplateOverrides, resetTemplateOverrides } from './ng-mocks-template-overrides';
 import { installTestBedInjection } from './ng-mocks-test-bed-injection';
 import { rememberTestModuleOptions, resetTestModuleOptions } from './ng-mocks-test-module-metadata';
 import ngMocksUniverse from './ng-mocks-universe';
@@ -66,6 +67,7 @@ const applyNgMocksOverrides = (testBed: TestBedStatic & { ngMocksOverrides?: Map
 const initTestBed = () => {
   installTestBedInjection(TestBed as never);
   installTestBedInjection(getTestBed() as never);
+  installTemplateOverrides(getTestBed());
   if (!(TestBed as any).ngMocksSelectors) {
     coreDefineProperty(TestBed, 'ngMocksSelectors', new Map());
   }
@@ -272,6 +274,7 @@ const resetTestingModule =
     } finally {
       // Older Ivy TestBed versions restore directive definitions but leave recompiled factories behind.
       resetDeclarationFactories();
+      resetTemplateOverrides();
     }
     if (errors.length > 0) {
       throw errors[0];

--- a/libs/ng-mocks/src/lib/common/ng-mocks-template-overrides.ts
+++ b/libs/ng-mocks/src/lib/common/ng-mocks-template-overrides.ts
@@ -1,0 +1,101 @@
+import { Component, ExistingProvider } from '@angular/core';
+import { getTestBed, MetadataOverride, TestBedStatic } from '@angular/core/testing';
+
+import funcInheritDefinition from '../mock-render/func.inherit-definition';
+import helperCreateClone from '../mock-service/helper.create-clone';
+
+import coreDefineProperty from './core.define-property';
+import { Type } from './core.types';
+
+type OverrideKey = 'overrideComponent' | 'overrideDirective';
+type Override = MetadataOverride<Component>;
+type OverrideRecord = [OverrideKey, Override];
+type NativeOverrides = Pick<TestBedStatic, OverrideKey>;
+type CompileTypes = (() => unknown) & { ngMocksTemplateOverridesPatched?: boolean };
+type OverrideTestBed = NativeOverrides & {
+  _compiler?: { compileTypesSync?: CompileTypes } | null;
+  ngMocksTemplateOverrides?: NativeOverrides;
+};
+type Middleware = ExistingProvider & { provide: Type<unknown>; useExisting: Type<unknown> };
+
+const overrides = new Map<Type<unknown>, OverrideRecord[]>();
+const middleware = new Map<Type<unknown>, Middleware>();
+
+const installCompiler = (instance: OverrideTestBed): void => {
+  const compiler = instance._compiler;
+  if (!compiler?.compileTypesSync || compiler.compileTypesSync.ngMocksTemplateOverridesPatched) {
+    return;
+  }
+  const original = compiler.compileTypesSync;
+  const compile: CompileTypes = helperCreateClone(original, undefined, undefined, () => {
+    const result = original.call(compiler);
+    // Native overrides replace Ivy getters before scopes and fixtures use them.
+    for (const alias of middleware.values()) {
+      funcInheritDefinition(alias.useExisting, alias.provide);
+    }
+
+    return result;
+  });
+  coreDefineProperty(compile, 'ngMocksTemplateOverridesPatched', true);
+  coreDefineProperty(compiler, 'compileTypesSync', compile, true);
+};
+
+const applyOverride = (instance: OverrideTestBed, method: OverrideKey, child: Middleware, override: Override): void => {
+  const forwarded = { ...override };
+  for (const operation of ['set', 'add', 'remove'] as const) {
+    if (override[operation]) {
+      forwarded[operation] = { ...override[operation] };
+      // The wrapper already binds the middleware's generated selector.
+      delete forwarded[operation]!.selector;
+    }
+  }
+  if (forwarded.set && 'providers' in forwarded.set) {
+    forwarded.set.providers = [...(forwarded.set.providers ?? []), child];
+  }
+  instance.ngMocksTemplateOverrides![method].call(instance, child.useExisting, forwarded);
+};
+
+export const installTemplateOverrides = (instance: OverrideTestBed): void => {
+  if (!instance.ngMocksTemplateOverrides) {
+    const original: NativeOverrides = {
+      overrideComponent: instance.overrideComponent,
+      overrideDirective: instance.overrideDirective,
+    };
+    coreDefineProperty(instance, 'ngMocksTemplateOverrides', original);
+    for (const method of ['overrideComponent', 'overrideDirective'] as const) {
+      coreDefineProperty(
+        instance,
+        method,
+        helperCreateClone(original[method], undefined, undefined, (source: Type<unknown>, override: Override) => {
+          const result = original[method].call(instance, source, override);
+          const history = overrides.get(source) ?? [];
+          history.push([method, override]);
+          overrides.set(source, history);
+          installCompiler(instance);
+          const child = middleware.get(source);
+          if (child) {
+            applyOverride(instance, method, child, override);
+          }
+
+          return result;
+        }),
+        true,
+      );
+    }
+  }
+  installCompiler(instance);
+};
+
+export const rememberTemplateOverrides = (alias: Middleware): void => {
+  const instance = getTestBed();
+  installTemplateOverrides(instance);
+  middleware.set(alias.provide, alias);
+  for (const [method, override] of overrides.get(alias.provide) ?? []) {
+    applyOverride(instance, method, alias, override);
+  }
+};
+
+export const resetTemplateOverrides = (): void => {
+  overrides.clear();
+  middleware.clear();
+};

--- a/libs/ng-mocks/src/lib/mock-render/func.inherit-definition.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.inherit-definition.ts
@@ -1,3 +1,8 @@
+import coreDefineProperty from '../common/core.define-property';
+import helperDefinePropertyDescriptor from '../mock-service/helper.define-property-descriptor';
+
+type InheritedGetter = (() => unknown) & { ngMocksInheritedDefinition?: boolean };
+
 // Middleware declarations represent the same Angular declaration under a new
 // selector. Recompiling copied metadata must not add inherited side effects twice.
 const inheritDefinition = (definition: any, original: any): void => {
@@ -41,7 +46,10 @@ export default (child: any, template: any): void => {
     if (!descriptor?.get) {
       continue;
     }
-    const getter = descriptor.get;
+    const getter: InheritedGetter = descriptor.get;
+    if (getter.ngMocksInheritedDefinition) {
+      continue;
+    }
     if (!descriptor.configurable) {
       // Production-mode JIT getters cannot be replaced, even by TestBed.
       inheritDefinition(getter.call(child), template[key]);
@@ -50,21 +58,20 @@ export default (child: any, template: any): void => {
 
     let lastDefinition: any;
     let lastOriginal: any;
-    Object.defineProperty(child, key, {
-      ...descriptor,
-      get() {
-        const definition = getter.call(this);
-        const original = template[key];
-        if (definition !== lastDefinition || original !== lastOriginal) {
-          // TestBed can recompile the original after the middleware was reflected.
-          // Read its effective definition here so overrides also take effect once.
-          inheritDefinition(definition, original);
-          lastDefinition = definition;
-          lastOriginal = original;
-        }
+    const inheritedGetter = function (this: unknown) {
+      const definition = getter.call(this);
+      const original = template[key];
+      if (definition !== lastDefinition || original !== lastOriginal) {
+        // TestBed can recompile the original after the middleware was reflected.
+        // Read its effective definition here so overrides also take effect once.
+        inheritDefinition(definition, original);
+        lastDefinition = definition;
+        lastOriginal = original;
+      }
 
-        return definition;
-      },
-    });
+      return definition;
+    };
+    coreDefineProperty(inheritedGetter, 'ngMocksInheritedDefinition', true);
+    helperDefinePropertyDescriptor(child, key, { ...descriptor, get: inheritedGetter });
   }
 };

--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.overrides.spec.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.overrides.spec.ts
@@ -1,0 +1,395 @@
+import {
+  Component,
+  Inject,
+  InjectionToken,
+  Optional,
+  reflectComponentType,
+  Self,
+  Type,
+} from '@angular/core';
+import { getTestBed, TestBed } from '@angular/core/testing';
+
+import { ngMocks } from '../mock-helper/mock-helper';
+
+import funcReflectTemplate from './func.reflect-template';
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14945
+describe('funcReflectTemplate:direct overrides', () => {
+  for (const overrideFirst of [true, false]) {
+    it(`applies direct component overrides ${overrideFirst ? 'before' : 'after'} cloning`, async () => {
+      const token = new InjectionToken<{ label: string }>(
+        'component provider',
+      );
+      const viewToken = new InjectionToken<{ label: string }>(
+        'component view provider',
+      );
+      const originalValue = { label: 'original provider' };
+      const originalViewValue = { label: 'original view' };
+      const originalProvider = {
+        provide: token,
+        useValue: originalValue,
+      };
+      const originalViewProvider = {
+        provide: viewToken,
+        useValue: originalViewValue,
+      };
+      const providers = [originalProvider];
+      const viewProviders = [originalViewProvider];
+      const inputs = ['label'];
+      const host = {
+        '(click)': 'originalClicks = originalClicks + 1',
+        role: 'button',
+      };
+
+      @Component({
+        host,
+        inputs,
+        providers,
+        standalone: false,
+        template: 'original {{ local.label }} {{ view.label }}',
+        viewProviders,
+      })
+      class TargetComponent {
+        public label = '';
+        public originalClicks = 0;
+        public overrideClicks = 0;
+
+        public constructor(
+          @Inject(token) public readonly local: { label: string },
+          @Inject(viewToken) public readonly view: { label: string },
+        ) {}
+      }
+
+      const annotations: Component[] =
+        Object.getOwnPropertyDescriptor(
+          TargetComponent,
+          '__annotations__',
+        )?.value;
+      const annotation = annotations[0];
+      const overriddenValue = { label: 'configured provider' };
+      const overriddenViewValue = { label: 'configured view' };
+      const overriddenProvider = {
+        provide: token,
+        useValue: overriddenValue,
+      };
+      const overriddenViewProvider = {
+        provide: viewToken,
+        useValue: overriddenViewValue,
+      };
+      const override = {
+        set: {
+          host: {
+            '(click)': 'overrideClicks = overrideClicks + 1',
+            role: 'presentation',
+          },
+          providers: [overriddenProvider],
+          template: 'override {{ local.label }} {{ view.label }}',
+          viewProviders: [overriddenViewProvider],
+        },
+      };
+      TestBed.configureTestingModule({
+        declarations: [TargetComponent],
+      });
+      if (overrideFirst) {
+        TestBed.overrideComponent(TargetComponent, override);
+      }
+      const configure = spyOn(
+        TestBed,
+        'configureTestingModule',
+      ).and.callThrough();
+
+      funcReflectTemplate(TargetComponent);
+
+      const child: Type<TargetComponent> =
+        configure.calls.mostRecent().args[0].declarations![0];
+      if (!overrideFirst) {
+        TestBed.overrideComponent(TargetComponent, override);
+      }
+      await TestBed.compileComponents();
+      const fixture = TestBed.createComponent(child);
+      fixture.detectChanges();
+      fixture.detectChanges();
+      fixture.nativeElement.dispatchEvent(new Event('click'));
+
+      expect(child).not.toBe(TargetComponent);
+      expect(
+        fixture.componentInstance instanceof TargetComponent,
+      ).toBe(true);
+      expect(ngMocks.formatText(fixture)).toBe(
+        'override configured provider configured view',
+      );
+      expect(fixture.componentInstance.local).toBe(overriddenValue);
+      expect(fixture.componentInstance.view).toBe(
+        overriddenViewValue,
+      );
+      expect(fixture.debugElement.injector.get(token)).toBe(
+        overriddenValue,
+      );
+      expect(fixture.debugElement.injector.get(viewToken)).toBe(
+        overriddenViewValue,
+      );
+      expect(fixture.debugElement.injector.get(TargetComponent)).toBe(
+        fixture.componentInstance,
+      );
+      expect(fixture.componentInstance.overrideClicks).toBe(1);
+      expect(fixture.componentInstance.originalClicks).toBe(0);
+      expect(fixture.nativeElement.getAttribute('role')).toBe(
+        'presentation',
+      );
+
+      expect(
+        Object.getOwnPropertyDescriptor(
+          TargetComponent,
+          '__annotations__',
+        )?.value,
+      ).toBe(annotations);
+      expect(annotations[0]).toBe(annotation);
+      expect(annotation.template).toBe(
+        'original {{ local.label }} {{ view.label }}',
+      );
+      expect(annotation.inputs).toBe(inputs);
+      expect(inputs).toEqual(['label']);
+      expect(annotation.providers).toBe(providers);
+      expect(providers).toEqual([originalProvider]);
+      expect(providers[0].useValue).toBe(originalValue);
+      expect(annotation.viewProviders).toBe(viewProviders);
+      expect(viewProviders).toEqual([originalViewProvider]);
+      expect(viewProviders[0].useValue).toBe(originalViewValue);
+      expect(annotation.host).toBe(host);
+      expect(host).toEqual({
+        '(click)': 'originalClicks = originalClicks + 1',
+        role: 'button',
+      });
+      expect(override.set.providers).toEqual([overriddenProvider]);
+      expect(override.set.viewProviders).toEqual([
+        overriddenViewProvider,
+      ]);
+      expect(override.set.host).toEqual({
+        '(click)': 'overrideClicks = overrideClicks + 1',
+        role: 'presentation',
+      });
+    });
+  }
+
+  it('applies ordered add and remove overrides once through static and instance TestBed calls', async () => {
+    const token = new InjectionToken<Array<{ label: string }>>(
+      'ordered component values',
+    );
+    const baseValue = { label: 'base' };
+    const removedValue = { label: 'removed' };
+    const earlyValue = { label: 'early' };
+    const lateValue = { label: 'late' };
+    const baseProvider = {
+      provide: token,
+      multi: true,
+      useValue: baseValue,
+    };
+    const removedProvider = {
+      provide: token,
+      multi: true,
+      useValue: removedValue,
+    };
+    const earlyProvider = {
+      provide: token,
+      multi: true,
+      useValue: earlyValue,
+    };
+    const lateProvider = {
+      provide: token,
+      multi: true,
+      useValue: lateValue,
+    };
+    const providers = [baseProvider, removedProvider];
+    const host = {
+      '(click)': 'originalClicks = originalClicks + 1',
+      role: 'button',
+    };
+
+    @Component({
+      host,
+      providers,
+      standalone: false,
+      template:
+        '{{ providedValues.length }}:{{ providedValues[0].label }}',
+    })
+    class TargetComponent {
+      public originalClicks = 0;
+      public overrideClicks = 0;
+
+      public constructor(
+        @Inject(token)
+        public readonly providedValues: Array<{ label: string }>,
+      ) {}
+    }
+
+    const annotations: Component[] = Object.getOwnPropertyDescriptor(
+      TargetComponent,
+      '__annotations__',
+    )?.value;
+    const annotation = annotations[0];
+    const earlyProviders = [earlyProvider];
+    const removedProviders = [removedProvider];
+    const lateProviders = [lateProvider];
+    const earlyOverride = { add: { providers: earlyProviders } };
+    const lateOverride = {
+      add: {
+        host: {
+          '(click)': 'overrideClicks = overrideClicks + 1',
+          role: 'presentation',
+        },
+        providers: lateProviders,
+      },
+      remove: { providers: removedProviders },
+    };
+    TestBed.configureTestingModule({
+      declarations: [TargetComponent],
+    });
+    TestBed.overrideComponent(TargetComponent, earlyOverride);
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.callThrough();
+
+    const template = funcReflectTemplate(TargetComponent);
+
+    const child: Type<TargetComponent> =
+      configure.calls.mostRecent().args[0].declarations![0];
+    getTestBed().overrideComponent(TargetComponent, lateOverride);
+    await TestBed.compileComponents();
+    expect(reflectComponentType(child)?.selector).toBe(
+      template.selector,
+    );
+    await TestBed.compileComponents();
+    expect(reflectComponentType(child)?.selector).toBe(
+      template.selector,
+    );
+    const fixture = TestBed.createComponent(child);
+    fixture.detectChanges();
+    fixture.detectChanges();
+    fixture.nativeElement.dispatchEvent(new Event('click'));
+
+    const values = fixture.componentInstance.providedValues;
+    expect(values).toEqual([baseValue, earlyValue, lateValue]);
+    expect(values[0]).toBe(baseValue);
+    expect(values[1]).toBe(earlyValue);
+    expect(values[2]).toBe(lateValue);
+    expect(fixture.debugElement.injector.get(token)).toBe(values);
+    expect(fixture.debugElement.injector.get(TargetComponent)).toBe(
+      fixture.componentInstance,
+    );
+    expect(ngMocks.formatText(fixture)).toBe('3:base');
+    expect(fixture.componentInstance.overrideClicks).toBe(1);
+    expect(fixture.componentInstance.originalClicks).toBe(0);
+    expect(fixture.nativeElement.getAttribute('role')).toBe(
+      'presentation',
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(
+        TargetComponent,
+        '__annotations__',
+      )?.value,
+    ).toBe(annotations);
+    expect(annotations[0]).toBe(annotation);
+    expect(annotation.providers).toBe(providers);
+    expect(providers).toEqual([baseProvider, removedProvider]);
+    expect(providers[0]).toBe(baseProvider);
+    expect(providers[1]).toBe(removedProvider);
+    expect(annotation.host).toBe(host);
+    expect(host).toEqual({
+      '(click)': 'originalClicks = originalClicks + 1',
+      role: 'button',
+    });
+    expect(earlyOverride.add.providers).toBe(earlyProviders);
+    expect(earlyProviders).toEqual([earlyProvider]);
+    expect(lateOverride.add.providers).toBe(lateProviders);
+    expect(lateProviders).toEqual([lateProvider]);
+    expect(lateOverride.remove.providers).toBe(removedProviders);
+    expect(removedProviders).toEqual([removedProvider]);
+    expect(lateOverride.add.host).toEqual({
+      '(click)': 'overrideClicks = overrideClicks + 1',
+      role: 'presentation',
+    });
+  });
+
+  it('keeps the generated selector and original-token alias when an override clears local providers', async () => {
+    const token = new InjectionToken<{ label: string }>(
+      'optional local value',
+    );
+    const originalValue = { label: 'local' };
+    const parentValue = { label: 'parent' };
+    const provider = { provide: token, useValue: originalValue };
+    const providers = [provider];
+
+    @Component({
+      providers,
+      standalone: false,
+      template: '{{ local === null ? "missing" : "present" }}',
+    })
+    class TargetComponent {
+      public constructor(
+        @Optional()
+        @Self()
+        @Inject(token)
+        public readonly local: { label: string } | null,
+      ) {}
+    }
+
+    const annotations: Component[] = Object.getOwnPropertyDescriptor(
+      TargetComponent,
+      '__annotations__',
+    )?.value;
+    const annotation = annotations[0];
+    const override = {
+      set: { providers: undefined, selector: 'renamed-original' },
+    };
+    TestBed.configureTestingModule({
+      declarations: [TargetComponent],
+      providers: [{ provide: token, useValue: parentValue }],
+    });
+    const configure = spyOn(
+      TestBed,
+      'configureTestingModule',
+    ).and.callThrough();
+
+    const template = funcReflectTemplate(TargetComponent);
+
+    const child: Type<TargetComponent> =
+      configure.calls.mostRecent().args[0].declarations![0];
+    TestBed.overrideComponent(TargetComponent, override);
+    await TestBed.compileComponents();
+    const fixture = TestBed.createComponent(child);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.local).toBeNull();
+    expect(TestBed.inject(token)).toBe(parentValue);
+    expect(ngMocks.formatText(fixture)).toBe('missing');
+    expect(fixture.debugElement.injector.get(TargetComponent)).toBe(
+      fixture.componentInstance,
+    );
+    expect(reflectComponentType(child)?.selector).toBe(
+      template.selector,
+    );
+    expect(reflectComponentType(child)?.selector).not.toBe(
+      override.set.selector,
+    );
+    expect(reflectComponentType(TargetComponent)?.selector).toBe(
+      override.set.selector,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(
+        TargetComponent,
+        '__annotations__',
+      )?.value,
+    ).toBe(annotations);
+    expect(annotations[0]).toBe(annotation);
+    expect(annotation.selector).toBeUndefined();
+    expect(annotation.providers).toBe(providers);
+    expect(providers).toEqual([provider]);
+    expect(providers[0]).toBe(provider);
+    expect(provider.useValue).toBe(originalValue);
+    expect(override.set).toEqual({
+      providers: undefined,
+      selector: 'renamed-original',
+    });
+  });
+});

--- a/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.reflect-template.ts
@@ -3,15 +3,16 @@ import { TestBed } from '@angular/core/testing';
 
 import { extendClass } from '../common/core.helpers';
 import coreReflectDirectiveResolve from '../common/core.reflect.directive-resolve';
-import { AnyType, DirectiveIo } from '../common/core.types';
+import { AnyType, DirectiveIo, Type } from '../common/core.types';
 import decorateInputs from '../common/decorate.inputs';
 import funcDirectiveIoParse from '../common/func.directive-io-parse';
 import { isNgDef } from '../common/func.is-ng-def';
 import { isStandalone } from '../common/func.is-standalone';
+import { rememberTemplateOverrides } from '../common/ng-mocks-template-overrides';
 
 import funcInheritDefinition from './func.inherit-definition';
 
-const registerTemplateMiddleware = (template: AnyType<any>, meta: Directive): void => {
+const registerTemplateMiddleware = (template: Type<unknown>, meta: Directive): void => {
   const child = extendClass(template);
 
   const alias = {
@@ -56,6 +57,7 @@ const registerTemplateMiddleware = (template: AnyType<any>, meta: Directive): vo
     })(child);
   }
   funcInheritDefinition(child, template);
+  rememberTemplateOverrides(alias);
   TestBed.configureTestingModule({
     [isStandalone(child) ? 'imports' : 'declarations']: [child],
   });

--- a/tests/issue-14945/before-factory.spec.ts
+++ b/tests/issue-14945/before-factory.spec.ts
@@ -1,0 +1,126 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  host: { 'data-early-default': '' },
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class EarlyDefaultComponent {
+  @Input() public items: string[] = [];
+}
+
+@NgModule({
+  declarations: [EarlyDefaultComponent],
+  exports: [EarlyDefaultComponent],
+})
+class EarlyDefaultModule {}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { 'data-early-on-push': '' },
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class EarlyOnPushComponent {
+  @Input() public items: string[] = [];
+}
+
+@NgModule({
+  declarations: [EarlyOnPushComponent],
+  exports: [EarlyOnPushComponent],
+})
+class EarlyOnPushModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14945
+describe('issue-14945:before-factory', () => {
+  it('uses an OnPush override compiled before the selectorless factory is created', async () => {
+    await MockBuilder(EarlyDefaultComponent, EarlyDefaultModule);
+    TestBed.overrideComponent(EarlyDefaultComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.OnPush },
+    });
+    await TestBed.compileComponents();
+    const factory = MockRenderFactory(EarlyDefaultComponent, [
+      'items',
+    ]);
+
+    const parameters: { items: string[] } = { items: [] };
+    const items = parameters.items;
+    const fixture = factory(parameters);
+    const instance = fixture.point.componentInstance;
+
+    expect(instance.constructor).not.toBe(EarlyDefaultComponent);
+    expect(instance instanceof EarlyDefaultComponent).toBe(true);
+    expect(fixture.point.injector.get(EarlyDefaultComponent)).toBe(
+      instance,
+    );
+    expect(instance.items).toBe(items);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    fixture.componentInstance.items.push('first');
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(items);
+    expect(parameters.items).toBe(items);
+    expect(instance.items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    const replacement = ['first', 'second'];
+    fixture.componentInstance.items = replacement;
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(replacement);
+    expect(parameters.items).toBe(replacement);
+    expect(items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('2');
+  });
+
+  it('uses a Default override compiled before the selectorless factory is created', async () => {
+    await MockBuilder(EarlyOnPushComponent, EarlyOnPushModule);
+    TestBed.overrideComponent(EarlyOnPushComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.Default },
+    });
+    await TestBed.compileComponents();
+    const factory = MockRenderFactory(EarlyOnPushComponent, [
+      'items',
+    ]);
+
+    const parameters: { items: string[] } = { items: [] };
+    const items = parameters.items;
+    const fixture = factory(parameters);
+    const instance = fixture.point.componentInstance;
+
+    expect(instance.constructor).not.toBe(EarlyOnPushComponent);
+    expect(instance instanceof EarlyOnPushComponent).toBe(true);
+    expect(fixture.point.injector.get(EarlyOnPushComponent)).toBe(
+      instance,
+    );
+    expect(instance.items).toBe(items);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    fixture.componentInstance.items.push('first');
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(items);
+    expect(parameters.items).toBe(items);
+    expect(instance.items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('1');
+
+    const replacement = ['first', 'second'];
+    fixture.componentInstance.items = replacement;
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(replacement);
+    expect(parameters.items).toBe(replacement);
+    expect(items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('2');
+  });
+});

--- a/tests/issue-14945/selector.spec.ts
+++ b/tests/issue-14945/selector.spec.ts
@@ -1,0 +1,129 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'selector-default-14945',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class SelectorDefaultComponent {
+  @Input() public items: string[] = [];
+}
+
+@NgModule({
+  declarations: [SelectorDefaultComponent],
+  exports: [SelectorDefaultComponent],
+})
+class SelectorDefaultModule {}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'selector-on-push-14945',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class SelectorOnPushComponent {
+  @Input() public items: string[] = [];
+}
+
+@NgModule({
+  declarations: [SelectorOnPushComponent],
+  exports: [SelectorOnPushComponent],
+})
+class SelectorOnPushModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14945
+describe('issue-14945:selector', () => {
+  it('uses an OnPush override applied after the simple-selector factory is created', async () => {
+    await MockBuilder(
+      SelectorDefaultComponent,
+      SelectorDefaultModule,
+    );
+    const factory = MockRenderFactory(SelectorDefaultComponent, [
+      'items',
+    ]);
+
+    TestBed.overrideComponent(SelectorDefaultComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.OnPush },
+    });
+    await TestBed.compileComponents();
+
+    const parameters: { items: string[] } = { items: [] };
+    const items = parameters.items;
+    const fixture = factory(parameters);
+    const instance = fixture.point.componentInstance;
+
+    expect(instance.constructor).toBe(SelectorDefaultComponent);
+    expect(fixture.point.injector.get(SelectorDefaultComponent)).toBe(
+      instance,
+    );
+    expect(instance.items).toBe(items);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    fixture.componentInstance.items.push('first');
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(items);
+    expect(parameters.items).toBe(items);
+    expect(instance.items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    const replacement = ['first', 'second'];
+    fixture.componentInstance.items = replacement;
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(replacement);
+    expect(parameters.items).toBe(replacement);
+    expect(items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('2');
+  });
+
+  it('uses a Default override applied after the simple-selector factory is created', async () => {
+    await MockBuilder(SelectorOnPushComponent, SelectorOnPushModule);
+    const factory = MockRenderFactory(SelectorOnPushComponent, [
+      'items',
+    ]);
+
+    TestBed.overrideComponent(SelectorOnPushComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.Default },
+    });
+    await TestBed.compileComponents();
+
+    const parameters: { items: string[] } = { items: [] };
+    const items = parameters.items;
+    const fixture = factory(parameters);
+    const instance = fixture.point.componentInstance;
+
+    expect(instance.constructor).toBe(SelectorOnPushComponent);
+    expect(fixture.point.injector.get(SelectorOnPushComponent)).toBe(
+      instance,
+    );
+    expect(instance.items).toBe(items);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    fixture.componentInstance.items.push('first');
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(items);
+    expect(parameters.items).toBe(items);
+    expect(instance.items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('1');
+
+    const replacement = ['first', 'second'];
+    fixture.componentInstance.items = replacement;
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(replacement);
+    expect(parameters.items).toBe(replacement);
+    expect(items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('2');
+  });
+});

--- a/tests/issue-14945/test.spec.ts
+++ b/tests/issue-14945/test.spec.ts
@@ -1,0 +1,127 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockBuilder, MockRenderFactory, ngMocks } from 'ng-mocks';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  host: { 'data-late-default': '' },
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class LateDefaultComponent {
+  @Input() public items: string[] = [];
+}
+
+@NgModule({
+  declarations: [LateDefaultComponent],
+  exports: [LateDefaultComponent],
+})
+class LateDefaultModule {}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { 'data-late-on-push': '' },
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '{{ items.length }}',
+})
+class LateOnPushComponent {
+  @Input() public items: string[] = [];
+}
+
+@NgModule({
+  declarations: [LateOnPushComponent],
+  exports: [LateOnPushComponent],
+})
+class LateOnPushModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14945
+describe('issue-14945', () => {
+  it('uses an OnPush override applied after the selectorless factory is created', async () => {
+    await MockBuilder(LateDefaultComponent, LateDefaultModule);
+    const factory = MockRenderFactory(LateDefaultComponent, [
+      'items',
+    ]);
+
+    // The factory has already created a separately decorated middleware class.
+    TestBed.overrideComponent(LateDefaultComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.OnPush },
+    });
+    await TestBed.compileComponents();
+
+    const parameters: { items: string[] } = { items: [] };
+    const items = parameters.items;
+    const fixture = factory(parameters);
+    const instance = fixture.point.componentInstance;
+
+    expect(instance.constructor).not.toBe(LateDefaultComponent);
+    expect(instance instanceof LateDefaultComponent).toBe(true);
+    expect(fixture.point.injector.get(LateDefaultComponent)).toBe(
+      instance,
+    );
+    expect(instance.items).toBe(items);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    fixture.componentInstance.items.push('first');
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(items);
+    expect(parameters.items).toBe(items);
+    expect(instance.items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    const replacement = ['first', 'second'];
+    fixture.componentInstance.items = replacement;
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(replacement);
+    expect(parameters.items).toBe(replacement);
+    expect(items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('2');
+  });
+
+  it('uses a Default override applied after the selectorless factory is created', async () => {
+    await MockBuilder(LateOnPushComponent, LateOnPushModule);
+    const factory = MockRenderFactory(LateOnPushComponent, ['items']);
+
+    TestBed.overrideComponent(LateOnPushComponent, {
+      set: { changeDetection: ChangeDetectionStrategy.Default },
+    });
+    await TestBed.compileComponents();
+
+    const parameters: { items: string[] } = { items: [] };
+    const items = parameters.items;
+    const fixture = factory(parameters);
+    const instance = fixture.point.componentInstance;
+
+    expect(instance.constructor).not.toBe(LateOnPushComponent);
+    expect(instance instanceof LateOnPushComponent).toBe(true);
+    expect(fixture.point.injector.get(LateOnPushComponent)).toBe(
+      instance,
+    );
+    expect(instance.items).toBe(items);
+    expect(ngMocks.formatText(fixture)).toEqual('0');
+
+    fixture.componentInstance.items.push('first');
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(items);
+    expect(parameters.items).toBe(items);
+    expect(instance.items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('1');
+
+    const replacement = ['first', 'second'];
+    fixture.componentInstance.items = replacement;
+    fixture.detectChanges();
+
+    expect(instance.items).toBe(replacement);
+    expect(parameters.items).toBe(replacement);
+    expect(items).toEqual(['first']);
+    expect(ngMocks.formatText(fixture)).toEqual('2');
+  });
+});

--- a/tests/mock-render-metadata/overrides.spec.ts
+++ b/tests/mock-render-metadata/overrides.spec.ts
@@ -1,0 +1,256 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  Inject,
+  InjectionToken,
+  Input,
+  NgModule,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { MockRenderFactory, ngMocks } from 'ng-mocks';
+
+// Class instances retain provider identity when View Engine compiles metadata.
+class Value {
+  public constructor(public readonly label: string) {}
+}
+
+const COMPONENT = new InjectionToken<Value>('component provider');
+const VIEW = new InjectionToken<Value>('component view provider');
+const DIRECTIVE = new InjectionToken<Value>('directive provider');
+const componentValue = new Value('original provider');
+const viewValue = new Value('original view');
+const directiveValue = new Value('original directive');
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  host: {
+    'data-metadata-override-component': '',
+    '[attr.data-label]': 'label',
+    '(click)': 'originalClicks = originalClicks + 1',
+    role: 'button',
+  },
+  providers: [{ provide: COMPONENT, useValue: componentValue }],
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: 'original:{{ label }}:{{ local.label }}:{{ view.label }}',
+  viewProviders: [{ provide: VIEW, useValue: viewValue }],
+})
+class TargetComponent {
+  @Input() public label = '';
+  public originalClicks = 0;
+  public overrideClicks = 0;
+
+  public constructor(
+    @Inject(COMPONENT) public readonly local: Value,
+    @Inject(VIEW) public readonly view: Value,
+  ) {}
+}
+
+@NgModule({
+  declarations: [TargetComponent],
+  exports: [TargetComponent],
+})
+class ComponentModule {}
+
+@Directive({
+  host: {
+    '[attr.data-label]': 'label',
+    '(click)': 'originalClicks = originalClicks + 1',
+    role: 'button',
+  },
+  providers: [{ provide: DIRECTIVE, useValue: directiveValue }],
+  selector: '[metadataOverrideFirst], [metadataOverrideSecond]',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+})
+class TargetDirective {
+  @Input() public label = '';
+  public originalClicks = 0;
+  public overrideClicks = 0;
+
+  public constructor(
+    @Inject(DIRECTIVE) public readonly local: Value,
+  ) {}
+}
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.Default,
+  selector: 'metadata-override-directive-host',
+  ['standalone' as never /* TODO: remove after upgrade to a14 */]: false,
+  template: '<div metadataOverrideFirst [label]="label"></div>',
+})
+class DirectiveHostComponent {
+  public label = 'restored';
+}
+
+@NgModule({
+  declarations: [TargetDirective, DirectiveHostComponent],
+  exports: [TargetDirective],
+})
+class DirectiveModule {}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14945
+describe('mock-render-metadata:overrides', () => {
+  it('uses late component overrides and leaves the original metadata reusable', async () => {
+    TestBed.configureTestingModule({ imports: [ComponentModule] });
+    const factory = MockRenderFactory(TargetComponent, ['label']);
+    const configuredValue = new Value('configured provider');
+    const configuredView = new Value('configured view');
+
+    // The override targets the original after its render subtype was created.
+    TestBed.overrideComponent(TargetComponent, {
+      set: {
+        host: {
+          '[attr.data-label]': 'label',
+          '(click)': 'overrideClicks = overrideClicks + 1',
+          role: 'presentation',
+        },
+        providers: [
+          { provide: COMPONENT, useValue: configuredValue },
+        ],
+        template:
+          'override:{{ label }}:{{ local.label }}:{{ view.label }}',
+        viewProviders: [{ provide: VIEW, useValue: configuredView }],
+      },
+    });
+    await TestBed.compileComponents();
+
+    const fixture = factory({ label: 'bound' });
+    const target = fixture.point.componentInstance;
+    const element = fixture.point.nativeElement;
+    fixture.detectChanges();
+
+    expect(target.constructor).not.toBe(TargetComponent);
+    expect(target instanceof TargetComponent).toBe(true);
+    expect(fixture.point.injector.get(TargetComponent)).toBe(target);
+    expect(target.local).toBe(configuredValue);
+    expect(target.view).toBe(configuredView);
+    expect(fixture.point.injector.get(COMPONENT)).toBe(
+      configuredValue,
+    );
+    expect(fixture.point.injector.get(VIEW)).toBe(configuredView);
+    expect(ngMocks.formatText(fixture)).toBe(
+      'override:bound:configured provider:configured view',
+    );
+    expect(element.getAttribute('role')).toBe('presentation');
+    expect(element.dataset.label).toBe('bound');
+
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+
+    expect(target.overrideClicks).toBe(1);
+    expect(target.originalClicks).toBe(0);
+
+    fixture.componentInstance.label = 'updated';
+    fixture.detectChanges();
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+
+    expect(ngMocks.formatText(fixture)).toBe(
+      'override:updated:configured provider:configured view',
+    );
+    expect(element.dataset.label).toBe('updated');
+    expect(target.overrideClicks).toBe(2);
+    expect(target.originalClicks).toBe(0);
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ComponentModule],
+    }).compileComponents();
+    const originalFixture = TestBed.createComponent(TargetComponent);
+    const original = originalFixture.componentInstance;
+    original.label = 'restored';
+    originalFixture.detectChanges();
+    originalFixture.debugElement.triggerEventHandler('click', {
+      type: 'click',
+    });
+
+    expect(original.constructor).toBe(TargetComponent);
+    expect(original.local).toBe(componentValue);
+    expect(original.view).toBe(viewValue);
+    expect(ngMocks.formatText(originalFixture)).toBe(
+      'original:restored:original provider:original view',
+    );
+    expect(originalFixture.nativeElement.getAttribute('role')).toBe(
+      'button',
+    );
+    expect(originalFixture.nativeElement.dataset.label).toBe(
+      'restored',
+    );
+    expect(original.originalClicks).toBe(1);
+    expect(original.overrideClicks).toBe(0);
+  });
+
+  it('uses late directive overrides and leaves the original metadata reusable', async () => {
+    TestBed.configureTestingModule({ imports: [DirectiveModule] });
+    const factory = MockRenderFactory(TargetDirective, ['label']);
+    const configuredValue = new Value('configured directive');
+
+    TestBed.overrideDirective(TargetDirective, {
+      set: {
+        host: {
+          '[attr.data-label]': 'label',
+          '(click)': 'overrideClicks = overrideClicks + 1',
+          role: 'link',
+        },
+        providers: [
+          { provide: DIRECTIVE, useValue: configuredValue },
+        ],
+      },
+    });
+    await TestBed.compileComponents();
+
+    const fixture = factory({ label: 'bound' });
+    const target = fixture.point.componentInstance;
+    const element = fixture.point.nativeElement;
+    fixture.detectChanges();
+
+    expect(target.constructor).not.toBe(TargetDirective);
+    expect(target instanceof TargetDirective).toBe(true);
+    expect(fixture.point.injector.get(TargetDirective)).toBe(target);
+    expect(target.local).toBe(configuredValue);
+    expect(fixture.point.injector.get(DIRECTIVE)).toBe(
+      configuredValue,
+    );
+    expect(element.getAttribute('role')).toBe('link');
+    expect(element.dataset.label).toBe('bound');
+
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+
+    expect(target.overrideClicks).toBe(1);
+    expect(target.originalClicks).toBe(0);
+
+    fixture.componentInstance.label = 'updated';
+    fixture.detectChanges();
+    fixture.point.triggerEventHandler('click', { type: 'click' });
+
+    expect(target.label).toBe('updated');
+    expect(element.dataset.label).toBe('updated');
+    expect(target.overrideClicks).toBe(2);
+    expect(target.originalClicks).toBe(0);
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [DirectiveModule],
+    }).compileComponents();
+    const originalFixture = TestBed.createComponent(
+      DirectiveHostComponent,
+    );
+    originalFixture.detectChanges();
+    const originalElement = ngMocks.find(
+      originalFixture,
+      '[metadataOverrideFirst]',
+    );
+    const original = ngMocks.get(originalElement, TargetDirective);
+    originalElement.triggerEventHandler('click', { type: 'click' });
+
+    expect(original.constructor).toBe(TargetDirective);
+    expect(original.local).toBe(directiveValue);
+    expect(originalElement.nativeElement.getAttribute('role')).toBe(
+      'button',
+    );
+    expect(originalElement.nativeElement.dataset.label).toBe(
+      'restored',
+    );
+    expect(original.originalClicks).toBe(1);
+    expect(original.overrideClicks).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

Selectorless components and directives with complex selectors use separately decorated render middleware. Direct TestBed overrides target the original declaration, leaving the middleware with copied metadata. This loses early and late change-detection overrides in View Engine and also affects component templates, providers, view providers, and directive providers.

## What

- Forward accepted component and directive overrides to active middleware through Angular's native metadata override handling, preserving operation order, generated selectors, and injection aliases.
- Restore the existing inheritance handling after Ivy recompiles middleware, keeping host listeners and bindings from being applied twice. Clear override tracking with the normal TestBed reset.
- Cover both strategy directions before and after factory creation, simple-selector controls, component and directive metadata, ordered provider additions/removals, provider clearing, and reuse of the original declarations after reset.

## Impact

Existing TestBed overrides affect MockRender middleware across the supported rendering engines while original annotations, input references, provider identities, and listener behavior remain intact. The fix restores expected behavior, so public documentation is unchanged.

Fixes #14945
