### PR TITLE
test(MockInstance): protect published deprecation metadata #14921

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -240,6 +240,8 @@ export default defineConfig([
       'tests-e2e/.angular/**',
       'tests-e2e/dist/**',
       'tests-failures/**',
+      // Declaration consumers are checked by build:types after both bundles exist.
+      'tests-types/issue-14921/*.ts',
       'tmp/**',
       '**/*.sh',
       '**/*.snap',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run clean && npm run build:webpack && npm run build:types && cp CHANGELOG.md dist/libs/ng-mocks && cp README.md dist/libs/ng-mocks && cp LICENSE dist/libs/ng-mocks && cp libs/ng-mocks/package.json dist/libs/ng-mocks/package.json && cp libs/ng-mocks/migrations.json dist/libs/ng-mocks/migrations.json && cp examples/main/test.spec.ts dist/libs/ng-mocks/example.spec.ts",
     "build:dev": "MODE=development npm run build",
     "build:webpack": "webpack",
-    "build:types": "npm run build:types:legacy && npm run build:types:modern",
+    "build:types": "npm run build:types:legacy && npm run build:types:modern && tsc -p tests-types/issue-14921/tsconfig.json && eslint --config tests-types/issue-14921/eslint.consumer.config.mjs tests-types/issue-14921/*.ts",
     "build:types:legacy": "dts-bundle-generator --no-banner -o ./dist/libs/ng-mocks/index.d.ts --project ./libs/ng-mocks/tsconfig.build.types.json --no-check --export-referenced-types=true ./libs/ng-mocks/src/index.d.ts",
     "build:types:modern": "dts-bundle-generator --no-banner -o ./dist/libs/ng-mocks/index.modern.d.ts --project ./libs/ng-mocks/tsconfig.build.types.json --no-check --export-referenced-types=true ./libs/ng-mocks/src/index.modern.d.ts",
     "build:all": "npm run lint && npm run build && npm run test",

--- a/tests-types/issue-14921/eslint.consumer.config.mjs
+++ b/tests-types/issue-14921/eslint.consumer.config.mjs
@@ -1,0 +1,24 @@
+import tsEslintPlugin from '@typescript-eslint/eslint-plugin';
+import tsEslintParser from '@typescript-eslint/parser';
+import { defineConfig } from 'eslint/config';
+
+export default defineConfig([
+  {
+    files: ['tests-types/issue-14921/*.ts'],
+    languageOptions: {
+      parser: tsEslintParser,
+      parserOptions: {
+        project: './tests-types/issue-14921/tsconfig.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsEslintPlugin,
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+    rules: {
+      '@typescript-eslint/no-deprecated': 'error',
+    },
+  },
+]);

--- a/tests-types/issue-14921/legacy.ts
+++ b/tests-types/issue-14921/legacy.ts
@@ -1,0 +1,73 @@
+import { InjectionToken, Injector } from '@angular/core';
+
+import { MockInstance, MockInstanceClassConfig, MockInstanceTokenConfig } from '../../dist/libs/ng-mocks/index';
+
+/** @see https://github.com/help-me-mom/ng-mocks/issues/14921 */
+class TargetService {
+  public name = '';
+
+  public update(value: number): string {
+    return String(value);
+  }
+}
+
+const token = new InjectionToken<TargetService>('target');
+
+// Deprecating a function overload must not contaminate its merged namespace.
+MockInstance.scope();
+MockInstance.scope('case');
+MockInstance.scope('suite');
+MockInstance.scope('all');
+MockInstance.remember();
+MockInstance.restore();
+MockInstance(TargetService);
+MockInstance(token);
+
+MockInstance(TargetService, (instance, injector) => {
+  const service: TargetService = instance;
+  const source: Injector | undefined = injector;
+  service.name = source ? source.get(token).name : 'mock';
+});
+MockInstance(TargetService, () => ({ name: 'mock' }));
+MockInstance(token, (instance, injector) => {
+  const service: TargetService | undefined = instance;
+  const source: Injector | undefined = injector;
+  // @ts-expect-error The token instance can be undefined.
+  instance.name;
+
+  return { name: service?.name ?? source?.get(token).name ?? 'mock' };
+});
+
+export const property: 'mock' = MockInstance(TargetService, 'name', 'mock');
+export const method: (value: number) => string = MockInstance(TargetService, 'update', value => String(value));
+export const getter: () => string = MockInstance(TargetService, 'name', () => 'mock', 'get');
+// @ts-expect-error The returned method retains its numeric parameter type.
+MockInstance(TargetService, 'update', value => String(value))(false);
+// @ts-expect-error The returned getter retains its string result type.
+MockInstance(TargetService, 'name', () => 'mock', 'get')().toFixed();
+export const setter: (value: string) => void = MockInstance(
+  TargetService,
+  'name',
+  value => {
+    const name: string = value;
+    MockInstance(TargetService, 'name', name);
+  },
+  'set',
+);
+
+const classConfig: MockInstanceClassConfig<TargetService> = {
+  init: instance => {
+    instance.name = 'mock';
+  },
+};
+const tokenConfig: MockInstanceTokenConfig<TargetService> = {
+  init: () => ({ name: 'mock' }),
+};
+MockInstance(TargetService, classConfig);
+MockInstance(token, tokenConfig);
+
+// Object-literal keys are declarations; read the members to verify their deprecation.
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- The legacy init member must remain deprecated.
+MockInstance(TargetService, classConfig.init);
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- The token init member must remain deprecated.
+MockInstance(token, tokenConfig.init);

--- a/tests-types/issue-14921/modern.ts
+++ b/tests-types/issue-14921/modern.ts
@@ -1,0 +1,73 @@
+import { InjectionToken, Injector } from '@angular/core';
+
+import { MockInstance, MockInstanceClassConfig, MockInstanceTokenConfig } from '../../dist/libs/ng-mocks/index.modern';
+
+/** @see https://github.com/help-me-mom/ng-mocks/issues/14921 */
+class TargetService {
+  public name = '';
+
+  public update(value: number): string {
+    return String(value);
+  }
+}
+
+const token = new InjectionToken<TargetService>('target');
+
+// Deprecating a function overload must not contaminate its merged namespace.
+MockInstance.scope();
+MockInstance.scope('case');
+MockInstance.scope('suite');
+MockInstance.scope('all');
+MockInstance.remember();
+MockInstance.restore();
+MockInstance(TargetService);
+MockInstance(token);
+
+MockInstance(TargetService, (instance, injector) => {
+  const service: TargetService = instance;
+  const source: Injector | undefined = injector;
+  service.name = source ? source.get(token).name : 'mock';
+});
+MockInstance(TargetService, () => ({ name: 'mock' }));
+MockInstance(token, (instance, injector) => {
+  const service: TargetService | undefined = instance;
+  const source: Injector | undefined = injector;
+  // @ts-expect-error The token instance can be undefined.
+  instance.name;
+
+  return { name: service?.name ?? source?.get(token).name ?? 'mock' };
+});
+
+export const property: 'mock' = MockInstance(TargetService, 'name', 'mock');
+export const method: (value: number) => string = MockInstance(TargetService, 'update', value => String(value));
+export const getter: () => string = MockInstance(TargetService, 'name', () => 'mock', 'get');
+// @ts-expect-error The returned method retains its numeric parameter type.
+MockInstance(TargetService, 'update', value => String(value))(false);
+// @ts-expect-error The returned getter retains its string result type.
+MockInstance(TargetService, 'name', () => 'mock', 'get')().toFixed();
+export const setter: (value: string) => void = MockInstance(
+  TargetService,
+  'name',
+  value => {
+    const name: string = value;
+    MockInstance(TargetService, 'name', name);
+  },
+  'set',
+);
+
+const classConfig: MockInstanceClassConfig<TargetService> = {
+  init: instance => {
+    instance.name = 'mock';
+  },
+};
+const tokenConfig: MockInstanceTokenConfig<TargetService> = {
+  init: () => ({ name: 'mock' }),
+};
+MockInstance(TargetService, classConfig);
+MockInstance(token, tokenConfig);
+
+// Object-literal keys are declarations; read the members to verify their deprecation.
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- The legacy init member must remain deprecated.
+MockInstance(TargetService, classConfig.init);
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- The token init member must remain deprecated.
+MockInstance(token, tokenConfig.init);

--- a/tests-types/issue-14921/tsconfig.json
+++ b/tests-types/issue-14921/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": [],
+    "noEmit": true
+  },
+  "files": ["legacy.ts", "modern.ts"]
+}


### PR DESCRIPTION
## Why

The original fix in #13306 moved deprecation annotations from `MockInstance` overloads to the legacy configuration's `init` members. Runtime tests and ordinary TypeScript compilation do not detect false deprecation warnings on the merged function and namespace API.

## What

Add type-aware consumers of both emitted declaration bundles to the existing declaration build. They cover scope management, class and token callbacks, property and method customization, and getter/setter overloads, with inferred-type controls. Narrow expected warnings on the legacy `init` members also fail if those annotations disappear.

## Impact

Protect the published annotation contract without changing runtime behavior, public APIs, dependencies, or documentation.

Fixes #14921
