### PR TITLE
docs(forms): clarify signal field parameters and touch behavior #14988

### DIFF
--- a/docs/articles/api/ngMocks/change.md
+++ b/docs/articles/api/ngMocks/change.md
@@ -46,7 +46,25 @@ ngMocks.change(['data-testid', 'inputControl'], 123);
 
 Profit!
 
-It supports both `FormsModule` and `ReactiveFormsModule`.
+It supports `FormsModule`, `ReactiveFormsModule`, and [signal forms](/guides/signal-forms.md).
+Supported hosts include native `input`, `textarea`, and `select` elements with `[formField]`,
+and real or mocked `ControlValueAccessor`, `FormValueControl`, and `FormCheckboxControl` components.
 
-Calling `ngMocks.change` also simulates that the user removes focus from the element by triggering a **blur** event. 
-If testing form changes in combination with blur events, it is therefore not necessary to call [`ngMocks.trigger`](trigger.md) after `ngMocks.change`.
+Changing a value and marking a field touched are separate interactions. Whether
+`ngMocks.change` also triggers a **blur** event depends on the selected control:
+
+| Selected control | Blur and touched behavior |
+| --- | --- |
+| Native form element | Includes blur. Touched state follows the real form binding and its update policy. |
+| Real CVA with input/change event handlers on the selected element | Includes blur. The blur handler must report the touch to the form binding. |
+| Real CVA using its registered change callback | Invokes the registered change callback without blur or touch. Use `ngMocks.touch` for a separate touch interaction. |
+| Mocked CVA | Includes host blur, but does not call the CVA touch callback. Use `ngMocks.touch` to invoke that callback. |
+| Real or mocked `FormValueControl` / `FormCheckboxControl` | Emits `valueChange` or `checkedChange` without blur or touch. Use `ngMocks.touch` when the control exposes a touch output. |
+
+For classic controls with `updateOn: 'submit'`, a reported touch remains pending until form submission.
+
+When the change already includes blur, another [`ngMocks.trigger`](trigger.md) call is
+unnecessary to exercise that blur handler. A dispatched blur event alone does not guarantee
+that a custom field becomes touched, and it does not move actual browser focus.
+See [`ngMocks.touch`](touch.md) for separate touch interactions and the
+[signal-forms guide](/guides/signal-forms.md) for native, CVA, and signal-control examples.

--- a/docs/articles/api/ngMocks/touch.md
+++ b/docs/articles/api/ngMocks/touch.md
@@ -23,7 +23,7 @@ Then solution may look like that:
 const el = ngMocks.find(['data-testid', 'inputControl']);
 
 // simulating touch
-ngMocks.touch(valueAccessorEl);
+ngMocks.touch(el);
 
 // asserting
 expect(component.myControl.touched).toEqual(true);
