### PR TITLE
docs(signal-forms): separate retained CVA validation guide #14986

### DIFF
--- a/docs/articles/guides/signal-forms.md
+++ b/docs/articles/guides/signal-forms.md
@@ -373,6 +373,146 @@ describe('TestSignalForms:cva', () => {
 });
 ```
 
+## Keep a CVA child's validation rule
+
+In Angular 22, `FormField` also integrates synchronous validators provided through
+`NG_VALIDATORS` on a CVA control. Keep the child when the test needs its real `validate()`
+implementation. Keeping only `FormField` still leaves the standalone component's child
+imports mocked.
+
+This control rejects the value `invalid`. It provides both `NG_VALUE_ACCESSOR` and
+`NG_VALIDATORS`, and reads the current value from the control passed to `validate()`:
+
+```ts
+import { Component, forwardRef, signal } from '@angular/core';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ValidationErrors,
+  Validator,
+} from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
+
+@Component({
+  selector: 'validated-name-control',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CvaComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => CvaComponent),
+      multi: true,
+    },
+  ],
+  template: `
+    <input
+      [value]="value"
+      (input)="value = $any($event.target).value; onChange(value)"
+      (blur)="onTouched()"
+    />
+  `,
+})
+class CvaComponent implements ControlValueAccessor, Validator {
+  public value = '';
+  public onChange: (value: string) => void = () => undefined;
+  public onTouched: () => void = () => undefined;
+
+  public writeValue(value: string): void {
+    this.value = value;
+  }
+
+  public registerOnChange(callback: (value: string) => void): void {
+    this.onChange = callback;
+  }
+
+  public registerOnTouched(callback: () => void): void {
+    this.onTouched = callback;
+  }
+
+  public validate(control: AbstractControl): ValidationErrors | null {
+    return control.value === 'invalid' ? { custom: true } : null;
+  }
+}
+
+@Component({
+  selector: 'target-signal-forms-cva-validator',
+  imports: [FormField, CvaComponent],
+  template: '<validated-name-control [formField]="f.name" />',
+})
+class TargetComponent {
+  public readonly model = signal({ name: 'invalid' });
+  public readonly f = form(this.model);
+}
+```
+
+Angular converts each returned `ValidationErrors` key into a signal-form error's `kind`.
+Here `{ custom: true }` produces `kind: 'custom'`. Returning `null` clears that error.
+The test checks the field's errors and the form's aggregate validity, then edits the
+retained child's native input to exercise its real template and CVA callback.
+
+- [Try it on CodeSandbox](https://codesandbox.io/p/sandbox/github/help-me-mom/ng-mocks-sandbox/tree/tests/?file=/src/examples/TestSignalForms/cva-validator.spec.ts&initialpath=%3Fspec%3DTestSignalForms%3Acva-validator)
+- [Try it on StackBlitz](https://stackblitz.com/github/help-me-mom/ng-mocks-sandbox/tree/tests?file=src/examples/TestSignalForms/cva-validator.spec.ts&initialpath=%3Fspec%3DTestSignalForms%3Acva-validator)
+
+```ts title="https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestSignalForms/cva-validator.spec.ts"
+import { MockBuilder, MockInstance, MockRender, NG_MOCKS_ROOT_PROVIDERS, ngMocks } from 'ng-mocks';
+
+describe('TestSignalForms:cva-validator', () => {
+  beforeEach(() =>
+    MockBuilder(TargetComponent)
+      .keep(FormField)
+      .keep(NG_MOCKS_ROOT_PROVIDERS)
+      .keep(CvaComponent),
+  );
+
+  it('maps the real validator error to field state and clears it after an edit', () => {
+    const fixture = MockRender(TargetComponent);
+    const component = fixture.point.componentInstance;
+    const child = ngMocks.find(CvaComponent);
+    const control = ngMocks.get(child, CvaComponent);
+    const input = ngMocks.find<HTMLInputElement>(child, 'input');
+
+    expect(ngMocks.get(child, NG_VALIDATORS)).toEqual([control]);
+    expect(control.value).toBe('invalid');
+    expect(input.nativeElement.value).toBe('invalid');
+    expect(component.f.name().errors().map(error => error.kind)).toEqual(['custom']);
+    expect(component.f.name().invalid()).toBe(true);
+    expect(component.f().invalid()).toBe(true);
+
+    ngMocks.change(input, 'Ada');
+    fixture.detectChanges();
+
+    expect(component.model()).toEqual({ name: 'Ada' });
+    expect(control.value).toBe('Ada');
+    expect(input.nativeElement.value).toBe('Ada');
+    expect(component.f.name().errors()).toEqual([]);
+    expect(component.f.name().valid()).toBe(true);
+    expect(component.f().valid()).toBe(true);
+  });
+});
+```
+
+Using `.mock(CvaComponent)` replaces the child's validation rule along with its other
+methods. The default mock does not reject `invalid`. To test the parent's response to a
+controlled error, use `MockInstance.scope()` in the suite and customize the mock's
+`validate` method **before** `MockRender`:
+
+```ts
+MockInstance(CvaComponent, 'validate', () => ({ controlled: true }));
+const fixture = MockRender(TargetComponent);
+const component = fixture.point.componentInstance;
+
+expect(component.f.name().errors().map(error => error.kind)).toEqual(['controlled']);
+expect(component.f().invalid()).toBe(true);
+```
+
+The complete spec includes both mock cases. Use the retained child to test its validation
+rule, and the controlled mock result when that rule is outside the parent's test scope.
+
 ## Test a form with a mocked signal control
 
 A `FormValueControl` uses a `value` model to exchange values with `FormField`.
@@ -485,4 +625,5 @@ describe('TestSignalForms:model', () => {
 - [Native fields, validation, and model updates](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestSignalForms/test.spec.ts)
 - [Field trees passed through custom templates](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestSignalForms/field-tree.spec.ts)
 - [Signal form with a mocked CVA child](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestSignalForms/cva.spec.ts)
+- [Signal form with a retained CVA validator](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestSignalForms/cva-validator.spec.ts)
 - [Signal form with a mocked model-based child](https://github.com/help-me-mom/ng-mocks/blob/main/examples/TestSignalForms/model.spec.ts)

--- a/examples/TestSignalForms/cva-validator.spec.ts
+++ b/examples/TestSignalForms/cva-validator.spec.ts
@@ -1,0 +1,152 @@
+import { Component, forwardRef, signal } from '@angular/core';
+import {
+  AbstractControl,
+  ControlValueAccessor,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ValidationErrors,
+  Validator,
+} from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
+
+import {
+  MockBuilder,
+  MockInstance,
+  MockRender,
+  NG_MOCKS_ROOT_PROVIDERS,
+  ngMocks,
+} from 'ng-mocks';
+
+@Component({
+  selector: 'validated-name-control',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CvaComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => CvaComponent),
+      multi: true,
+    },
+  ],
+  template: `
+    <input
+      [value]="value"
+      (input)="value = $any($event.target).value; onChange(value)"
+      (blur)="onTouched()"
+    />
+  `,
+})
+class CvaComponent implements ControlValueAccessor, Validator {
+  public value = '';
+  public onChange: (value: string) => void = () => undefined;
+  public onTouched: () => void = () => undefined;
+
+  public writeValue(value: string): void {
+    this.value = value;
+  }
+
+  public registerOnChange(callback: (value: string) => void): void {
+    this.onChange = callback;
+  }
+
+  public registerOnTouched(callback: () => void): void {
+    this.onTouched = callback;
+  }
+
+  public validate(control: AbstractControl): ValidationErrors | null {
+    return control.value === 'invalid' ? { custom: true } : null;
+  }
+}
+
+@Component({
+  selector: 'target-signal-forms-cva-validator',
+  imports: [FormField, CvaComponent],
+  template: '<validated-name-control [formField]="f.name" />',
+})
+class TargetComponent {
+  public readonly model = signal({ name: 'invalid' });
+  public readonly f = form(this.model);
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14986
+describe('TestSignalForms:cva-validator', () => {
+  MockInstance.scope();
+
+  describe('retained validator', () => {
+    beforeEach(() =>
+      MockBuilder(TargetComponent)
+        .keep(FormField)
+        .keep(NG_MOCKS_ROOT_PROVIDERS)
+        .keep(CvaComponent),
+    );
+
+    it('maps the real validator error to field state and clears it after an edit', () => {
+      const fixture = MockRender(TargetComponent);
+      const component = fixture.point.componentInstance;
+      const child = ngMocks.find(CvaComponent);
+      const control = ngMocks.get(child, CvaComponent);
+      const input = ngMocks.find<HTMLInputElement>(child, 'input');
+
+      expect(ngMocks.get(child, NG_VALIDATORS)).toEqual([control]);
+      expect(control.value).toBe('invalid');
+      expect(input.nativeElement.value).toBe('invalid');
+      // Angular 22 converts each legacy ValidationErrors key to an error kind.
+      expect(
+        component.f
+          .name()
+          .errors()
+          .map(error => error.kind),
+      ).toEqual(['custom']);
+      expect(component.f.name().invalid()).toBe(true);
+      expect(component.f().invalid()).toBe(true);
+
+      // Exercise the retained child's input and registered CVA callback.
+      ngMocks.change(input, 'Ada');
+      fixture.detectChanges();
+
+      expect(component.model()).toEqual({ name: 'Ada' });
+      expect(control.value).toBe('Ada');
+      expect(input.nativeElement.value).toBe('Ada');
+      expect(component.f.name().errors()).toEqual([]);
+      expect(component.f.name().valid()).toBe(true);
+      expect(component.f().valid()).toBe(true);
+    });
+  });
+
+  describe('mocked validator', () => {
+    beforeEach(() =>
+      MockBuilder(TargetComponent)
+        .keep(FormField)
+        .keep(NG_MOCKS_ROOT_PROVIDERS)
+        .mock(CvaComponent),
+    );
+
+    it('does not run the original validation rule on a mocked child', () => {
+      const fixture = MockRender(TargetComponent);
+      const component = fixture.point.componentInstance;
+
+      expect(component.model()).toEqual({ name: 'invalid' });
+      expect(component.f.name().errors()).toEqual([]);
+      expect(component.f().valid()).toBe(true);
+    });
+
+    it('uses a controlled validation result supplied before rendering', () => {
+      MockInstance(CvaComponent, 'validate', () => ({
+        controlled: true,
+      }));
+      const fixture = MockRender(TargetComponent);
+      const component = fixture.point.componentInstance;
+
+      expect(
+        component.f
+          .name()
+          .errors()
+          .map(error => error.kind),
+      ).toEqual(['controlled']);
+      expect(component.f().invalid()).toBe(true);
+    });
+  });
+});

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -111,6 +111,7 @@ file|tests/issue-14914/nonconfigurable.spec.ts|features=ivy
 file|tests/issue-14909/test.spec.ts|features=signalForms
 file|tests/issue-14911/standalone.spec.ts|features=standalone
 file|tests/issue-14911/host-directives.spec.ts|features=hostDirectives
+file|examples/TestSignalForms/cva-validator.spec.ts|versions=22+
 file|examples/TestSignalForms/model.spec.ts|versions=22+
 file|examples/TestSignalForms/*.spec.ts|features=signalForms
 file|tests/ng-mocks-change/signal-forms.spec.ts|features=signalForms


### PR DESCRIPTION
## Why

#14925 asks how a retained ControlValueAccessor child's `validate()` result reaches signal-form errors. The basic form guides cover finding, reading, and changing values, but do not demonstrate that validation connection. Keeping `FormField` alone still mocks the imported child, so its original `NG_VALIDATORS` rule is not exercised.

## What

- Add a focused guide under How to test for CVA validation with signal forms in Angular 22.
- Show a retained child's `{ custom: true }` error becoming a signal-field error with kind `custom`, then clearing after editing its input.
- Compare the default mocked child with a controlled `MockInstance` validation result.
- Include the complete executable example, source and sandbox links, and the Angular 22 example gate.

## Impact

Readers can test the real child's validation rule or control its result in a parent test. Keeping `FormField` is intentional: Angular's real field connection performs the validation. The mocked-binding value and touch support added in #15038 does not replace that connection.

The basic signal-forms guide stays focused on ordinary field interactions. This PR changes documentation and examples without changing library behavior.

Closes #14986.
Related to #14925.
Follow-up to #14991.