@@ -38,3 +38,15 @@ ngMocks.touch('[data-testid="inputControl"]');
 ```
 
 Profit!
+
+`ngMocks.touch` simulates a separate touch interaction without supplying a new value.
+It can exercise a native blur handler, a CVA touch callback, or a signal control's touch output.
+For `FormValueControl` and `FormCheckboxControl`, the control must expose `touch` in Angular 22.
+Angular 21 uses the `touched` model's implicit `touchedChange` output instead.
+See the [Angular 22 example](/guides/signal-forms.md#test-a-form-with-a-mocked-signal-control)
+for the `touch` output and resulting field state.
+
+For a real CVA with focus or blur handlers on the selected element, those handlers
+must report the touch to the form. Otherwise, `ngMocks.touch` can trigger blur while the field
+remains untouched. Select the control's interactive element whose blur handler reports touch;
+another call does not supply missing touch handling.

--- a/docs/articles/guides/signal-forms.md
+++ b/docs/articles/guides/signal-forms.md
@@ -252,6 +252,11 @@ detect and wire the accessor when it creates the mock.
 See [form control definitions](/extra/mock-form-controls.md#caution-about-controlvalueaccessor)
 for why function-valued properties do not work for this API.
 
+On a mocked CVA host, `ngMocks.change` also dispatches a DOM blur event, but does not
+invoke the registered touch callback. Use `ngMocks.touch` for that separate interaction.
+The [change API](/api/ngMocks/change.md) explains how blur and touched behavior differ
+for native elements and real custom controls.
+
 ```ts
 import { Component, forwardRef, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';

--- a/test-spread.conf
+++ b/test-spread.conf
@@ -118,6 +118,7 @@ file|examples/TestSignalForms/model.spec.ts|versions=22+
 file|examples/TestSignalForms/*.spec.ts|features=signalForms
 file|tests/ng-mocks-change/signal-forms.spec.ts|features=signalForms
 file|tests/ng-mocks-change/signal-native.spec.ts|features=signalForms
+file|tests/ng-mocks-change/signal-cva-events.spec.ts|features=signalForms
 file|tests/ng-mocks-change/signal-model-controls.spec.ts|features=signalForms
 file|tests/ng-mocks-change/signal-model-controls-touch-v21.spec.ts|versions=21
 file|tests/ng-mocks-change/signal-model-controls-touch-v22.spec.ts|versions=22+

--- a/tests/ng-mocks-change/signal-cva-events.spec.ts
+++ b/tests/ng-mocks-change/signal-cva-events.spec.ts
@@ -1,0 +1,204 @@
+import { Component, forwardRef, signal } from '@angular/core';
+import {
+  ControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+} from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
+
+import {
+  MockBuilder,
+  MockRender,
+  NG_MOCKS_ROOT_PROVIDERS,
+  ngMocks,
+} from 'ng-mocks';
+
+@Component({
+  selector: 'cva-signal-events',
+  template: '{{ value }}',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CvaComponent),
+      multi: true,
+    },
+  ],
+})
+class CvaComponent implements ControlValueAccessor {
+  public value = '';
+  public onChange: (value: string) => void = () => undefined;
+  public onTouched: () => void = () => undefined;
+
+  public writeValue(value: string): void {
+    this.value = value;
+  }
+
+  public registerOnChange(callback: (value: string) => void): void {
+    this.onChange = callback;
+  }
+
+  public registerOnTouched(callback: () => void): void {
+    this.onTouched = callback;
+  }
+}
+
+@Component({
+  selector: 'target-signal-cva-events',
+  imports: [FormField, CvaComponent],
+  template: `
+    <cva-signal-events class="callback" [formField]="f.callback" />
+    <cva-signal-events
+      #withTouch
+      class="with-touch"
+      [formField]="f.withTouch"
+      (input)="
+        withTouch.value = $any($event.target).value;
+        withTouch.onChange(withTouch.value)
+      "
+      (blur)="withTouch.onTouched()"
+    />
+    <cva-signal-events
+      #withoutTouch
+      class="without-touch"
+      [formField]="f.withoutTouch"
+      (input)="
+        withoutTouch.value = $any($event.target).value;
+        withoutTouch.onChange(withoutTouch.value)
+      "
+      (blur)="blurCount = blurCount + 1"
+    />
+  `,
+})
+class TargetComponent {
+  public readonly model = signal({
+    callback: 'Ada',
+    withTouch: 'Grace',
+    withoutTouch: 'Katherine',
+  });
+  public readonly f = form(this.model);
+  public blurCount = 0;
+}
+
+// @see https://github.com/help-me-mom/ng-mocks/issues/14988
+describe('ng-mocks-change:signal-cva-events', () => {
+  for (const mode of ['real', 'mock']) {
+    describe(`${mode} callback control`, () => {
+      beforeEach(() => {
+        const builder = MockBuilder(TargetComponent)
+          .keep(FormField)
+          .keep(NG_MOCKS_ROOT_PROVIDERS);
+
+        return mode === 'real'
+          ? builder.keep(CvaComponent)
+          : builder.mock(CvaComponent);
+      });
+
+      it('keeps the change and touch callbacks separate from host blur', () => {
+        const fixture = MockRender(TargetComponent);
+        const component = fixture.point.componentInstance;
+        const child = ngMocks.find('.callback');
+        const blurs: string[] = [];
+        // Observe DOM events without adding Angular host event handling.
+        child.nativeElement.addEventListener('blur', () =>
+          blurs.push('blur'),
+        );
+
+        ngMocks.change(child, 'Updated');
+        fixture.detectChanges();
+
+        expect(component.model()).toEqual({
+          callback: 'Updated',
+          withTouch: 'Grace',
+          withoutTouch: 'Katherine',
+        });
+        expect(component.f.callback().dirty()).toBe(true);
+        expect(component.f.callback().touched()).toBe(false);
+        expect(blurs).toEqual(mode === 'real' ? [] : ['blur']);
+
+        ngMocks.touch(child);
+        fixture.detectChanges();
+
+        expect(component.model().callback).toBe('Updated');
+        expect(component.f.callback().dirty()).toBe(true);
+        expect(component.f.callback().touched()).toBe(true);
+        expect(blurs).toEqual(
+          mode === 'real' ? [] : ['blur', 'blur'],
+        );
+        expect(component.f.withTouch().dirty()).toBe(false);
+        expect(component.f.withTouch().touched()).toBe(false);
+        expect(component.f.withoutTouch().dirty()).toBe(false);
+        expect(component.f.withoutTouch().touched()).toBe(false);
+        expect(component.blurCount).toBe(0);
+      });
+    });
+  }
+
+  describe('real controls with host event handlers', () => {
+    beforeEach(() =>
+      MockBuilder(TargetComponent)
+        .keep(FormField)
+        .keep(NG_MOCKS_ROOT_PROVIDERS)
+        .keep(CvaComponent),
+    );
+
+    it('marks the field touched when the blur handler reports the touch', () => {
+      const fixture = MockRender(TargetComponent);
+      const component = fixture.point.componentInstance;
+      const child = ngMocks.find('.with-touch');
+      const blurs: string[] = [];
+      child.nativeElement.addEventListener('blur', () =>
+        blurs.push('blur'),
+      );
+
+      ngMocks.change(child, 'Updated');
+      fixture.detectChanges();
+
+      expect(component.model()).toEqual({
+        callback: 'Ada',
+        withTouch: 'Updated',
+        withoutTouch: 'Katherine',
+      });
+      expect(ngMocks.get(child, CvaComponent).value).toBe('Updated');
+      expect(ngMocks.formatText(child)).toBe('Updated');
+      expect(component.f.withTouch().dirty()).toBe(true);
+      expect(component.f.withTouch().touched()).toBe(true);
+      expect(blurs).toEqual(['blur']);
+      expect(component.f.callback().dirty()).toBe(false);
+      expect(component.f.callback().touched()).toBe(false);
+      expect(component.f.withoutTouch().dirty()).toBe(false);
+      expect(component.f.withoutTouch().touched()).toBe(false);
+    });
+
+    it('does not infer a touch from a blur handler that omits the touch callback', () => {
+      const fixture = MockRender(TargetComponent);
+      const component = fixture.point.componentInstance;
+      const child = ngMocks.find('.without-touch');
+
+      ngMocks.change(child, 'Updated');
+      fixture.detectChanges();
+
+      expect(component.model().withoutTouch).toBe('Updated');
+      expect(ngMocks.get(child, CvaComponent).value).toBe('Updated');
+      expect(ngMocks.formatText(child)).toBe('Updated');
+      expect(component.f.withoutTouch().dirty()).toBe(true);
+      expect(component.f.withoutTouch().touched()).toBe(false);
+      expect(component.blurCount).toBe(1);
+
+      // A separate blur interaction still depends on the control's touch wiring.
+      ngMocks.touch(child);
+      fixture.detectChanges();
+
+      expect(component.model()).toEqual({
+        callback: 'Ada',
+        withTouch: 'Grace',
+        withoutTouch: 'Updated',
+      });
+      expect(component.f.withoutTouch().dirty()).toBe(true);
+      expect(component.f.withoutTouch().touched()).toBe(false);
+      expect(component.blurCount).toBe(2);
+      expect(component.f.callback().dirty()).toBe(false);
+      expect(component.f.callback().touched()).toBe(false);
+      expect(component.f.withTouch().dirty()).toBe(false);
+      expect(component.f.withTouch().touched()).toBe(false);
+    });
+  });
+});

--- a/tests/ng-mocks-change/signal-model-controls.spec.ts
+++ b/tests/ng-mocks-change/signal-model-controls.spec.ts
@@ -97,6 +97,10 @@ describe('ng-mocks-change:signal-model-controls', () => {
         const control = ngMocks.get(child, ValueControl);
         const value = control.value;
         const values: string[] = [];
+        const blurs: string[] = [];
+        child.nativeElement.addEventListener('blur', () =>
+          blurs.push('blur'),
+        );
         ngMocks
           .output(child, 'valueChange')
           .subscribe(next => values.push(next));
@@ -116,6 +120,7 @@ describe('ng-mocks-change:signal-model-controls', () => {
         expect(control.value).toBe(value);
         expect(value()).toBe('Grace');
         expect(values).toEqual(['Grace']);
+        expect(blurs).toEqual([]);
         expect(component.f.name().value()).toBe('Grace');
         expect(component.f.name().dirty()).toBe(true);
         expect(component.f.name().touched()).toBe(false);
@@ -141,6 +146,10 @@ describe('ng-mocks-change:signal-model-controls', () => {
         const control = ngMocks.get(child, CheckboxControl);
         const checked = control.checked;
         const values: boolean[] = [];
+        const blurs: string[] = [];
+        child.nativeElement.addEventListener('blur', () =>
+          blurs.push('blur'),
+        );
         ngMocks
           .output(child, 'checkedChange')
           .subscribe(next => values.push(next));
@@ -179,6 +188,7 @@ describe('ng-mocks-change:signal-model-controls', () => {
         expect(control.checked).toBe(checked);
         expect(checked()).toBe(false);
         expect(values).toEqual([true, false]);
+        expect(blurs).toEqual([]);
         expect(component.f.enabled().dirty()).toBe(true);
         expect(component.f.enabled().touched()).toBe(false);
         expect(component.f.name().dirty()).toBe(false);


### PR DESCRIPTION
## Why

The signal-forms request in #14925 includes passing callable field trees through a custom `MockRender` template. The API's generic `valueKeys` example does not show the field-tree setup or explain which params key to preserve. The touch follow-up in #14988 also needs to distinguish a custom control's touch contract from a DOM blur event.

## What

Explain `FieldTree` parameters beside the existing callable-values guidance, including `valueKeys: ['f']` for `f.name`, `valueKeys: ['field']` for a directly supplied field, and creating the wrapper before the form's injection context. Link the existing executable example and both sandboxes.

Clarify the Angular 21 `touchedChange` model output, Angular 22 `touch` output, and why a real CVA's blur handler must report the touch. Keep the mocked `FormField` binding behavior introduced by #15038 and the simple signal-forms guide intact.

Add focused coverage for real and mocked callback CVAs, real CVA hosts whose blur handlers do or do not report touch, and value/checkbox model controls whose changes do not dispatch DOM blur.

## Impact

Readers can preserve a field tree in a custom template and choose the appropriate separate touch interaction. This documents existing behavior and adds regression coverage without changing the runtime.

Closes #14988.
Related to #14984 and #14925.
Follow-up to #14991 and #15038.
